### PR TITLE
feat: Refactor logging and enhance output conversion toolchain

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,6 +131,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v6
+
       - name: Download NuGet artifacts
         uses: actions/download-artifact@v8
         with:
@@ -144,115 +146,21 @@ jobs:
           path: ./native-artifacts
           merge-multiple: false
 
-      - name: Collect native binaries
-        shell: bash
-        run: |
-          for dir in ./native-artifacts/native-*/; do
-            rid=$(basename "$dir" | sed 's/^native-//')
-            if [[ "$rid" == win-* ]]; then
-              src="$dir/console2svg.exe"
-              dst="./release-upload/console2svg-${rid}.exe"
-            else
-              src="$dir/console2svg"
-              dst="./release-upload/console2svg-${rid}"
-            fi
-            if [ -f "$src" ]; then
-              cp "$src" "$dst"
-            fi
-          done
-
       - name: Install Linux packaging tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y rpm
+          sudo apt-get install -y rpm unzip zip
           sudo gem install --no-document fpm
 
-      - name: Build Linux packages
+      - name: Build release assets
         shell: bash
-        run: |
-          for rid in linux-x64 linux-arm64; do
-            case "$rid" in
-              linux-x64)
-                asset_arch=x64
-                deb_arch=amd64
-                rpm_arch=x86_64
-                ;;
-              linux-arm64)
-                asset_arch=arm64
-                deb_arch=arm64
-                rpm_arch=aarch64
-                ;;
-            esac
-
-            src="./native-artifacts/native-${rid}/console2svg"
-            if [ ! -f "$src" ]; then
-              continue
-            fi
-
-            chmod 755 "$src"
-
-            common_args=(
-              -s dir
-              -n console2svg
-              -v "${{ needs.build-nupkg.outputs.package-version }}"
-              --iteration "${{ needs.build-nupkg.outputs.package-iteration }}"
-              --license Apache-2.0
-              --url "https://github.com/${{ github.repository }}"
-              --description "Convert terminal output to SVG images."
-            )
-
-            fpm "${common_args[@]}" -t deb -a "$deb_arch" -p "./release-upload/console2svg.${asset_arch}.deb" "$src=/usr/local/bin/console2svg"
-            fpm "${common_args[@]}" -t rpm -a "$rpm_arch" -p "./release-upload/console2svg.${asset_arch}.rpm" "$src=/usr/local/bin/console2svg"
-          done
-
-      - name: Build Windows ffmpeg zip bundles
-        shell: bash
-        run: |
-          sudo apt-get install -y unzip
-
-          for rid in win-x64 win-arm64; do
-            case "$rid" in
-              win-x64)
-                ffmpeg_zip_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-lgpl-shared.zip"
-                ;;
-              win-arm64)
-                ffmpeg_zip_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-winarm64-lgpl-shared.zip"
-                ;;
-            esac
-
-            src="./native-artifacts/native-${rid}/console2svg.exe"
-            if [ ! -f "$src" ]; then
-              continue
-            fi
-
-            # Download and extract the ffmpeg bundle
-            ffmpeg_zip="./ffmpeg-${rid}.zip"
-            curl -fsSL -o "$ffmpeg_zip" "$ffmpeg_zip_url"
-
-            ffmpeg_dir="./ffmpeg-extract-${rid}"
-            mkdir -p "$ffmpeg_dir"
-            unzip -q "$ffmpeg_zip" -d "$ffmpeg_dir"
-
-            # The BtbN zip contains a top-level directory with a bin/ subdirectory
-            top_dir=$(ls -d "$ffmpeg_dir"/*/ | head -1)
-            ffmpeg_bin_dir="${top_dir}bin"
-            if [ ! -f "$ffmpeg_bin_dir/ffmpeg.exe" ]; then
-              echo "ffmpeg.exe not found at $ffmpeg_bin_dir/ffmpeg.exe."
-              exit 1
-            fi
-
-            # Build the bundle zip: console2svg.exe + ffmpeg binaries (exe + dlls) + LICENSE
-            bundle_dir="./console2svg-${rid}-ffmpeg"
-            mkdir -p "$bundle_dir"
-            cp "$src" "$bundle_dir/console2svg.exe"
-            cp "$ffmpeg_bin_dir"/*.exe "$bundle_dir/"
-            cp "$ffmpeg_bin_dir"/*.dll "$bundle_dir/"
-            cp "${top_dir}LICENSE.txt" "$bundle_dir/ffmpeg-LICENSE.txt"
-
-            zip_name="./release-upload/console2svg-${rid}-ffmpeg.zip"
-            zip -q -r "$zip_name" "$bundle_dir"
-            echo "Created $zip_name"
-          done
+        env:
+          RELEASE_UPLOAD_DIR: ./release-upload
+          NATIVE_ARTIFACTS_DIR: ./native-artifacts
+          PACKAGE_VERSION: ${{ needs.build-nupkg.outputs.package-version }}
+          PACKAGE_ITERATION: ${{ needs.build-nupkg.outputs.package-iteration }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: ./scripts/release/build-release-assets.sh
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -160,7 +160,7 @@ jobs:
           PACKAGE_VERSION: ${{ needs.build-nupkg.outputs.package-version }}
           PACKAGE_ITERATION: ${{ needs.build-nupkg.outputs.package-iteration }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: ./scripts/release/build-release-assets.sh
+        run: ./scripts/release-action/build-release-assets.sh
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -280,10 +280,8 @@ The replay file is in a simple JSON format. If you make a mistake in the input, 
 
 In v0.7 and later, you can specify the output format based on the file extension specified with `-o output.mp4`.
 
-`console2svg` uses `resvg` for PNG rendering when available. The release archives and npm package bundle it where the upstream `resvg` release provides a compatible binary.
-For JPEG/WebP/video outputs, install `ffmpeg`.  
-On Linux/macOS, you can easily install it using a package manager.  
-On Windows, it's a bit more involved, so you can use the bundled version of ffmpeg (which also includes `resvg`) ([x64](https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64-ffmpeg.zip), [arm64](https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-arm64-ffmpeg.zip)).
+`console2svg` first checks whether the detected `ffmpeg` build advertises `--enable-librsvg`.
+If it does, `ffmpeg` is used directly for SVG input. Otherwise, `resvg` is used when available.
 
 ```bash
 # ubuntu
@@ -301,6 +299,16 @@ Then, you can specify the output file with the desired extension. For example, t
 
 ```bash
 console2svg -c -d macos --timeout 5 --fps 30 --output output.mp4 -- some-command
+```
+
+`console2svg` first checks if the detected `ffmpeg` build advertises `--enable-librsvg`. If it does, it uses `ffmpeg` directly for various conversions.
+If not, it first uses `resvg` to render SVG to PNG, and then uses `ffmpeg` to convert PNG to JPG/MP4/WebM, etc.
+
+```
+# if ffmpeg has librsvg
+console output -> [ffmpeg] -> png/jpg/mp4/webm/...
+# otherwise
+console output -> [resvg] -> png -> [ffmpeg] -> jpg/mp4/webm/...
 ```
 
 ## Appearance options

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ For example, let's open [this image](https://raw.githubusercontent.com/arika0093
 
 There are similar tools, but console2svg stands out for:
 
-* [**No dependencies**](#install): no additional software or libraries required. available as npm, dotnet tool and static binary.
 * [**Video mode**](#animated-svg): save command execution animations as SVG. great for documentation and blog posts.
 * [**Crop**](#static-svg-with-crop): trim specific parts of the output. Crop based on text patterns is also supported, making it easy to trim specific lines or sections.
 * [**Background and window**](#window-chrome): add background and window frames to produce presentation-ready SVGs for documentation, blogs, social media, etc.
@@ -68,23 +67,26 @@ dotnet tool install -g ConsoleToSvg
 npm install -g console2svg
 ```
 
-It is also available as a standalone binary that you can download from the releases page and add to your PATH.
+It is also available as standalone archives on the releases page.
+Matching archives bundle `resvg` when the upstream release provides a compatible binary, so you can usually extract the files into a directory on your `PATH`.
 
 ```sh
-# ubuntu
-curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg.amd64.deb -o console2svg.deb
-dpkg -i console2svg.deb
+# ubuntu package
+curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg.x64.deb -o console2svg.deb
+sudo dpkg -i console2svg.deb
 
-# linux
-curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-linux-x64 -o console2svg
-mv -f console2svg /usr/local/bin/
-chmod +x /usr/local/bin/console2svg
+# linux/macOS bundle
+curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-linux-x64.tar.gz -o console2svg-linux-x64.tar.gz
+sudo tar -xzf console2svg-linux-x64.tar.gz -C /usr/local/bin
 
-# windows (binary only)
-curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64.exe -o console2svg.exe
+# windows bundle
+curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64.zip -o console2svg-win-x64.zip
+mkdir -p console2svg
+tar -xf console2svg-win-x64.zip -C console2svg
+
 # windows (with ffmpeg)
 curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64-ffmpeg.zip -o console2svg-win-x64-ffmpeg.zip
-unzip console2svg-win-x64-ffmpeg.zip -d console2svg
+tar -xf console2svg-win-x64-ffmpeg.zip -C console2svg
 cd console2svg
 ```
 
@@ -278,9 +280,10 @@ The replay file is in a simple JSON format. If you make a mistake in the input, 
 
 In v0.7 and later, you can specify the output format based on the file extension specified with `-o output.mp4`.
 
-First, install `ffmpeg`.  
+`console2svg` uses `resvg` for PNG rendering when available. The release archives and npm package bundle it where the upstream `resvg` release provides a compatible binary.
+For JPEG/WebP/video outputs, install `ffmpeg`.  
 On Linux/macOS, you can easily install it using a package manager.  
-On Windows, it's a bit more involved, so you can use the bundled version of ffmpeg ([x64](https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64-ffmpeg.zip), [arm64](https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-arm64-ffmpeg.zip)).
+On Windows, it's a bit more involved, so you can use the bundled version of ffmpeg (which also includes `resvg`) ([x64](https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64-ffmpeg.zip), [arm64](https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-arm64-ffmpeg.zip)).
 
 ```bash
 # ubuntu
@@ -289,7 +292,8 @@ sudo apt install ffmpeg
 brew install ffmpeg
 # windows 
 curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64-ffmpeg.zip -o console2svg-win-x64-ffmpeg.zip
-unzip console2svg-win-x64-ffmpeg.zip
+mkdir -p console2svg
+tar -xf console2svg-win-x64-ffmpeg.zip -C console2svg
 cd console2svg
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Setup console2svg
-description: Installs console2svg by downloading a release binary or building from source (develop), then adds it to PATH
+description: Installs console2svg by downloading a release bundle or building from source (develop), then adds it to PATH
 
 inputs:
   version:
@@ -62,30 +62,53 @@ runs:
         VERSION="${{ inputs.version }}"
 
         case "${{ runner.os }}/${{ runner.arch }}" in
-          Linux/X64)     RID="linux-x64"   ; EXT="" ;;
-          Linux/ARM64)   RID="linux-arm64" ; EXT="" ;;
-          Windows/X64)   RID="win-x64"     ; EXT=".exe" ;;
-          Windows/ARM64) RID="win-arm64"   ; EXT=".exe" ;;
-          macOS/X64)     RID="osx-x64"     ; EXT="" ;;
-          macOS/ARM64)   RID="osx-arm64"   ; EXT="" ;;
+          Linux/X64)     RID="linux-x64"   ; EXT=""     ; ARCHIVE_EXT=".tar.gz" ;;
+          Linux/ARM64)   RID="linux-arm64" ; EXT=""     ; ARCHIVE_EXT=".tar.gz" ;;
+          Windows/X64)   RID="win-x64"     ; EXT=".exe" ; ARCHIVE_EXT=".zip" ;;
+          Windows/ARM64) RID="win-arm64"   ; EXT=".exe" ; ARCHIVE_EXT=".zip" ;;
+          macOS/X64)     RID="osx-x64"     ; EXT=""     ; ARCHIVE_EXT=".tar.gz" ;;
+          macOS/ARM64)   RID="osx-arm64"   ; EXT=""     ; ARCHIVE_EXT=".tar.gz" ;;
           *)
             echo "Unsupported OS/arch: ${{ runner.os }}/${{ runner.arch }}"
             exit 1
             ;;
         esac
 
-        FILE="console2svg-${RID}${EXT}"
+        ARCHIVE_FILE="console2svg-${RID}${ARCHIVE_EXT}"
+        LEGACY_FILE="console2svg-${RID}${EXT}"
         if [ "$VERSION" = "latest" ]; then
-          URL="https://github.com/arika0093/console2svg/releases/latest/download/${FILE}"
+          BASE_URL="https://github.com/arika0093/console2svg/releases/latest/download"
         else
-          URL="https://github.com/arika0093/console2svg/releases/download/v${VERSION}/${FILE}"
+          BASE_URL="https://github.com/arika0093/console2svg/releases/download/v${VERSION}"
         fi
 
         INSTALL_DIR="${{ runner.tool_cache }}/console2svg/${VERSION}/${{ runner.arch }}"
         mkdir -p "$INSTALL_DIR"
 
-        echo "Downloading ${URL} ..."
-        curl -fsSL -L -o "${INSTALL_DIR}/console2svg${EXT}" "${URL}"
+        ARCHIVE_URL="${BASE_URL}/${ARCHIVE_FILE}"
+        LEGACY_URL="${BASE_URL}/${LEGACY_FILE}"
+        ARCHIVE_PATH="${INSTALL_DIR}/${ARCHIVE_FILE}"
+
+        echo "Downloading ${ARCHIVE_URL} ..."
+        if curl -fsSL -L -o "${ARCHIVE_PATH}" "${ARCHIVE_URL}"; then
+          if [ "${ARCHIVE_EXT}" = ".zip" ]; then
+            tar -xf "${ARCHIVE_PATH}" -C "${INSTALL_DIR}"
+          else
+            tar -xzf "${ARCHIVE_PATH}" -C "${INSTALL_DIR}"
+          fi
+          rm -f "${ARCHIVE_PATH}"
+        else
+          echo "Archive asset not found, falling back to legacy single-binary asset."
+          curl -fsSL -L -o "${INSTALL_DIR}/console2svg${EXT}" "${LEGACY_URL}"
+        fi
+
+        if [ ! -f "${INSTALL_DIR}/console2svg${EXT}" ]; then
+          echo "Installed console2svg binary not found in ${INSTALL_DIR}"
+          ls -la "${INSTALL_DIR}"
+          exit 1
+        fi
+
         [ -z "${EXT}" ] && chmod +x "${INSTALL_DIR}/console2svg"
+        [ -f "${INSTALL_DIR}/resvg" ] && chmod +x "${INSTALL_DIR}/resvg"
 
         echo "${INSTALL_DIR}" >> "$GITHUB_PATH"

--- a/scripts/release-action/build-release-assets.sh
+++ b/scripts/release-action/build-release-assets.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${RELEASE_UPLOAD_DIR:?}"
+: "${NATIVE_ARTIFACTS_DIR:?}"
+: "${PACKAGE_VERSION:?}"
+: "${PACKAGE_ITERATION:?}"
+: "${GITHUB_REPOSITORY:?}"
+
+mkdir -p "$RELEASE_UPLOAD_DIR"
+release_upload_dir="$(cd "$RELEASE_UPLOAD_DIR" && pwd)"
+resvg_cache_dir="$(mktemp -d)"
+trap 'rm -rf "$resvg_cache_dir"' EXIT
+
+# Fails fast when a required input file is missing.
+require_file() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    echo "Required file not found: $path" >&2
+    exit 1
+  fi
+}
+
+# Returns the expected console2svg binary name for the target RID.
+binary_name_for_rid() {
+  local rid="$1"
+  local tool_name="$2"
+
+  if [[ "$rid" == win-* ]]; then
+    printf '%s.exe' "$tool_name"
+  else
+    printf '%s' "$tool_name"
+  fi
+}
+
+# Chooses the archive format we publish for the target RID.
+archive_extension_for_rid() {
+  local rid="$1"
+
+  if [[ "$rid" == win-* ]]; then
+    printf '.zip'
+  else
+    printf '.tar.gz'
+  fi
+}
+
+# Maps a RID to the latest upstream resvg release asset.
+# Returns non-zero when upstream does not publish a compatible binary.
+resvg_asset_for_rid() {
+  local rid="$1"
+
+  case "$rid" in
+    linux-x64)
+      printf '%s' "resvg-linux-x86_64.tar.gz"
+      ;;
+    linux-arm64)
+      return 1
+      ;;
+    osx-x64)
+      printf '%s' "resvg-macos-x86_64.zip"
+      ;;
+    osx-arm64)
+      printf '%s' "resvg-macos-aarch64.zip"
+      ;;
+    win-x64|win-arm64)
+      # Upstream only ships a win64 binary; Windows on ARM can run it via x64 emulation.
+      printf '%s' "resvg-win64.zip"
+      ;;
+    *)
+      echo "Unsupported RID for resvg lookup: $rid" >&2
+      exit 1
+      ;;
+  esac
+}
+
+# Returns the resvg binary name after extracting the upstream asset.
+resvg_binary_name_for_rid() {
+  local rid="$1"
+
+  if [[ "$rid" == win-* ]]; then
+    printf '%s' "resvg.exe"
+  else
+    printf '%s' "resvg"
+  fi
+}
+
+# Resolves the downloaded native console2svg artifact path for a RID.
+console_binary_path() {
+  local rid="$1"
+  printf '%s/native-%s/%s' \
+    "$NATIVE_ARTIFACTS_DIR" \
+    "$rid" \
+    "$(binary_name_for_rid "$rid" console2svg)"
+}
+
+# Downloads and caches the latest upstream resvg binary for a RID when available.
+ensure_resvg_binary() {
+  local rid="$1"
+  local asset_name binary_name cache_dir cached_binary temp_dir asset_path extract_dir extracted_binary
+
+  if ! asset_name="$(resvg_asset_for_rid "$rid")"; then
+    return 1
+  fi
+
+  binary_name="$(resvg_binary_name_for_rid "$rid")"
+  cache_dir="${resvg_cache_dir}/${rid}"
+  cached_binary="${cache_dir}/${binary_name}"
+  if [[ -f "$cached_binary" ]]; then
+    printf '%s' "$cached_binary"
+    return 0
+  fi
+
+  temp_dir="$(mktemp -d)"
+  asset_path="${temp_dir}/${asset_name}"
+  extract_dir="${temp_dir}/extract"
+  mkdir -p "$cache_dir" "$extract_dir"
+
+  curl -fsSL \
+    -o "$asset_path" \
+    "https://github.com/linebender/resvg/releases/latest/download/${asset_name}"
+
+  if [[ "$asset_name" == *.zip ]]; then
+    unzip -q "$asset_path" -d "$extract_dir"
+  else
+    tar -xzf "$asset_path" -C "$extract_dir"
+  fi
+
+  extracted_binary="$(find "$extract_dir" -type f -name "$binary_name" | sort | head -n 1)"
+  if [[ -z "$extracted_binary" ]]; then
+    echo "Failed to locate $binary_name inside $asset_name" >&2
+    find "$extract_dir" -maxdepth 5 -type f | sort >&2
+    exit 1
+  fi
+
+  cp "$extracted_binary" "$cached_binary"
+  if [[ "$binary_name" == "resvg" ]]; then
+    chmod 755 "$cached_binary"
+  fi
+
+  rm -rf "$temp_dir"
+  printf '%s' "$cached_binary"
+}
+
+# Copies resvg into a staging directory when upstream provides a compatible binary.
+stage_resvg_if_available() {
+  local rid="$1"
+  local staging_dir="$2"
+  local resvg_src
+
+  if ! resvg_src="$(ensure_resvg_binary "$rid")"; then
+    return 1
+  fi
+
+  cp "$resvg_src" "$staging_dir/$(resvg_binary_name_for_rid "$rid")"
+  if [[ "$rid" != win-* ]]; then
+    chmod 755 "$staging_dir/$(resvg_binary_name_for_rid "$rid")"
+  fi
+}
+
+# Creates the standalone tar.gz/zip bundle for a RID.
+create_standard_bundle() {
+  local rid="$1"
+  local console_src archive_ext archive_path bundle_dir
+
+  console_src="$(console_binary_path "$rid")"
+  archive_ext="$(archive_extension_for_rid "$rid")"
+  archive_path="${release_upload_dir}/console2svg-${rid}${archive_ext}"
+  bundle_dir="$(mktemp -d)"
+
+  require_file "$console_src"
+
+  cp "$console_src" "$bundle_dir/$(binary_name_for_rid "$rid" console2svg)"
+  if [[ "$rid" != win-* ]]; then
+    chmod 755 "$bundle_dir/$(binary_name_for_rid "$rid" console2svg)"
+  fi
+
+  if ! stage_resvg_if_available "$rid" "$bundle_dir"; then
+    echo "No upstream resvg release asset for $rid; standard bundle will include console2svg only."
+  fi
+
+  if [[ "$archive_ext" == ".zip" ]]; then
+    (
+      cd "$bundle_dir"
+      zip -q -r "$archive_path" .
+    )
+  else
+    tar -czf "$archive_path" -C "$bundle_dir" .
+  fi
+
+  rm -rf "$bundle_dir"
+  echo "Created standard bundle: $archive_path"
+}
+
+# Builds the Linux .deb/.rpm packages and adds resvg when upstream publishes one.
+build_linux_package() {
+  local rid="$1"
+  local console_src resvg_src asset_arch deb_arch rpm_arch
+  local -a common_args package_inputs
+
+  console_src="$(console_binary_path "$rid")"
+  require_file "$console_src"
+
+  case "$rid" in
+    linux-x64)
+      asset_arch="x64"
+      deb_arch="amd64"
+      rpm_arch="x86_64"
+      ;;
+    linux-arm64)
+      asset_arch="arm64"
+      deb_arch="arm64"
+      rpm_arch="aarch64"
+      ;;
+    *)
+      echo "Unsupported Linux RID for packaging: $rid" >&2
+      exit 1
+      ;;
+  esac
+
+  chmod 755 "$console_src"
+  common_args=(
+    -s dir
+    -n console2svg
+    -v "$PACKAGE_VERSION"
+    --iteration "$PACKAGE_ITERATION"
+    --license Apache-2.0
+    --url "https://github.com/${GITHUB_REPOSITORY}"
+    --description "Convert terminal output to SVG images."
+  )
+  package_inputs=("$console_src=/usr/local/bin/console2svg")
+
+  if resvg_src="$(ensure_resvg_binary "$rid")"; then
+    chmod 755 "$resvg_src"
+    package_inputs+=("$resvg_src=/usr/local/bin/resvg")
+  else
+    echo "No upstream resvg release asset for $rid; Linux package will include console2svg only."
+  fi
+
+  fpm "${common_args[@]}" \
+    -t deb \
+    -a "$deb_arch" \
+    -p "${release_upload_dir}/console2svg.${asset_arch}.deb" \
+    "${package_inputs[@]}"
+
+  fpm "${common_args[@]}" \
+    -t rpm \
+    -a "$rpm_arch" \
+    -p "${release_upload_dir}/console2svg.${asset_arch}.rpm" \
+    "${package_inputs[@]}"
+
+  echo "Created Linux packages for $rid"
+}
+
+# Builds the Windows ffmpeg bundle with resvg, ffmpeg.exe, and the ffmpeg license only.
+build_windows_ffmpeg_bundle() {
+  local rid="$1"
+  local console_src resvg_src ffmpeg_zip_url temp_root ffmpeg_zip ffmpeg_extract
+  local top_dir ffmpeg_bin_dir bundle_dir archive_path
+
+  console_src="$(console_binary_path "$rid")"
+  require_file "$console_src"
+
+  if ! resvg_src="$(ensure_resvg_binary "$rid")"; then
+    echo "Windows ffmpeg bundle requires a resvg binary for $rid" >&2
+    exit 1
+  fi
+
+  case "$rid" in
+    win-x64)
+      ffmpeg_zip_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-lgpl.zip"
+      ;;
+    win-arm64)
+      ffmpeg_zip_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-winarm64-lgpl.zip"
+      ;;
+    *)
+      echo "Unsupported Windows RID for ffmpeg bundle: $rid" >&2
+      exit 1
+      ;;
+  esac
+
+  archive_path="${release_upload_dir}/console2svg-${rid}-ffmpeg.zip"
+  temp_root="$(mktemp -d)"
+  ffmpeg_zip="${temp_root}/ffmpeg.zip"
+  ffmpeg_extract="${temp_root}/ffmpeg"
+  bundle_dir="${temp_root}/bundle"
+
+  curl -fsSL -o "$ffmpeg_zip" "$ffmpeg_zip_url"
+  unzip -q "$ffmpeg_zip" -d "$ffmpeg_extract"
+
+  top_dir="$(find "$ffmpeg_extract" -mindepth 1 -maxdepth 1 -type d | sort | head -n 1)"
+  if [[ -z "$top_dir" ]]; then
+    echo "Unable to determine extracted ffmpeg directory for $rid" >&2
+    exit 1
+  fi
+
+  ffmpeg_bin_dir="${top_dir}/bin"
+  require_file "${ffmpeg_bin_dir}/ffmpeg.exe"
+  require_file "${top_dir}/LICENSE.txt"
+
+  mkdir -p "$bundle_dir"
+  cp "$console_src" "$bundle_dir/console2svg.exe"
+  cp "$resvg_src" "$bundle_dir/resvg.exe"
+  cp "${ffmpeg_bin_dir}/ffmpeg.exe" "$bundle_dir/ffmpeg.exe"
+  cp "${top_dir}/LICENSE.txt" "$bundle_dir/ffmpeg-LICENSE.txt"
+
+  (
+    cd "$bundle_dir"
+    zip -q -r "$archive_path" .
+  )
+
+  rm -rf "$temp_root"
+  echo "Created Windows ffmpeg bundle: $archive_path"
+}
+
+for rid in linux-x64 linux-arm64 win-x64 win-arm64 osx-x64 osx-arm64; do
+  create_standard_bundle "$rid"
+done
+
+for rid in linux-x64 linux-arm64; do
+  build_linux_package "$rid"
+done
+
+for rid in win-x64 win-arm64; do
+  build_windows_ffmpeg_bundle "$rid"
+done

--- a/src/ConsoleToSvg/AssemblyInfo.cs
+++ b/src/ConsoleToSvg/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ConsoleToSvg.Tests")]

--- a/src/ConsoleToSvg/Cli/OptionParser.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.cs
@@ -45,9 +45,9 @@ public static class OptionParser
                 -o, --out <path>          Output file path (default: output.svg).
                                           Extension determines format:
                                             .svg         : SVG output (default, no external tools required).
-                                            .png         : Raster image via resvg (bundled in release archives or via PATH).
-                                            .jpg/.webp/… : Raster image via resvg + ffmpeg.
-                                            .mp4/.webm/… : Video via frame sequences; prefers resvg + ffmpeg.
+                                            .png         : Raster image via ffmpeg(librsvg build) or resvg.
+                                            .jpg/.webp/… : Raster image via ffmpeg (+resvg).
+                                            .mp4/.webm/… : Video via ffmpeg (+resvg).
                 --stdout                  Write SVG to stdout instead of a file.
                                           PTY output forwarding is suppressed so the pipe receives only SVG.
                 -m, --mode <image|video|repeat>  Output mode (default: image).

--- a/src/ConsoleToSvg/Cli/OptionParser.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.cs
@@ -45,7 +45,7 @@ public static class OptionParser
                 -o, --out <path>          Output file path (default: output.svg).
                                           Extension determines format:
                                             .svg         : SVG output (default, no external tools required).
-                                            .png         : Raster image via ffmpeg(librsvg build) or resvg.
+                                            .png         : Raster image via ffmpeg (librsvg-enabled build) or resvg.
                                             .jpg/.webp/… : Raster image via ffmpeg (+resvg).
                                             .mp4/.webm/… : Video via ffmpeg (+resvg).
                 --stdout                  Write SVG to stdout instead of a file.

--- a/src/ConsoleToSvg/Cli/OptionParser.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.cs
@@ -16,8 +16,6 @@ public static class OptionParser
 
             Major options:
                 -o, --out <path>          Output file path (default: output.svg).
-                                          Non-SVG extensions trigger image/video conversion
-                                          (e.g. output.png, output.mp4).
                 -w, --width <int|adjust>  Terminal width in characters (default: auto[pipe], 100[pty]).
                 -h, --height <int|adjust> Terminal height in rows (default: auto).
                 -v                        Output animated SVG (alias for --mode video).
@@ -46,10 +44,10 @@ public static class OptionParser
             Options (Common):
                 -o, --out <path>          Output file path (default: output.svg).
                                           Extension determines format:
-                                            .svg          – SVG output (default, no external tools required).
-                                            .png          – Raster image via resvg (bundled in release archives or via PATH).
-                                            .jpg/.webp/…  – Raster image via resvg + ffmpeg.
-                                            .mp4/.webm/…  – Video via frame sequences; prefers resvg + ffmpeg.
+                                            .svg         : SVG output (default, no external tools required).
+                                            .png         : Raster image via resvg (bundled in release archives or via PATH).
+                                            .jpg/.webp/… : Raster image via resvg + ffmpeg.
+                                            .mp4/.webm/… : Video via frame sequences; prefers resvg + ffmpeg.
                 --stdout                  Write SVG to stdout instead of a file.
                                           PTY output forwarding is suppressed so the pipe receives only SVG.
                 -m, --mode <image|video|repeat>  Output mode (default: image).

--- a/src/ConsoleToSvg/Cli/OptionParser.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.cs
@@ -16,7 +16,8 @@ public static class OptionParser
 
             Major options:
                 -o, --out <path>          Output file path (default: output.svg).
-                                          Non-SVG extensions trigger ffmpeg conversion (e.g. output.png, output.mp4).
+                                          Non-SVG extensions trigger image/video conversion
+                                          (e.g. output.png, output.mp4).
                 -w, --width <int|adjust>  Terminal width in characters (default: auto[pipe], 100[pty]).
                 -h, --height <int|adjust> Terminal height in rows (default: auto).
                 -v                        Output animated SVG (alias for --mode video).
@@ -46,8 +47,9 @@ public static class OptionParser
                 -o, --out <path>          Output file path (default: output.svg).
                                           Extension determines format:
                                             .svg          – SVG output (default, no external tools required).
-                                            .png/.jpg/…   – Raster image via ffmpeg (ffmpeg must be installed).
-                                            .mp4/.webm/…  – Video via ffmpeg using frame sequences (ffmpeg must be installed).
+                                            .png          – Raster image via resvg (bundled in release archives or via PATH).
+                                            .jpg/.webp/…  – Raster image via resvg + ffmpeg.
+                                            .mp4/.webm/…  – Video via frame sequences; prefers resvg + ffmpeg.
                 --stdout                  Write SVG to stdout instead of a file.
                                           PTY output forwarding is suppressed so the pipe receives only SVG.
                 -m, --mode <image|video|repeat>  Output mode (default: image).

--- a/src/ConsoleToSvg/Conversion/OutputConverter.cs
+++ b/src/ConsoleToSvg/Conversion/OutputConverter.cs
@@ -52,13 +52,13 @@ internal static class OutputConverter
     internal static string GetExecutableFileName(string toolName, bool isWindows) =>
         isWindows ? $"{toolName}.exe" : toolName;
 
-    // Prefer bundled tools first, then the current working directory, then PATH.
+    // Prefer bundled tools first, then PATH. The current working directory is intentionally
+    // excluded to avoid accidentally (or maliciously) executing a binary dropped into the CWD.
     internal static string? TryResolveExecutable(string toolName)
         => TryResolveExecutable(
             toolName,
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
             Environment.ProcessPath,
-            Environment.CurrentDirectory,
             Environment.GetEnvironmentVariable("PATH")
         );
 
@@ -66,7 +66,6 @@ internal static class OutputConverter
         string toolName,
         bool isWindows,
         string? processPath,
-        string? currentDirectory,
         string? pathEnvironment
     )
     {
@@ -76,12 +75,6 @@ internal static class OutputConverter
         if (bundled is not null)
         {
             return bundled;
-        }
-
-        var fromCurrentDirectory = TryResolveDirectoryExecutable(fileName, currentDirectory);
-        if (fromCurrentDirectory is not null)
-        {
-            return fromCurrentDirectory;
         }
 
         if (string.IsNullOrWhiteSpace(pathEnvironment))
@@ -344,9 +337,29 @@ internal static class OutputConverter
         }
     }
 
-    // Keep the user-facing failure terse; the search order is deterministic from the code path above.
-    private static string BuildUnavailableToolsMessage(string outputPath) =>
-        $"Cannot generate {outputPath} because ffmpeg and resvg cannot be used for this conversion.";
+    private const string FfmpegInstallHint =
+        "Install ffmpeg with SVG input support (librsvg-enabled build), or install both resvg and ffmpeg.";
+
+    // Describe the required toolchain for the requested output format so the user knows what to install.
+    private static string BuildUnavailableToolsMessage(string outputPath)
+    {
+        var extension = Path.GetExtension(outputPath)?.ToLowerInvariant();
+        var extLabel = extension?.TrimStart('.').ToUpperInvariant() ?? string.Empty;
+
+        return extension switch
+        {
+            ".png" =>
+                $"Cannot generate {outputPath} because PNG output requires either resvg or ffmpeg with SVG input support (librsvg-enabled build), and neither is available.",
+            ".jpg" or ".jpeg" =>
+                $"Cannot generate {outputPath} because JPEG output requires ffmpeg. {FfmpegInstallHint}",
+            ".bmp" or ".gif" or ".webp" =>
+                $"Cannot generate {outputPath} because {extLabel} output requires ffmpeg. {FfmpegInstallHint}",
+            ".mp4" or ".mov" or ".webm" or ".mkv" or ".avi" =>
+                $"Cannot generate {outputPath} because video output requires ffmpeg. {FfmpegInstallHint}",
+            _ =>
+                $"Cannot generate {outputPath} because the required conversion toolchain is unavailable for the requested output format.",
+        };
+    }
 
     private static Task RunResvgAsync(
         string resvg,

--- a/src/ConsoleToSvg/Conversion/OutputConverter.cs
+++ b/src/ConsoleToSvg/Conversion/OutputConverter.cs
@@ -19,8 +19,29 @@ internal enum RasterConversionStrategy
     ResvgThenFfmpeg,
 }
 
+internal sealed class ConversionToolchain
+{
+    internal ConversionToolchain(string? ffmpegPath, bool ffmpegSupportsSvgInput, string? resvgPath)
+    {
+        FfmpegPath = ffmpegPath;
+        FfmpegSupportsSvgInput = ffmpegSupportsSvgInput;
+        ResvgPath = resvgPath;
+    }
+
+    internal string? FfmpegPath { get; }
+
+    internal bool FfmpegSupportsSvgInput { get; }
+
+    internal string? ResvgPath { get; }
+
+    internal bool HasFfmpeg => !string.IsNullOrWhiteSpace(FfmpegPath);
+
+    internal bool HasResvg => !string.IsNullOrWhiteSpace(ResvgPath);
+}
+
 internal static class OutputConverter
 {
+    // Animated formats are routed through the frame-sequence pipeline unless image mode is explicit.
     private static readonly HashSet<string> VideoExtensions = new(StringComparer.OrdinalIgnoreCase)
     {
         "mp4", "webm", "avi", "mov", "mkv", "ogv", "flv", "ts", "wmv", "m4v", "gif",
@@ -31,11 +52,13 @@ internal static class OutputConverter
     internal static string GetExecutableFileName(string toolName, bool isWindows) =>
         isWindows ? $"{toolName}.exe" : toolName;
 
-    internal static string? TryResolveExecutable(string toolName) =>
-        TryResolveExecutable(
+    // Prefer bundled tools first, then the current working directory, then PATH.
+    internal static string? TryResolveExecutable(string toolName)
+        => TryResolveExecutable(
             toolName,
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
             Environment.ProcessPath,
+            Environment.CurrentDirectory,
             Environment.GetEnvironmentVariable("PATH")
         );
 
@@ -43,14 +66,22 @@ internal static class OutputConverter
         string toolName,
         bool isWindows,
         string? processPath,
+        string? currentDirectory,
         string? pathEnvironment
     )
     {
         var fileName = GetExecutableFileName(toolName, isWindows);
-        var bundled = TryResolveBundledExecutable(fileName, processPath);
+
+        var bundled = TryResolveDirectoryExecutable(fileName, Path.GetDirectoryName(processPath));
         if (bundled is not null)
         {
             return bundled;
+        }
+
+        var fromCurrentDirectory = TryResolveDirectoryExecutable(fileName, currentDirectory);
+        if (fromCurrentDirectory is not null)
+        {
+            return fromCurrentDirectory;
         }
 
         if (string.IsNullOrWhiteSpace(pathEnvironment))
@@ -64,13 +95,8 @@ internal static class OutputConverter
                  ))
         {
             var directory = rawDirectory.Trim('"');
-            if (directory.Length == 0)
-            {
-                continue;
-            }
-
-            var candidate = Path.Combine(directory, fileName);
-            if (File.Exists(candidate))
+            var candidate = TryResolveDirectoryExecutable(fileName, directory);
+            if (candidate is not null)
             {
                 return candidate;
             }
@@ -79,26 +105,35 @@ internal static class OutputConverter
         return null;
     }
 
-    internal static RasterConversionStrategy GetRasterConversionStrategy(
+    internal static bool HelpOutputEnablesLibrsvg(string helpOutput) =>
+        helpOutput.Contains("--enable-librsvg", StringComparison.Ordinal);
+
+    // Choose the cheapest viable path: direct ffmpeg SVG input, then resvg, otherwise fail.
+    internal static RasterConversionStrategy? GetRasterConversionStrategy(
         string outputPath,
+        bool ffmpegSupportsSvgInput,
         bool resvgAvailable
     )
     {
-        var outputExtension = Path.GetExtension(outputPath).TrimStart('.').ToLowerInvariant();
-        if (outputExtension == "png")
+        if (ffmpegSupportsSvgInput)
         {
-            return resvgAvailable
-                ? RasterConversionStrategy.ResvgPngOnly
-                : RasterConversionStrategy.DirectSvgWithFfmpeg;
+            return RasterConversionStrategy.DirectSvgWithFfmpeg;
         }
 
-        return resvgAvailable
-            ? RasterConversionStrategy.ResvgThenFfmpeg
-            : RasterConversionStrategy.DirectSvgWithFfmpeg;
+        if (!resvgAvailable)
+        {
+            return null;
+        }
+
+        var outputExtension = Path.GetExtension(outputPath).TrimStart('.').ToLowerInvariant();
+        return outputExtension == "png"
+            ? RasterConversionStrategy.ResvgPngOnly
+            : RasterConversionStrategy.ResvgThenFfmpeg;
     }
 
-    internal static string GetVideoFrameExtension(bool resvgAvailable) =>
-        resvgAvailable ? "png" : "svg";
+    // Video uses PNG frames only when resvg has to rasterize the SVG frames first.
+    internal static string GetVideoFrameExtension(bool useResvg) =>
+        useResvg ? "png" : "svg";
 
     internal static async Task ConvertSvgToRasterAsync(
         string svgPath,
@@ -107,23 +142,59 @@ internal static class OutputConverter
         CancellationToken cancellationToken
     )
     {
-        var resvg = TryResolveExecutable("resvg");
-        switch (GetRasterConversionStrategy(outputPath, resvg is not null))
+        var toolchain = await DetectToolchainAsync(logger, cancellationToken).ConfigureAwait(false);
+        var strategy = GetRasterConversionStrategy(
+            outputPath,
+            toolchain.FfmpegSupportsSvgInput,
+            toolchain.HasResvg
+        );
+
+        if (strategy is null)
         {
+            throw new InvalidOperationException(BuildUnavailableToolsMessage(outputPath));
+        }
+
+        switch (strategy.Value)
+        {
+            case RasterConversionStrategy.DirectSvgWithFfmpeg:
+                logger.ZLogDebug($"Raster output via ffmpeg SVG input. Out={outputPath}");
+                await RunFfmpegImageAsync(
+                        toolchain.FfmpegPath!,
+                        svgPath,
+                        outputPath,
+                        logger,
+                        cancellationToken,
+                        "Ensure ffmpeg supports SVG input or install resvg."
+                    )
+                    .ConfigureAwait(false);
+                return;
+
             case RasterConversionStrategy.ResvgPngOnly:
                 logger.ZLogDebug($"Raster output via resvg only. Out={outputPath}");
-                await RunResvgAsync(resvg!, svgPath, outputPath, logger, cancellationToken)
+                await RunResvgAsync(toolchain.ResvgPath!, svgPath, outputPath, logger, cancellationToken)
                     .ConfigureAwait(false);
                 return;
 
             case RasterConversionStrategy.ResvgThenFfmpeg:
+                if (!toolchain.HasFfmpeg)
+                {
+                    throw new InvalidOperationException(BuildUnavailableToolsMessage(outputPath));
+                }
+
+                // resvg handles SVG -> PNG, then ffmpeg converts PNG to the requested target format.
                 logger.ZLogDebug($"Raster output via resvg + ffmpeg. Out={outputPath}");
                 var tempPng = Path.Combine(Path.GetTempPath(), $"c2s-{Guid.NewGuid():N}.png");
                 try
                 {
-                    await RunResvgAsync(resvg!, svgPath, tempPng, logger, cancellationToken)
+                    await RunResvgAsync(toolchain.ResvgPath!, svgPath, tempPng, logger, cancellationToken)
                         .ConfigureAwait(false);
-                    await RunFfmpegImageAsync(tempPng, outputPath, logger, cancellationToken)
+                    await RunFfmpegImageAsync(
+                            toolchain.FfmpegPath!,
+                            tempPng,
+                            outputPath,
+                            logger,
+                            cancellationToken
+                        )
                         .ConfigureAwait(false);
                 }
                 finally
@@ -133,18 +204,7 @@ internal static class OutputConverter
                 return;
 
             default:
-                logger.ZLogDebug(
-                    $"resvg not found. Falling back to direct ffmpeg SVG conversion. Out={outputPath}"
-                );
-                await RunFfmpegImageAsync(
-                        svgPath,
-                        outputPath,
-                        logger,
-                        cancellationToken,
-                        "Ensure ffmpeg supports SVG input or install resvg."
-                    )
-                    .ConfigureAwait(false);
-                return;
+                throw new InvalidOperationException($"Unexpected raster conversion strategy: {strategy.Value}");
         }
     }
 
@@ -156,15 +216,18 @@ internal static class OutputConverter
         CancellationToken cancellationToken
     )
     {
-        var resvg = TryResolveExecutable("resvg");
-        if (resvg is null)
+        var toolchain = await DetectToolchainAsync(logger, cancellationToken).ConfigureAwait(false);
+
+        if (toolchain.FfmpegSupportsSvgInput)
         {
-            logger.ZLogDebug($"resvg not found. Falling back to ffmpeg SVG frame input.");
+            // ffmpeg can read SVG input directly, so there is no reason to involve resvg.
+            logger.ZLogDebug($"Video output via ffmpeg SVG input. Out={outputPath}");
             await RunFfmpegVideoAsync(
+                    toolchain.FfmpegPath!,
                     framesDir,
                     fps,
                     outputPath,
-                    GetVideoFrameExtension(resvgAvailable: false),
+                    GetVideoFrameExtension(useResvg: false),
                     logger,
                     cancellationToken,
                     "Ensure ffmpeg supports SVG input or install resvg."
@@ -173,12 +236,23 @@ internal static class OutputConverter
             return;
         }
 
+        if (!toolchain.HasResvg)
+        {
+            throw new InvalidOperationException(BuildUnavailableToolsMessage(outputPath));
+        }
+
+        if (!toolchain.HasFfmpeg)
+        {
+            throw new InvalidOperationException(BuildUnavailableToolsMessage(outputPath));
+        }
+
+        // When ffmpeg cannot read SVG input, render each frame to PNG first.
         logger.ZLogDebug($"Video output via resvg + ffmpeg. Out={outputPath}");
         var pngFramesDir = Path.Combine(Path.GetTempPath(), $"c2s-{Guid.NewGuid():N}");
         try
         {
             await ConvertSvgFramesToPngAsync(
-                    resvg,
+                    toolchain.ResvgPath!,
                     framesDir,
                     pngFramesDir,
                     logger,
@@ -186,10 +260,11 @@ internal static class OutputConverter
                 )
                 .ConfigureAwait(false);
             await RunFfmpegVideoAsync(
+                    toolchain.FfmpegPath!,
                     pngFramesDir,
                     fps,
                     outputPath,
-                    GetVideoFrameExtension(resvgAvailable: true),
+                    GetVideoFrameExtension(useResvg: true),
                     logger,
                     cancellationToken
                 )
@@ -201,25 +276,77 @@ internal static class OutputConverter
         }
     }
 
-    private static string? TryResolveBundledExecutable(string fileName, string? processPath)
+    // Resolve a tool from a specific directory without consulting the shell.
+    private static string? TryResolveDirectoryExecutable(string fileName, string? directory)
     {
-        if (string.IsNullOrWhiteSpace(processPath))
+        if (string.IsNullOrWhiteSpace(directory))
         {
             return null;
         }
 
-        var processDirectory = Path.GetDirectoryName(processPath);
-        if (string.IsNullOrWhiteSpace(processDirectory))
-        {
-            return null;
-        }
-
-        var bundledCandidate = Path.Combine(processDirectory, fileName);
-        return File.Exists(bundledCandidate) ? bundledCandidate : null;
+        var candidate = Path.Combine(directory, fileName);
+        return File.Exists(candidate) ? Path.GetFullPath(candidate) : null;
     }
 
-    private static string FindExecutableOrThrow(string toolName, string requiredMessage) =>
-        TryResolveExecutable(toolName) ?? throw new InvalidOperationException(requiredMessage);
+    private static async Task<ConversionToolchain> DetectToolchainAsync(
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        // Probe once so all later decisions use the same tool availability snapshot.
+        var ffmpegPath = TryResolveExecutable("ffmpeg");
+        var resvgPath = TryResolveExecutable("resvg");
+        var ffmpegSupportsSvgInput =
+            ffmpegPath is not null
+            && await ProbeFfmpegSvgInputSupportAsync(ffmpegPath, logger, cancellationToken)
+                .ConfigureAwait(false);
+
+        logger.ZLogDebug(
+            $"Toolchain detected. Ffmpeg={ffmpegPath ?? "(missing)"} FfmpegSvg={ffmpegSupportsSvgInput} Resvg={resvgPath ?? "(missing)"}"
+        );
+
+        return new ConversionToolchain(ffmpegPath, ffmpegSupportsSvgInput, resvgPath);
+    }
+
+    private static async Task<bool> ProbeFfmpegSvgInputSupportAsync(
+        string ffmpegPath,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            // `ffmpeg -h` includes the build configuration line that exposes `--enable-librsvg`.
+            var helpOutput = await RunProcessForOutputAsync(
+                    toolDisplayName: "ffmpeg",
+                    executablePath: ffmpegPath,
+                    args: ["-h"],
+                    logger,
+                    cancellationToken,
+                    startFailureMessage:
+                        "Please ensure ffmpeg is installed (bundled with the application or available in PATH).",
+                    exitFailureMessage: "Failed to inspect ffmpeg build configuration."
+                )
+                .ConfigureAwait(false);
+
+            var supportsLibrsvg = HelpOutputEnablesLibrsvg(helpOutput);
+            logger.ZLogDebug(
+                $"ffmpeg SVG input support detected. Path={ffmpegPath} SupportsLibrsvg={supportsLibrsvg}"
+            );
+            return supportsLibrsvg;
+        }
+        catch (InvalidOperationException ex)
+        {
+            logger.ZLogDebug(
+                $"Failed to probe ffmpeg SVG input support. Path={ffmpegPath} Error={ex.Message}"
+            );
+            return false;
+        }
+    }
+
+    // Keep the user-facing failure terse; the search order is deterministic from the code path above.
+    private static string BuildUnavailableToolsMessage(string outputPath) =>
+        $"Cannot generate {outputPath} because ffmpeg and resvg cannot be used for this conversion.";
 
     private static Task RunResvgAsync(
         string resvg,
@@ -240,6 +367,7 @@ internal static class OutputConverter
         );
 
     private static Task RunFfmpegImageAsync(
+        string ffmpeg,
         string inputPath,
         string outputPath,
         ILogger logger,
@@ -247,6 +375,7 @@ internal static class OutputConverter
         string exitFailureMessage = "Ensure ffmpeg supports the requested output format."
     ) =>
         RunFfmpegAsync(
+            ffmpeg,
             ["-y", "-i", inputPath, "-frames:v", "1", "-update", "1", outputPath],
             logger,
             cancellationToken,
@@ -254,6 +383,7 @@ internal static class OutputConverter
         );
 
     private static Task RunFfmpegVideoAsync(
+        string ffmpeg,
         string framesDir,
         double fps,
         string outputPath,
@@ -266,6 +396,7 @@ internal static class OutputConverter
         var framePattern = Path.Combine(framesDir, $"frame-%04d.{frameExtension}");
         var fpsValue = fps.ToString(CultureInfo.InvariantCulture);
         return RunFfmpegAsync(
+            ffmpeg,
             ["-y", "-framerate", fpsValue, "-i", framePattern, outputPath],
             logger,
             cancellationToken,
@@ -274,18 +405,13 @@ internal static class OutputConverter
     }
 
     private static Task RunFfmpegAsync(
+        string ffmpeg,
         string[] args,
         ILogger logger,
         CancellationToken cancellationToken,
         string exitFailureMessage
-    )
-    {
-        var ffmpeg = FindExecutableOrThrow(
-            "ffmpeg",
-            "ffmpeg is required for this output format. Please ensure ffmpeg is installed "
-                + "(bundled with the application or available in PATH)."
-        );
-        return RunProcessAsync(
+    ) =>
+        RunProcessAsync(
             toolDisplayName: "ffmpeg",
             executablePath: ffmpeg,
             args,
@@ -295,7 +421,6 @@ internal static class OutputConverter
                 "Please ensure ffmpeg is installed (bundled with the application or available in PATH).",
             exitFailureMessage
         );
-    }
 
     private static async Task ConvertSvgFramesToPngAsync(
         string resvg,
@@ -306,6 +431,7 @@ internal static class OutputConverter
     )
     {
         Directory.CreateDirectory(pngFramesDir);
+        // Keep frame names aligned so ffmpeg can still consume a `%04d` sequence.
         foreach (var svgFramePath in Directory
                      .EnumerateFiles(svgFramesDir, "frame-*.svg")
                      .OrderBy(path => path, StringComparer.Ordinal))
@@ -318,6 +444,69 @@ internal static class OutputConverter
             await RunResvgAsync(resvg, svgFramePath, pngFramePath, logger, cancellationToken)
                 .ConfigureAwait(false);
         }
+    }
+
+    private static async Task<string> RunProcessForOutputAsync(
+        string toolDisplayName,
+        string executablePath,
+        string[] args,
+        ILogger logger,
+        CancellationToken cancellationToken,
+        string startFailureMessage,
+        string exitFailureMessage
+    )
+    {
+        logger.ZLogDebug($"Running {toolDisplayName} for output: {executablePath} {string.Join(' ', args)}");
+
+        using var process = new Process();
+        process.StartInfo.FileName = executablePath;
+        process.StartInfo.UseShellExecute = false;
+        process.StartInfo.RedirectStandardOutput = true;
+        process.StartInfo.RedirectStandardError = true;
+        foreach (var arg in args)
+        {
+            process.StartInfo.ArgumentList.Add(arg);
+        }
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Failed to start {toolDisplayName}. {startFailureMessage}\n{ex.Message}",
+                ex
+            );
+        }
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+
+        using var killOnCancel = cancellationToken.Register(() =>
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // Process may have already exited.
+            }
+        });
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        var stdout = await stdoutTask.ConfigureAwait(false);
+        var stderr = await stderrTask.ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"{toolDisplayName} exited with code {process.ExitCode}. {exitFailureMessage}"
+            );
+        }
+
+        return $"{stdout}\n{stderr}";
     }
 
     private static async Task RunProcessAsync(

--- a/src/ConsoleToSvg/Conversion/OutputConverter.cs
+++ b/src/ConsoleToSvg/Conversion/OutputConverter.cs
@@ -1,0 +1,412 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ZLogger;
+
+namespace ConsoleToSvg.Conversion;
+
+internal enum RasterConversionStrategy
+{
+    DirectSvgWithFfmpeg,
+    ResvgPngOnly,
+    ResvgThenFfmpeg,
+}
+
+internal static class OutputConverter
+{
+    private static readonly HashSet<string> VideoExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "mp4", "webm", "avi", "mov", "mkv", "ogv", "flv", "ts", "wmv", "m4v", "gif",
+    };
+
+    internal static bool IsVideoFormat(string extension) => VideoExtensions.Contains(extension);
+
+    internal static string GetExecutableFileName(string toolName, bool isWindows) =>
+        isWindows ? $"{toolName}.exe" : toolName;
+
+    internal static string? TryResolveExecutable(string toolName) =>
+        TryResolveExecutable(
+            toolName,
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            Environment.ProcessPath,
+            Environment.GetEnvironmentVariable("PATH")
+        );
+
+    internal static string? TryResolveExecutable(
+        string toolName,
+        bool isWindows,
+        string? processPath,
+        string? pathEnvironment
+    )
+    {
+        var fileName = GetExecutableFileName(toolName, isWindows);
+        var bundled = TryResolveBundledExecutable(fileName, processPath);
+        if (bundled is not null)
+        {
+            return bundled;
+        }
+
+        if (string.IsNullOrWhiteSpace(pathEnvironment))
+        {
+            return null;
+        }
+
+        foreach (var rawDirectory in pathEnvironment.Split(
+                     Path.PathSeparator,
+                     StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+                 ))
+        {
+            var directory = rawDirectory.Trim('"');
+            if (directory.Length == 0)
+            {
+                continue;
+            }
+
+            var candidate = Path.Combine(directory, fileName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    internal static RasterConversionStrategy GetRasterConversionStrategy(
+        string outputPath,
+        bool resvgAvailable
+    )
+    {
+        var outputExtension = Path.GetExtension(outputPath).TrimStart('.').ToLowerInvariant();
+        if (outputExtension == "png")
+        {
+            return resvgAvailable
+                ? RasterConversionStrategy.ResvgPngOnly
+                : RasterConversionStrategy.DirectSvgWithFfmpeg;
+        }
+
+        return resvgAvailable
+            ? RasterConversionStrategy.ResvgThenFfmpeg
+            : RasterConversionStrategy.DirectSvgWithFfmpeg;
+    }
+
+    internal static string GetVideoFrameExtension(bool resvgAvailable) =>
+        resvgAvailable ? "png" : "svg";
+
+    internal static async Task ConvertSvgToRasterAsync(
+        string svgPath,
+        string outputPath,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        var resvg = TryResolveExecutable("resvg");
+        switch (GetRasterConversionStrategy(outputPath, resvg is not null))
+        {
+            case RasterConversionStrategy.ResvgPngOnly:
+                logger.ZLogDebug($"Raster output via resvg only. Out={outputPath}");
+                await RunResvgAsync(resvg!, svgPath, outputPath, logger, cancellationToken)
+                    .ConfigureAwait(false);
+                return;
+
+            case RasterConversionStrategy.ResvgThenFfmpeg:
+                logger.ZLogDebug($"Raster output via resvg + ffmpeg. Out={outputPath}");
+                var tempPng = Path.Combine(Path.GetTempPath(), $"c2s-{Guid.NewGuid():N}.png");
+                try
+                {
+                    await RunResvgAsync(resvg!, svgPath, tempPng, logger, cancellationToken)
+                        .ConfigureAwait(false);
+                    await RunFfmpegImageAsync(tempPng, outputPath, logger, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                finally
+                {
+                    TryDeleteFile(tempPng, logger);
+                }
+                return;
+
+            default:
+                logger.ZLogDebug(
+                    $"resvg not found. Falling back to direct ffmpeg SVG conversion. Out={outputPath}"
+                );
+                await RunFfmpegImageAsync(
+                        svgPath,
+                        outputPath,
+                        logger,
+                        cancellationToken,
+                        "Ensure ffmpeg supports SVG input or install resvg."
+                    )
+                    .ConfigureAwait(false);
+                return;
+        }
+    }
+
+    internal static async Task ConvertSvgFramesToVideoAsync(
+        string framesDir,
+        double fps,
+        string outputPath,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        var resvg = TryResolveExecutable("resvg");
+        if (resvg is null)
+        {
+            logger.ZLogDebug($"resvg not found. Falling back to ffmpeg SVG frame input.");
+            await RunFfmpegVideoAsync(
+                    framesDir,
+                    fps,
+                    outputPath,
+                    GetVideoFrameExtension(resvgAvailable: false),
+                    logger,
+                    cancellationToken,
+                    "Ensure ffmpeg supports SVG input or install resvg."
+                )
+                .ConfigureAwait(false);
+            return;
+        }
+
+        logger.ZLogDebug($"Video output via resvg + ffmpeg. Out={outputPath}");
+        var pngFramesDir = Path.Combine(Path.GetTempPath(), $"c2s-{Guid.NewGuid():N}");
+        try
+        {
+            await ConvertSvgFramesToPngAsync(
+                    resvg,
+                    framesDir,
+                    pngFramesDir,
+                    logger,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+            await RunFfmpegVideoAsync(
+                    pngFramesDir,
+                    fps,
+                    outputPath,
+                    GetVideoFrameExtension(resvgAvailable: true),
+                    logger,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            TryDeleteDirectory(pngFramesDir, logger);
+        }
+    }
+
+    private static string? TryResolveBundledExecutable(string fileName, string? processPath)
+    {
+        if (string.IsNullOrWhiteSpace(processPath))
+        {
+            return null;
+        }
+
+        var processDirectory = Path.GetDirectoryName(processPath);
+        if (string.IsNullOrWhiteSpace(processDirectory))
+        {
+            return null;
+        }
+
+        var bundledCandidate = Path.Combine(processDirectory, fileName);
+        return File.Exists(bundledCandidate) ? bundledCandidate : null;
+    }
+
+    private static string FindExecutableOrThrow(string toolName, string requiredMessage) =>
+        TryResolveExecutable(toolName) ?? throw new InvalidOperationException(requiredMessage);
+
+    private static Task RunResvgAsync(
+        string resvg,
+        string svgPath,
+        string pngPath,
+        ILogger logger,
+        CancellationToken cancellationToken
+    ) =>
+        RunProcessAsync(
+            toolDisplayName: "resvg",
+            executablePath: resvg,
+            args: [svgPath, pngPath],
+            logger,
+            cancellationToken,
+            startFailureMessage:
+                "Please ensure resvg is installed (bundled with the application or available in PATH).",
+            exitFailureMessage: "Please ensure resvg can read the SVG input."
+        );
+
+    private static Task RunFfmpegImageAsync(
+        string inputPath,
+        string outputPath,
+        ILogger logger,
+        CancellationToken cancellationToken,
+        string exitFailureMessage = "Ensure ffmpeg supports the requested output format."
+    ) =>
+        RunFfmpegAsync(
+            ["-y", "-i", inputPath, "-frames:v", "1", "-update", "1", outputPath],
+            logger,
+            cancellationToken,
+            exitFailureMessage
+        );
+
+    private static Task RunFfmpegVideoAsync(
+        string framesDir,
+        double fps,
+        string outputPath,
+        string frameExtension,
+        ILogger logger,
+        CancellationToken cancellationToken,
+        string exitFailureMessage = "Ensure ffmpeg supports the requested output format."
+    )
+    {
+        var framePattern = Path.Combine(framesDir, $"frame-%04d.{frameExtension}");
+        var fpsValue = fps.ToString(CultureInfo.InvariantCulture);
+        return RunFfmpegAsync(
+            ["-y", "-framerate", fpsValue, "-i", framePattern, outputPath],
+            logger,
+            cancellationToken,
+            exitFailureMessage
+        );
+    }
+
+    private static Task RunFfmpegAsync(
+        string[] args,
+        ILogger logger,
+        CancellationToken cancellationToken,
+        string exitFailureMessage
+    )
+    {
+        var ffmpeg = FindExecutableOrThrow(
+            "ffmpeg",
+            "ffmpeg is required for this output format. Please ensure ffmpeg is installed "
+                + "(bundled with the application or available in PATH)."
+        );
+        return RunProcessAsync(
+            toolDisplayName: "ffmpeg",
+            executablePath: ffmpeg,
+            args,
+            logger,
+            cancellationToken,
+            startFailureMessage:
+                "Please ensure ffmpeg is installed (bundled with the application or available in PATH).",
+            exitFailureMessage
+        );
+    }
+
+    private static async Task ConvertSvgFramesToPngAsync(
+        string resvg,
+        string svgFramesDir,
+        string pngFramesDir,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        Directory.CreateDirectory(pngFramesDir);
+        foreach (var svgFramePath in Directory
+                     .EnumerateFiles(svgFramesDir, "frame-*.svg")
+                     .OrderBy(path => path, StringComparer.Ordinal))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var pngFramePath = Path.Combine(
+                pngFramesDir,
+                $"{Path.GetFileNameWithoutExtension(svgFramePath)}.png"
+            );
+            await RunResvgAsync(resvg, svgFramePath, pngFramePath, logger, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private static async Task RunProcessAsync(
+        string toolDisplayName,
+        string executablePath,
+        string[] args,
+        ILogger logger,
+        CancellationToken cancellationToken,
+        string startFailureMessage,
+        string exitFailureMessage
+    )
+    {
+        logger.ZLogDebug($"Running {toolDisplayName}: {executablePath} {string.Join(' ', args)}");
+
+        using var process = new Process();
+        process.StartInfo.FileName = executablePath;
+        process.StartInfo.UseShellExecute = false;
+        foreach (var arg in args)
+        {
+            process.StartInfo.ArgumentList.Add(arg);
+        }
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Failed to start {toolDisplayName}. {startFailureMessage}\n{ex.Message}",
+                ex
+            );
+        }
+
+        using var killOnCancel = cancellationToken.Register(() =>
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // Process may have already exited.
+            }
+        });
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"{toolDisplayName} exited with code {process.ExitCode}. {exitFailureMessage}"
+            );
+        }
+
+        logger.ZLogDebug($"{toolDisplayName} completed successfully.");
+    }
+
+    private static void TryDeleteFile(string path, ILogger logger)
+    {
+        if (!File.Exists(path))
+        {
+            return;
+        }
+
+        try
+        {
+            File.Delete(path);
+        }
+        catch (Exception ex)
+        {
+            logger.ZLogDebug(ex, $"Failed to delete temp file {path}: {ex.Message}");
+        }
+    }
+
+    private static void TryDeleteDirectory(string path, ILogger logger)
+    {
+        if (!Directory.Exists(path))
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch (Exception ex)
+        {
+            logger.ZLogDebug(ex, $"Failed to delete temp dir {path}: {ex.Message}");
+        }
+    }
+}

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -8,6 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using ConsoleToSvg.Cli;
+using ConsoleToSvg.Conversion;
 using ConsoleToSvg.Recording;
 using ConsoleToSvg.Svg;
 using Microsoft.Extensions.Logging;
@@ -173,7 +173,7 @@ internal static class Program
                     var useVideoPath =
                         options.IsModeExplicit
                             ? options.Mode is OutputMode.Video or OutputMode.Repeat
-                            : IsVideoFormat(outputExt);
+                            : OutputConverter.IsVideoFormat(outputExt);
 
                     if (useVideoPath)
                     {
@@ -212,7 +212,7 @@ internal static class Program
                             }
 
                             EnsureDirectory(options.OutputPath);
-                            await RunFfmpegVideoAsync(
+                            await OutputConverter.ConvertSvgFramesToVideoAsync(
                                     tempDir,
                                     options.VideoFps,
                                     options.OutputPath,
@@ -257,7 +257,7 @@ internal static class Program
                                 )
                                 .ConfigureAwait(false);
                             EnsureDirectory(options.OutputPath);
-                            await RunFfmpegImageAsync(
+                            await OutputConverter.ConvertSvgToRasterAsync(
                                     tempSvg,
                                     options.OutputPath,
                                     logger,
@@ -497,127 +497,6 @@ internal static class Program
         {
             Directory.CreateDirectory(directory);
         }
-    }
-
-    // Video file extensions that are handled by the frame-sequence → ffmpeg path.
-    // GIF is included here because the primary use-case for terminal recordings is
-    // an animated GIF; users who want a static GIF can specify --mode image separately.
-    private static readonly HashSet<string> VideoExtensions = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "mp4", "webm", "avi", "mov", "mkv", "ogv", "flv", "ts", "wmv", "m4v", "gif",
-    };
-
-    private static bool IsVideoFormat(string extension) => VideoExtensions.Contains(extension);
-
-    /// <summary>
-    /// Finds the ffmpeg executable to use for format conversion.
-    /// Preference order: binary next to this executable (bundled), then PATH.
-    /// </summary>
-    private static string FindFfmpegExecutable()
-    {
-        var exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "ffmpeg.exe" : "ffmpeg";
-
-        // 1. Check next to this binary (covers the bundled Windows distribution and npm dist/ layout)
-        var exeDir = Path.GetDirectoryName(Environment.ProcessPath ?? string.Empty);
-        if (!string.IsNullOrEmpty(exeDir))
-        {
-            var bundled = Path.Combine(exeDir, exeName);
-            if (File.Exists(bundled))
-            {
-                return bundled;
-            }
-        }
-
-        // 2. Rely on PATH
-        return exeName;
-    }
-
-    /// <summary>Runs ffmpeg with the given arguments and throws if the process exits non-zero.</summary>
-    private static async Task RunFfmpegAsync(
-        string[] args,
-        ILogger logger,
-        CancellationToken cancellationToken
-    )
-    {
-        var ffmpeg = FindFfmpegExecutable();
-        logger.ZLogDebug($"Running ffmpeg: {ffmpeg} {string.Join(' ', args)}");
-
-        using var process = new Process();
-        process.StartInfo.FileName = ffmpeg;
-        process.StartInfo.UseShellExecute = false;
-        foreach (var arg in args)
-        {
-            process.StartInfo.ArgumentList.Add(arg);
-        }
-
-        try
-        {
-            process.Start();
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidOperationException(
-                $"Failed to start ffmpeg. Please ensure ffmpeg is installed "
-                + "(bundled with the application or available in PATH).\n"
-                + ex.Message,
-                ex
-            );
-        }
-
-        using var killOnCancel = cancellationToken.Register(() =>
-        {
-            try { process.Kill(entireProcessTree: true); }
-            catch { /* process may have already exited */ }
-        });
-
-        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-
-        if (process.ExitCode != 0)
-        {
-            throw new InvalidOperationException(
-                $"ffmpeg exited with code {process.ExitCode}. "
-                + "Ensure ffmpeg supports the requested output format."
-            );
-        }
-
-        logger.ZLogDebug($"ffmpeg completed successfully.");
-    }
-
-    /// <summary>Converts a directory of frame-NNNN.svg files into a video using ffmpeg.</summary>
-    private static async Task RunFfmpegVideoAsync(
-        string framesDir,
-        double fps,
-        string outputPath,
-        ILogger logger,
-        CancellationToken cancellationToken
-    )
-    {
-        var framePattern = Path.Combine(framesDir, "frame-%04d.svg");
-        var fpsStr = fps.ToString(CultureInfo.InvariantCulture);
-        await RunFfmpegAsync(
-                ["-y", "-framerate", fpsStr, "-i", framePattern, outputPath],
-                logger,
-                cancellationToken
-            )
-            .ConfigureAwait(false);
-    }
-
-    /// <summary>Converts a single SVG file to an image format using ffmpeg.</summary>
-    private static async Task RunFfmpegImageAsync(
-        string svgPath,
-        string outputPath,
-        ILogger logger,
-        CancellationToken cancellationToken
-    )
-    {
-        await RunFfmpegAsync(
-                // -frames:v 1 -update 1 ensure a single frame is written without
-                // the "image sequence pattern" warning from ffmpeg.
-                ["-y", "-i", svgPath, "-frames:v", "1", "-update", "1", outputPath],
-                logger,
-                cancellationToken
-            )
-            .ConfigureAwait(false);
     }
 
     /// <returns>The number of frame files written to <paramref name="directory"/>.</returns>

--- a/src/ConsoleToSvg/Recording/PtyRecorder.cs
+++ b/src/ConsoleToSvg/Recording/PtyRecorder.cs
@@ -1156,6 +1156,14 @@ public static class PtyRecorder
     )
     {
         var env = new Dictionary<string, string>();
+        foreach (System.Collections.DictionaryEntry entry in Environment.GetEnvironmentVariables())
+        {
+            if (entry.Key is string key && entry.Value is string value)
+            {
+                env[key] = value;
+            }
+        }
+
         logger.ZLogDebug($"Setting PTY size environment variables: COLUMNS={width} LINES={height}");
         env["COLUMNS"] = width.ToString(System.Globalization.CultureInfo.InvariantCulture);
         env["LINES"] = height.ToString(System.Globalization.CultureInfo.InvariantCulture);

--- a/src/ConsoleToSvg/Recording/PtyRecorder.cs
+++ b/src/ConsoleToSvg/Recording/PtyRecorder.cs
@@ -1156,15 +1156,6 @@ public static class PtyRecorder
     )
     {
         var env = new Dictionary<string, string>();
-        foreach (System.Collections.DictionaryEntry entry in Environment.GetEnvironmentVariables())
-        {
-            if (entry.Key is string key && entry.Value is string value)
-            {
-                env[key] = value;
-                logger.ZLogDebug($"Inherited environment variable: {key}={value}");
-            }
-        }
-
         logger.ZLogDebug($"Setting PTY size environment variables: COLUMNS={width} LINES={height}");
         env["COLUMNS"] = width.ToString(System.Globalization.CultureInfo.InvariantCulture);
         env["LINES"] = height.ToString(System.Globalization.CultureInfo.InvariantCulture);

--- a/tests/ConsoleToSvg.Tests/Conversion/OutputConverterTests.cs
+++ b/tests/ConsoleToSvg.Tests/Conversion/OutputConverterTests.cs
@@ -33,6 +33,7 @@ public sealed class OutputConverterTests
                 "resvg",
                 isWindows: false,
                 processPath: Path.Combine(appDir, "console2svg"),
+                currentDirectory: null,
                 pathEnvironment: pathDir
             );
 
@@ -45,25 +46,30 @@ public sealed class OutputConverterTests
     }
 
     [Test]
-    public void TryResolveExecutable_FallsBackToPath()
+    public void TryResolveExecutable_ChecksCurrentDirectoryBeforePath()
     {
         var tempRoot = CreateTempDirectory();
         try
         {
+            var currentDir = Path.Combine(tempRoot, "cwd");
             var pathDir = Path.Combine(tempRoot, "path");
+            Directory.CreateDirectory(currentDir);
             Directory.CreateDirectory(pathDir);
 
+            var fromCurrentDirectory = Path.Combine(currentDir, "ffmpeg.exe");
             var onPath = Path.Combine(pathDir, "ffmpeg.exe");
+            File.WriteAllText(fromCurrentDirectory, string.Empty);
             File.WriteAllText(onPath, string.Empty);
 
             var resolved = OutputConverter.TryResolveExecutable(
                 "ffmpeg",
                 isWindows: true,
                 processPath: null,
+                currentDirectory: currentDir,
                 pathEnvironment: pathDir
             );
 
-            resolved.ShouldBe(onPath);
+            resolved.ShouldBe(fromCurrentDirectory);
         }
         finally
         {
@@ -74,21 +80,45 @@ public sealed class OutputConverterTests
     [Test]
     public void GetRasterConversionStrategy_SelectsExpectedPipelines()
     {
-        OutputConverter.GetRasterConversionStrategy("output.png", resvgAvailable: true)
+        OutputConverter.GetRasterConversionStrategy(
+                "output.png",
+                ffmpegSupportsSvgInput: true,
+                resvgAvailable: true
+            )
+            .ShouldBe(RasterConversionStrategy.DirectSvgWithFfmpeg);
+        OutputConverter.GetRasterConversionStrategy(
+                "output.png",
+                ffmpegSupportsSvgInput: false,
+                resvgAvailable: true
+            )
             .ShouldBe(RasterConversionStrategy.ResvgPngOnly);
-        OutputConverter.GetRasterConversionStrategy("output.jpg", resvgAvailable: true)
+        OutputConverter.GetRasterConversionStrategy(
+                "output.jpg",
+                ffmpegSupportsSvgInput: false,
+                resvgAvailable: true
+            )
             .ShouldBe(RasterConversionStrategy.ResvgThenFfmpeg);
-        OutputConverter.GetRasterConversionStrategy("output.png", resvgAvailable: false)
-            .ShouldBe(RasterConversionStrategy.DirectSvgWithFfmpeg);
-        OutputConverter.GetRasterConversionStrategy("output.gif", resvgAvailable: false)
-            .ShouldBe(RasterConversionStrategy.DirectSvgWithFfmpeg);
+        OutputConverter.GetRasterConversionStrategy(
+                "output.gif",
+                ffmpegSupportsSvgInput: false,
+                resvgAvailable: false
+            )
+            .ShouldBeNull();
     }
 
     [Test]
     public void GetVideoFrameExtension_UsesPngWhenResvgIsAvailable()
     {
-        OutputConverter.GetVideoFrameExtension(resvgAvailable: true).ShouldBe("png");
-        OutputConverter.GetVideoFrameExtension(resvgAvailable: false).ShouldBe("svg");
+        OutputConverter.GetVideoFrameExtension(useResvg: true).ShouldBe("png");
+        OutputConverter.GetVideoFrameExtension(useResvg: false).ShouldBe("svg");
+    }
+
+    [Test]
+    public void HelpOutputEnablesLibrsvg_DetectsBuildFlag()
+    {
+        OutputConverter.HelpOutputEnablesLibrsvg("configuration: --enable-gpl --enable-librsvg")
+            .ShouldBeTrue();
+        OutputConverter.HelpOutputEnablesLibrsvg("configuration: --enable-gpl").ShouldBeFalse();
     }
 
     private static string CreateTempDirectory()

--- a/tests/ConsoleToSvg.Tests/Conversion/OutputConverterTests.cs
+++ b/tests/ConsoleToSvg.Tests/Conversion/OutputConverterTests.cs
@@ -33,7 +33,6 @@ public sealed class OutputConverterTests
                 "resvg",
                 isWindows: false,
                 processPath: Path.Combine(appDir, "console2svg"),
-                currentDirectory: null,
                 pathEnvironment: pathDir
             );
 
@@ -46,7 +45,7 @@ public sealed class OutputConverterTests
     }
 
     [Test]
-    public void TryResolveExecutable_ChecksCurrentDirectoryBeforePath()
+    public void TryResolveExecutable_IgnoresCurrentDirectoryAndChecksPath()
     {
         var tempRoot = CreateTempDirectory();
         try
@@ -56,6 +55,7 @@ public sealed class OutputConverterTests
             Directory.CreateDirectory(currentDir);
             Directory.CreateDirectory(pathDir);
 
+            // A binary in the current working directory should not be picked up (security risk).
             var fromCurrentDirectory = Path.Combine(currentDir, "ffmpeg.exe");
             var onPath = Path.Combine(pathDir, "ffmpeg.exe");
             File.WriteAllText(fromCurrentDirectory, string.Empty);
@@ -65,11 +65,10 @@ public sealed class OutputConverterTests
                 "ffmpeg",
                 isWindows: true,
                 processPath: null,
-                currentDirectory: currentDir,
                 pathEnvironment: pathDir
             );
 
-            resolved.ShouldBe(fromCurrentDirectory);
+            resolved.ShouldBe(onPath);
         }
         finally
         {

--- a/tests/ConsoleToSvg.Tests/Conversion/OutputConverterTests.cs
+++ b/tests/ConsoleToSvg.Tests/Conversion/OutputConverterTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.IO;
+using ConsoleToSvg.Conversion;
+
+namespace ConsoleToSvg.Tests.Conversion;
+
+public sealed class OutputConverterTests
+{
+    [Test]
+    public void GetExecutableFileName_AppendsExeOnWindows()
+    {
+        OutputConverter.GetExecutableFileName("resvg", isWindows: true).ShouldBe("resvg.exe");
+        OutputConverter.GetExecutableFileName("resvg", isWindows: false).ShouldBe("resvg");
+    }
+
+    [Test]
+    public void TryResolveExecutable_PrefersBundledBinaryOverPath()
+    {
+        var tempRoot = CreateTempDirectory();
+        try
+        {
+            var appDir = Path.Combine(tempRoot, "app");
+            var pathDir = Path.Combine(tempRoot, "path");
+            Directory.CreateDirectory(appDir);
+            Directory.CreateDirectory(pathDir);
+
+            var bundled = Path.Combine(appDir, "resvg");
+            var onPath = Path.Combine(pathDir, "resvg");
+            File.WriteAllText(bundled, string.Empty);
+            File.WriteAllText(onPath, string.Empty);
+
+            var resolved = OutputConverter.TryResolveExecutable(
+                "resvg",
+                isWindows: false,
+                processPath: Path.Combine(appDir, "console2svg"),
+                pathEnvironment: pathDir
+            );
+
+            resolved.ShouldBe(bundled);
+        }
+        finally
+        {
+            DeleteTempDirectory(tempRoot);
+        }
+    }
+
+    [Test]
+    public void TryResolveExecutable_FallsBackToPath()
+    {
+        var tempRoot = CreateTempDirectory();
+        try
+        {
+            var pathDir = Path.Combine(tempRoot, "path");
+            Directory.CreateDirectory(pathDir);
+
+            var onPath = Path.Combine(pathDir, "ffmpeg.exe");
+            File.WriteAllText(onPath, string.Empty);
+
+            var resolved = OutputConverter.TryResolveExecutable(
+                "ffmpeg",
+                isWindows: true,
+                processPath: null,
+                pathEnvironment: pathDir
+            );
+
+            resolved.ShouldBe(onPath);
+        }
+        finally
+        {
+            DeleteTempDirectory(tempRoot);
+        }
+    }
+
+    [Test]
+    public void GetRasterConversionStrategy_SelectsExpectedPipelines()
+    {
+        OutputConverter.GetRasterConversionStrategy("output.png", resvgAvailable: true)
+            .ShouldBe(RasterConversionStrategy.ResvgPngOnly);
+        OutputConverter.GetRasterConversionStrategy("output.jpg", resvgAvailable: true)
+            .ShouldBe(RasterConversionStrategy.ResvgThenFfmpeg);
+        OutputConverter.GetRasterConversionStrategy("output.png", resvgAvailable: false)
+            .ShouldBe(RasterConversionStrategy.DirectSvgWithFfmpeg);
+        OutputConverter.GetRasterConversionStrategy("output.gif", resvgAvailable: false)
+            .ShouldBe(RasterConversionStrategy.DirectSvgWithFfmpeg);
+    }
+
+    [Test]
+    public void GetVideoFrameExtension_UsesPngWhenResvgIsAvailable()
+    {
+        OutputConverter.GetVideoFrameExtension(resvgAvailable: true).ShouldBe("png");
+        OutputConverter.GetVideoFrameExtension(resvgAvailable: false).ShouldBe("svg");
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"c2s-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void DeleteTempDirectory(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+}

--- a/wrapper/npm/cli/install.js
+++ b/wrapper/npm/cli/install.js
@@ -42,12 +42,6 @@ const isWin = platform === 'win32';
 const distDir = path.join(__dirname, '..', 'dist');
 const destPath = path.join(distDir, `console2svg${isWin ? '.exe' : ''}`);
 
-if (fs.existsSync(destPath)) {
-  process.exit(0);
-}
-
-fs.mkdirSync(distDir, { recursive: true });
-
 function fail(message, err) {
   if (err) {
     console.error(message, err.message || err);
@@ -57,7 +51,12 @@ function fail(message, err) {
   process.exit(1);
 }
 
-function download(downloadUrl, redirects, onFinish) {
+function resetDistDir() {
+  fs.rmSync(distDir, { recursive: true, force: true });
+  fs.mkdirSync(distDir, { recursive: true });
+}
+
+function download(downloadUrl, tempPath, redirects, onFinish) {
   if (redirects > 5) {
     fail('console2svg: too many redirects while downloading.');
   }
@@ -65,8 +64,6 @@ function download(downloadUrl, redirects, onFinish) {
   const proxy = getProxyForUrl(downloadUrl);
   const agent = proxy ? new HttpsProxyAgent(proxy) : undefined;
   const urlObj = new URL(downloadUrl);
-
-  const tempPath = `${destPath}.tmp`;
 
   const request = https.get(
     {
@@ -83,7 +80,7 @@ function download(downloadUrl, redirects, onFinish) {
     (res) => {
       if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
         res.resume();
-        download(res.headers.location, redirects + 1, onFinish);
+        download(res.headers.location, tempPath, redirects + 1, onFinish);
         return;
       }
 
@@ -105,11 +102,11 @@ function download(downloadUrl, redirects, onFinish) {
       });
       file.on('error', (err) => {
         try {
-            fs.unlinkSync(tempPath);
-          } catch {
-            // ignore
-          }
-          fail('console2svg: write failed.', err);
+          fs.unlinkSync(tempPath);
+        } catch {
+          // ignore
+        }
+        fail('console2svg: write failed.', err);
       });
     }
   );
@@ -119,12 +116,15 @@ function download(downloadUrl, redirects, onFinish) {
   });
 }
 
+resetDistDir();
+
 if (isWin) {
-  // On Windows: download the ffmpeg bundle zip (console2svg.exe + ffmpeg.exe + DLLs)
+  // On Windows: download the ffmpeg bundle zip (console2svg.exe + resvg.exe + ffmpeg.exe + DLLs)
   const zipFileName = `console2svg-${rid}-ffmpeg.zip`;
   const zipUrl = `https://github.com/arika0093/console2svg/releases/download/v${version}/${zipFileName}`;
+  const tempZipPath = path.join(distDir, `${zipFileName}.tmp`);
 
-  download(zipUrl, 0, (tempZipPath) => {
+  download(zipUrl, tempZipPath, 0, (downloadedZipPath) => {
     // Escape single quotes in paths for PowerShell single-quoted string literals.
     const psEscape = (p) => p.replace(/'/g, "''");
     // Extract the zip into distDir using PowerShell
@@ -134,12 +134,12 @@ if (isWin) {
         '-NoProfile',
         '-NonInteractive',
         '-Command',
-        `Expand-Archive -LiteralPath '${psEscape(tempZipPath)}' -DestinationPath '${psEscape(distDir)}' -Force`
+        `Expand-Archive -LiteralPath '${psEscape(downloadedZipPath)}' -DestinationPath '${psEscape(distDir)}' -Force`
       ],
       { stdio: 'inherit' }
     );
 
-    try { fs.unlinkSync(tempZipPath); } catch { /* ignore */ }
+    try { fs.unlinkSync(downloadedZipPath); } catch { /* ignore */ }
 
     if (result.status !== 0) {
       fail('console2svg: failed to extract zip bundle.');
@@ -152,14 +152,33 @@ if (isWin) {
     process.exit(0);
   });
 } else {
-  // On Linux/macOS: download the single binary
-  const fileName = `console2svg-${rid}`;
-  const url = `https://github.com/arika0093/console2svg/releases/download/v${version}/${fileName}`;
+  // On Linux/macOS: download the release tarball bundle (console2svg + resvg)
+  const archiveFileName = `console2svg-${rid}.tar.gz`;
+  const url = `https://github.com/arika0093/console2svg/releases/download/v${version}/${archiveFileName}`;
+  const tempArchivePath = path.join(distDir, `${archiveFileName}.tmp`);
 
-  download(url, 0, (tempPath) => {
-    fs.renameSync(tempPath, destPath);
+  download(url, tempArchivePath, 0, (downloadedArchivePath) => {
+    const result = spawnSync(
+      'tar',
+      ['-xzf', downloadedArchivePath, '-C', distDir],
+      { stdio: 'inherit' }
+    );
+
+    try { fs.unlinkSync(downloadedArchivePath); } catch { /* ignore */ }
+
+    if (result.status !== 0) {
+      fail('console2svg: failed to extract tar.gz bundle.');
+    }
+
+    if (!fs.existsSync(destPath)) {
+      fail('console2svg: console2svg not found after extraction.');
+    }
+
     fs.chmodSync(destPath, 0o755);
+    const resvgPath = path.join(distDir, 'resvg');
+    if (fs.existsSync(resvgPath)) {
+      fs.chmodSync(resvgPath, 0o755);
+    }
     process.exit(0);
   });
 }
-

--- a/wrapper/npm/cli/install.js
+++ b/wrapper/npm/cli/install.js
@@ -51,8 +51,7 @@ function fail(message, err) {
   process.exit(1);
 }
 
-function resetDistDir() {
-  fs.rmSync(distDir, { recursive: true, force: true });
+function ensureDistDir() {
   fs.mkdirSync(distDir, { recursive: true });
 }
 
@@ -116,10 +115,15 @@ function download(downloadUrl, tempPath, redirects, onFinish) {
   });
 }
 
-resetDistDir();
+ensureDistDir();
+
+if (fs.existsSync(destPath)) {
+  // Binary already installed; skip the download.
+  process.exit(0);
+}
 
 if (isWin) {
-  // On Windows: download the ffmpeg bundle zip (console2svg.exe + resvg.exe + ffmpeg.exe + DLLs)
+  // On Windows: download the ffmpeg bundle zip (console2svg.exe + resvg.exe + ffmpeg.exe)
   const zipFileName = `console2svg-${rid}-ffmpeg.zip`;
   const zipUrl = `https://github.com/arika0093/console2svg/releases/download/v${version}/${zipFileName}`;
   const tempZipPath = path.join(distDir, `${zipFileName}.tmp`);


### PR DESCRIPTION
- [x] Fix security issue: remove current-directory probe from `TryResolveExecutable` in `OutputConverter.cs`
- [x] Update `BuildUnavailableToolsMessage` in `OutputConverter.cs` to give format-specific error messages; extract duplicate install hint into a constant
- [x] Fix help text formatting in `OptionParser.cs`: `ffmpeg(librsvg build)` → `ffmpeg (librsvg-enabled build)`
- [x] Fix install script: skip download if binary already present (avoid re-downloading on re-install)
- [x] Fix Windows bundle comment in `install.js`: remove stale reference to DLLs
- [x] Update tests to reflect removal of current-directory probe (verify CWD is NOT checked)
- [x] All 282 tests pass