### PR TITLE
Add --save-frames option to export individual static SVG frames

### DIFF
--- a/src/ConsoleToSvg/Cli/AppOptions.cs
+++ b/src/ConsoleToSvg/Cli/AppOptions.cs
@@ -106,4 +106,7 @@ public sealed class AppOptions
 
     /// <summary>Write SVG output to stdout instead of a file. PTY forwarding is suppressed.</summary>
     public bool StdOut { get; set; }
+
+    /// <summary>Directory path to save individual static SVG frames (one per visual frame).</summary>
+    public string? SaveFramesDir { get; set; }
 }

--- a/src/ConsoleToSvg/Cli/OptionParser.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.cs
@@ -91,6 +91,7 @@ public static class OptionParser
 
             Options (Image mode):
                 --frame <int>             Frame index for image mode.
+                --save-frames <dir>       Save each visual frame as a separate static SVG in the given directory.
                 --crop-top <value>        Crop top by px, ch, or text pattern (e.g. 10px, 2ch, sometext, summary:-3).
                 --crop-bottom <value>     Crop bottom by px, ch, or text pattern.
                 --crop-right <value>      Crop right by px or ch.
@@ -630,6 +631,15 @@ public static class OptionParser
                 }
 
                 options.BackColor = value;
+                return true;
+            case "--save-frames":
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    error = "--save-frames requires a directory path.";
+                    return false;
+                }
+
+                options.SaveFramesDir = value;
                 return true;
             default:
                 error = $"Unknown option: {name}";

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -157,6 +157,12 @@ internal static class Program
                 logger.ZLogDebug($"Output file written: {options.OutputPath}");
             }
 
+            if (!string.IsNullOrWhiteSpace(options.SaveFramesDir))
+            {
+                await SaveFramesAsync(session, renderOptions, options.SaveFramesDir!, logger, outputToken)
+                    .ConfigureAwait(false);
+            }
+
             if (wasCanceled)
             {
                 var cause = GetCancellationCause(options, canceledByCtrlC);
@@ -365,6 +371,46 @@ internal static class Program
         {
             Directory.CreateDirectory(directory);
         }
+    }
+
+    private static async Task SaveFramesAsync(
+        RecordingSession session,
+        SvgRenderOptions baseOptions,
+        string directory,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        Directory.CreateDirectory(directory);
+        var utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        var eventCount = session.Events.Count;
+        var savedCount = 0;
+        string? previousSvg = null;
+
+        logger.ZLogDebug($"Saving individual frames to {directory}. Events={eventCount}");
+
+        for (var i = 0; i < eventCount; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            baseOptions.Frame = i;
+            var frameSvg = SvgRenderer.Render(session, baseOptions);
+
+            if (frameSvg == previousSvg)
+            {
+                continue;
+            }
+
+            previousSvg = frameSvg;
+            var framePath = Path.Combine(directory, $"frame-{savedCount:D4}.svg");
+            await File.WriteAllTextAsync(framePath, frameSvg, utf8, cancellationToken)
+                .ConfigureAwait(false);
+            savedCount++;
+        }
+
+        baseOptions.Frame = null;
+        logger.ZLogDebug($"Saved {savedCount} unique frames (of {eventCount} events) to {directory}");
+        await Console.Error.WriteLineAsync($"Saved {savedCount} frames to {directory}");
     }
 
     private static string GetDefaultPrompt()

--- a/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.cs
+++ b/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.cs
@@ -954,4 +954,33 @@ public sealed class OptionParserTests
         ok.ShouldBeFalse();
         error.ShouldBe("--mode must be image, video, or repeat.");
     }
+
+    [Test]
+    public void SaveFramesOptionParsed()
+    {
+        var ok = OptionParser.TryParse(
+            new[] { "--save-frames", "frames-out" },
+            out var options,
+            out _,
+            out _
+        );
+        ok.ShouldBeTrue();
+        options!.SaveFramesDir.ShouldBe("frames-out");
+    }
+
+    [Test]
+    public void SaveFramesDefaultIsNull()
+    {
+        var ok = OptionParser.TryParse(System.Array.Empty<string>(), out var options, out _, out _);
+        ok.ShouldBeTrue();
+        options!.SaveFramesDir.ShouldBeNull();
+    }
+
+    [Test]
+    public void SaveFramesRequiresValue()
+    {
+        var ok = OptionParser.TryParse(new[] { "--save-frames" }, out _, out var error, out _);
+        ok.ShouldBeFalse();
+        error.ShouldNotBeNull();
+    }
 }


### PR DESCRIPTION
Adds a `--save-frames <dir>` option that exports each visually distinct frame from a recording as a separate static SVG file. This makes it easy to extract a specific frame from an animated recording - for example, to use as a thumbnail, embed in documentation, or inspect a particular point in a terminal session - without manually digging through the animated SVG markup.

**Usage:**
```
console2svg -v -c -d macos --save-frames ./frames -- copilot --banner
```

This renders every event in the recording, skips consecutive duplicates, and writes the unique frames as `frame-0000.svg`, `frame-0001.svg`, etc. It works alongside the normal SVG output, so you can generate both the animated SVG and the individual frames in a single run.

**Add `--save-frames` option**
- Added a new `--save-frames <dir>` command-line option to allow saving each unique visual frame as a separate SVG file in the specified directory. (`src/ConsoleToSvg/Cli/AppOptions.cs` [[1]](diffhunk://#diff-ce65d6c9610663e582fdf68dd3fe0fc6f30ee648f6e26d2130da58e206e80673R109-R111) `src/ConsoleToSvg/Cli/OptionParser.cs` [[2]](diffhunk://#diff-a4c5fc6a79c2a971e08eab0cb7e97d32b0368a73532b02b5211dc2c732e05f8eR94) [[3]](diffhunk://#diff-a4c5fc6a79c2a971e08eab0cb7e97d32b0368a73532b02b5211dc2c732e05f8eR635-R643)

**Implementation of frame saving**
- Implemented `SaveFramesAsync`, which iterates through all recording session events, renders each unique frame to SVG, and writes it to the target directory, skipping duplicates. (`src/ConsoleToSvg/Program.cs` [[1]](diffhunk://#diff-9882c9691d856f7300d61f3ee6d7b90eb1d2f25e5d412e85d44055bb0fc4a082R160-R165) [[2]](diffhunk://#diff-9882c9691d856f7300d61f3ee6d7b90eb1d2f25e5d412e85d44055bb0fc4a082R376-R415)

**Testing and validation**
- Added unit tests to verify correct parsing of the `--save-frames` option, its default value, and required argument validation. (`tests/ConsoleToSvg.Tests/Cli/OptionParserTests.cs` [tests/ConsoleToSvg.Tests/Cli/OptionParserTests.csR957-R985](diffhunk://#diff-b72ab0b3a867136c4f84c2fc4360370c060c8bfb1d5b11f0dc53439faa0f97f0R957-R985))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--save-frames <directory>` CLI option to export individual static SVG frames to a specified directory, with automatic deduplication of consecutive identical frames during processing.

* **Tests**
  * Added comprehensive tests for the `--save-frames` option covering successful parsing with directory paths, default null behavior, and proper error handling for missing or invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->