### PR TITLE
Add release asset building scripts and SVG conversion functionality

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,9 +124,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: native-${{ matrix.rid }}
-          path: |
-            ./native-publish/${{ matrix.rid }}/console2svg*
-            ./native-publish/${{ matrix.rid }}/*resvg_wrapper*
+          path: ./native-publish/${{ matrix.rid }}/
 
   release-github:
     needs: [build-nupkg, build-aot]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,13 +124,17 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: native-${{ matrix.rid }}
-          path: ./native-publish/${{ matrix.rid }}/console2svg*
+          path: |
+            ./native-publish/${{ matrix.rid }}/console2svg*
+            ./native-publish/${{ matrix.rid }}/*resvg_wrapper*
 
   release-github:
     needs: [build-nupkg, build-aot]
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v6
+
       - name: Download NuGet artifacts
         uses: actions/download-artifact@v8
         with:
@@ -144,115 +148,21 @@ jobs:
           path: ./native-artifacts
           merge-multiple: false
 
-      - name: Collect native binaries
-        shell: bash
-        run: |
-          for dir in ./native-artifacts/native-*/; do
-            rid=$(basename "$dir" | sed 's/^native-//')
-            if [[ "$rid" == win-* ]]; then
-              src="$dir/console2svg.exe"
-              dst="./release-upload/console2svg-${rid}.exe"
-            else
-              src="$dir/console2svg"
-              dst="./release-upload/console2svg-${rid}"
-            fi
-            if [ -f "$src" ]; then
-              cp "$src" "$dst"
-            fi
-          done
-
       - name: Install Linux packaging tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y rpm
+          sudo apt-get install -y rpm unzip zip
           sudo gem install --no-document fpm
 
-      - name: Build Linux packages
+      - name: Build release assets
         shell: bash
-        run: |
-          for rid in linux-x64 linux-arm64; do
-            case "$rid" in
-              linux-x64)
-                asset_arch=x64
-                deb_arch=amd64
-                rpm_arch=x86_64
-                ;;
-              linux-arm64)
-                asset_arch=arm64
-                deb_arch=arm64
-                rpm_arch=aarch64
-                ;;
-            esac
-
-            src="./native-artifacts/native-${rid}/console2svg"
-            if [ ! -f "$src" ]; then
-              continue
-            fi
-
-            chmod 755 "$src"
-
-            common_args=(
-              -s dir
-              -n console2svg
-              -v "${{ needs.build-nupkg.outputs.package-version }}"
-              --iteration "${{ needs.build-nupkg.outputs.package-iteration }}"
-              --license Apache-2.0
-              --url "https://github.com/${{ github.repository }}"
-              --description "Convert terminal output to SVG images."
-            )
-
-            fpm "${common_args[@]}" -t deb -a "$deb_arch" -p "./release-upload/console2svg.${asset_arch}.deb" "$src=/usr/local/bin/console2svg"
-            fpm "${common_args[@]}" -t rpm -a "$rpm_arch" -p "./release-upload/console2svg.${asset_arch}.rpm" "$src=/usr/local/bin/console2svg"
-          done
-
-      - name: Build Windows ffmpeg zip bundles
-        shell: bash
-        run: |
-          sudo apt-get install -y unzip
-
-          for rid in win-x64 win-arm64; do
-            case "$rid" in
-              win-x64)
-                ffmpeg_zip_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-lgpl-shared.zip"
-                ;;
-              win-arm64)
-                ffmpeg_zip_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-winarm64-lgpl-shared.zip"
-                ;;
-            esac
-
-            src="./native-artifacts/native-${rid}/console2svg.exe"
-            if [ ! -f "$src" ]; then
-              continue
-            fi
-
-            # Download and extract the ffmpeg bundle
-            ffmpeg_zip="./ffmpeg-${rid}.zip"
-            curl -fsSL -o "$ffmpeg_zip" "$ffmpeg_zip_url"
-
-            ffmpeg_dir="./ffmpeg-extract-${rid}"
-            mkdir -p "$ffmpeg_dir"
-            unzip -q "$ffmpeg_zip" -d "$ffmpeg_dir"
-
-            # The BtbN zip contains a top-level directory with a bin/ subdirectory
-            top_dir=$(ls -d "$ffmpeg_dir"/*/ | head -1)
-            ffmpeg_bin_dir="${top_dir}bin"
-            if [ ! -f "$ffmpeg_bin_dir/ffmpeg.exe" ]; then
-              echo "ffmpeg.exe not found at $ffmpeg_bin_dir/ffmpeg.exe."
-              exit 1
-            fi
-
-            # Build the bundle zip: console2svg.exe + ffmpeg binaries (exe + dlls) + LICENSE
-            bundle_dir="./console2svg-${rid}-ffmpeg"
-            mkdir -p "$bundle_dir"
-            cp "$src" "$bundle_dir/console2svg.exe"
-            cp "$ffmpeg_bin_dir"/*.exe "$bundle_dir/"
-            cp "$ffmpeg_bin_dir"/*.dll "$bundle_dir/"
-            cp "${top_dir}LICENSE.txt" "$bundle_dir/ffmpeg-LICENSE.txt"
-
-            zip_name="./release-upload/console2svg-${rid}-ffmpeg.zip"
-            zip -q -r "$zip_name" "$bundle_dir"
-            echo "Created $zip_name"
-          done
+        env:
+          RELEASE_UPLOAD_DIR: ./release-upload
+          NATIVE_ARTIFACTS_DIR: ./native-artifacts
+          PACKAGE_VERSION: ${{ needs.build-nupkg.outputs.package-version }}
+          PACKAGE_ITERATION: ${{ needs.build-nupkg.outputs.package-iteration }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: ./scripts/release-action/build-release-assets.sh
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The easiest way is to run the following command (of course, please check the [co
 curl -fsSL https://raw.githubusercontent.com/arika0093/console2svg/main/install.sh | sh
 ```
 
-The script installs the appropriate release bundle into `/usr/local/bin` when writable, or `~/.local/bin` otherwise. You can override this with `INSTALL_DIR=/your/path`.
+The script downloads and extracts the appropriate release bundle directly into `/usr/local/bin` when writable, or `~/.local/bin` otherwise. You can override this with `INSTALL_DIR=/your/path`.
 
 It is available as a standalone bundle that you can download from the releases page and add to your PATH.
 The standard `.tar.gz`/`.zip` bundles include the matching `ResvgSharp` native runtime when that runtime exists for the target platform.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For example, let's open [this image](https://raw.githubusercontent.com/arika0093
 
 There are similar tools, but console2svg stands out for:
 
-* [**No dependencies**](#install): no additional software or libraries required. available as npm, dotnet tool and static binary.
+* [**Flexible output pipeline**](#convert-to-other-formats): SVG is always first-class, PNG is rendered with built-in `ResvgSharp`, and other raster/video formats use `ffmpeg` directly when possible.
 * [**Video mode**](#animated-svg): save command execution animations as SVG. great for documentation and blog posts.
 * [**Crop**](#static-svg-with-crop): trim specific parts of the output. Crop based on text patterns is also supported, making it easy to trim specific lines or sections.
 * [**Background and window**](#window-chrome): add background and window frames to produce presentation-ready SVGs for documentation, blogs, social media, etc.
@@ -68,7 +68,8 @@ dotnet tool install -g ConsoleToSvg
 npm install -g console2svg
 ```
 
-It is also available as a standalone binary that you can download from the releases page and add to your PATH.
+It is also available as a standalone bundle that you can download from the releases page and add to your PATH.
+The standard `.tar.gz`/`.zip` bundles include the matching `ResvgSharp` native runtime when that runtime exists for the target platform.
 
 ```sh
 # ubuntu
@@ -76,17 +77,36 @@ curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/cons
 dpkg -i console2svg.deb
 
 # linux
-curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-linux-x64 -o console2svg
+curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-linux-x64.tar.gz -o console2svg-linux-x64.tar.gz
+tar -xzf console2svg-linux-x64.tar.gz
 mv -f console2svg /usr/local/bin/
+mv -f libresvg_wrapper.so /usr/local/bin/
 chmod +x /usr/local/bin/console2svg
 
-# windows (binary only)
-curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64.exe -o console2svg.exe
-# windows (with ffmpeg)
-curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64-ffmpeg.zip -o console2svg-win-x64-ffmpeg.zip
-unzip console2svg-win-x64-ffmpeg.zip -d console2svg
+# windows (console2svg + ResvgSharp runtime)
+curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64.zip -o console2svg-win-x64.zip
+unzip console2svg-win-x64.zip -d console2svg
 cd console2svg
+
+# windows (console2svg + ResvgSharp runtime + ffmpeg)
+curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64-ffmpeg.zip -o console2svg-win-x64-ffmpeg.zip
+unzip console2svg-win-x64-ffmpeg.zip -d console2svg-ffmpeg
+cd console2svg-ffmpeg
 ```
+
+If you build or publish from source, keep the matching `resvg_wrapper` sidecar next to `console2svg` for PNG output and for any fallback path that rasterizes through `ResvgSharp`.
+
+On macOS, the extracted sidecar is `libresvg_wrapper.dylib`.
+
+```sh
+# NativeAOT publish output example (linux-x64)
+ls publish/
+# console2svg
+# libresvg_wrapper.so
+```
+
+> [!NOTE]
+> `ResvgSharp` 1.0.3 currently ships native runtime assets for `linux-x64`, `linux-arm64`, `osx-x64`, `osx-arm64`, and `win-x64`. `win-arm64` native bundles may not include the `resvg_wrapper` runtime.
 
 ### GitHub Actions
 
@@ -278,9 +298,14 @@ The replay file is in a simple JSON format. If you make a mistake in the input, 
 
 In v0.7 and later, you can specify the output format based on the file extension specified with `-o output.mp4`.
 
-First, install `ffmpeg`.  
+* `.png` is always rendered directly with the built-in `ResvgSharp` renderer, so no external tools are required.
+* Other raster formats such as `.jpg`, `.jpeg`, and `.webp` first try direct `ffmpeg` SVG input when the detected build advertises `--enable-librsvg`.
+* Video formats such as `.mp4`, `.webm`, and `.gif` do the same: direct SVG frames when possible, otherwise `console2svg` rasterizes frames with `ResvgSharp` and hands PNG frames to `ffmpeg`.
+* If `ffmpeg` is installed but built without `librsvg`, `console2svg` automatically falls back to `ResvgSharp -> PNG -> ffmpeg`.
+
+If you need anything other than PNG, install `ffmpeg`.  
 On Linux/macOS, you can easily install it using a package manager.  
-On Windows, it's a bit more involved, so you can use the bundled version of ffmpeg ([x64](https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64-ffmpeg.zip), [arm64](https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-arm64-ffmpeg.zip)).
+On Windows, it's a bit more involved, so you can use the [bundled version of ffmpeg(x64)](https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64-ffmpeg.zip).
 
 ```bash
 # ubuntu
@@ -293,7 +318,19 @@ unzip console2svg-win-x64-ffmpeg.zip
 cd console2svg
 ```
 
-Then, you can specify the output file with the desired extension. For example, to convert to MP4 video:
+Then, you can specify the output file with the desired extension. For example, to render a PNG without ffmpeg:
+
+```bash
+console2svg -c -d macos --output output.png -- some-command
+```
+
+To convert to JPEG through `ffmpeg`:
+
+```bash
+console2svg -c -d macos --output output.jpg -- some-command
+```
+
+To convert to MP4 video:
 
 ```bash
 console2svg -c -d macos --timeout 5 --fps 30 --output output.mp4 -- some-command

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ For example, let's open [this image](https://raw.githubusercontent.com/arika0093
 
 There are similar tools, but console2svg stands out for:
 
-* [**Flexible output pipeline**](#convert-to-other-formats): SVG is always first-class, PNG is rendered with built-in `ResvgSharp`, and other raster/video formats use `ffmpeg` directly when possible.
 * [**Video mode**](#animated-svg): save command execution animations as SVG. great for documentation and blog posts.
 * [**Crop**](#static-svg-with-crop): trim specific parts of the output. Crop based on text patterns is also supported, making it easy to trim specific lines or sections.
 * [**Background and window**](#window-chrome): add background and window frames to produce presentation-ready SVGs for documentation, blogs, social media, etc.
@@ -59,16 +58,15 @@ console2svg -v -c -d macos -- copilot --banner
 ## Install
 [![NuGet Version](https://img.shields.io/nuget/v/ConsoleToSvg?style=flat-square&logo=NuGet&color=0080CC)](https://www.nuget.org/packages/ConsoleToSvg/) [![npm version](https://img.shields.io/npm/v/console2svg?style=flat-square&logo=npm&color=0080CC)](https://www.npmjs.com/package/console2svg) [![GitHub Release](https://img.shields.io/github/v/release/arika0093/console2svg?style=flat-square&logo=github&label=GitHub%20Release&color=%230080CC)](https://github.com/arika0093/console2svg/releases/latest)
  
-You can install it as a global tool using the dotnet or npm package manager.
+The easiest way is to run the following command (of course, please check the [content](./install.sh) before running it. It just does what the following sections describe).
 
 ```sh
-# dotnet global tool
-dotnet tool install -g ConsoleToSvg
-# npm global package
-npm install -g console2svg
+curl -fsSL https://raw.githubusercontent.com/arika0093/console2svg/main/install.sh | sh
 ```
 
-It is also available as a standalone bundle that you can download from the releases page and add to your PATH.
+The script installs the appropriate release bundle into `/usr/local/bin` when writable, or `~/.local/bin` otherwise. You can override this with `INSTALL_DIR=/your/path`.
+
+It is available as a standalone bundle that you can download from the releases page and add to your PATH.
 The standard `.tar.gz`/`.zip` bundles include the matching `ResvgSharp` native runtime when that runtime exists for the target platform.
 
 ```sh
@@ -76,37 +74,25 @@ The standard `.tar.gz`/`.zip` bundles include the matching `ResvgSharp` native r
 curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg.amd64.deb -o console2svg.deb
 dpkg -i console2svg.deb
 
-# linux
-curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-linux-x64.tar.gz -o console2svg-linux-x64.tar.gz
-tar -xzf console2svg-linux-x64.tar.gz
-mv -f console2svg /usr/local/bin/
-mv -f libresvg_wrapper.so /usr/local/bin/
+# macos
+curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-osx-arm64.tar.gz -o console2svg-osx-arm64.tar.gz
+tar -xzf console2svg-osx-arm64.tar.gz -C /usr/local/bin --strip-components=1
 chmod +x /usr/local/bin/console2svg
 
-# windows (console2svg + ResvgSharp runtime)
+# windows (console2svg + ffmpeg)
 curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64.zip -o console2svg-win-x64.zip
 unzip console2svg-win-x64.zip -d console2svg
 cd console2svg
-
-# windows (console2svg + ResvgSharp runtime + ffmpeg)
-curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64-ffmpeg.zip -o console2svg-win-x64-ffmpeg.zip
-unzip console2svg-win-x64-ffmpeg.zip -d console2svg-ffmpeg
-cd console2svg-ffmpeg
 ```
 
-If you build or publish from source, keep the matching `resvg_wrapper` sidecar next to `console2svg` for PNG output and for any fallback path that rasterizes through `ResvgSharp`.
-
-On macOS, the extracted sidecar is `libresvg_wrapper.dylib`.
+You can also install it as a global tool using the dotnet or npm package manager.
 
 ```sh
-# NativeAOT publish output example (linux-x64)
-ls publish/
-# console2svg
-# libresvg_wrapper.so
+# dotnet global tool
+dotnet tool install -g ConsoleToSvg
+# npm global package
+npm install -g console2svg
 ```
-
-> [!NOTE]
-> `ResvgSharp` 1.0.3 currently ships native runtime assets for `linux-x64`, `linux-arm64`, `osx-x64`, `osx-arm64`, and `win-x64`. `win-arm64` native bundles may not include the `resvg_wrapper` runtime.
 
 ### GitHub Actions
 
@@ -305,7 +291,7 @@ In v0.7 and later, you can specify the output format based on the file extension
 
 If you need anything other than PNG, install `ffmpeg`.  
 On Linux/macOS, you can easily install it using a package manager.  
-On Windows, it's a bit more involved, so you can use the [bundled version of ffmpeg(x64)](https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64-ffmpeg.zip).
+On Windows, `console2svg-win-x64.zip` already includes `ffmpeg.exe`.
 
 ```bash
 # ubuntu
@@ -313,8 +299,8 @@ sudo apt install ffmpeg
 # macos
 brew install ffmpeg
 # windows 
-curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64-ffmpeg.zip -o console2svg-win-x64-ffmpeg.zip
-unzip console2svg-win-x64-ffmpeg.zip
+curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64.zip -o console2svg-win-x64.zip
+unzip console2svg-win-x64.zip
 cd console2svg
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -122,10 +122,14 @@ runs:
 
           case "$RID" in
             linux-*)
-              curl -fsSL -L -o "${INSTALL_DIR}/libresvg_wrapper.so" "${RELEASE_BASE_URL}/libresvg_wrapper-${RID}.so"
+              if curl -fsSL -L -o "${INSTALL_DIR}/libresvg_wrapper.so" "${RELEASE_BASE_URL}/libresvg_wrapper-${RID}.so"; then
+                :
+              fi
               ;;
             osx-*)
-              curl -fsSL -L -o "${INSTALL_DIR}/libresvg_wrapper.dylib" "${RELEASE_BASE_URL}/libresvg_wrapper-${RID}.dylib"
+              if curl -fsSL -L -o "${INSTALL_DIR}/libresvg_wrapper.dylib" "${RELEASE_BASE_URL}/libresvg_wrapper-${RID}.dylib"; then
+                :
+              fi
               ;;
             win-*)
               if curl -fsSL -L -o "${INSTALL_DIR}/resvg_wrapper.dll" "${RELEASE_BASE_URL}/resvg_wrapper-${RID}.dll"; then
@@ -133,6 +137,11 @@ runs:
               fi
               ;;
           esac
+        fi
+
+        if [ ! -f "${INSTALL_DIR}/console2svg${EXT}" ]; then
+          echo "console2svg${EXT} was not found after installation."
+          exit 1
         fi
 
         [ -z "${EXT}" ] && chmod +x "${INSTALL_DIR}/console2svg"

--- a/action.yml
+++ b/action.yml
@@ -90,11 +90,6 @@ runs:
         mkdir -p "$INSTALL_DIR"
 
         BUNDLE="console2svg-${RID}${ARCHIVE_EXT}"
-        FALLBACK_BUNDLE=""
-        if [ "${{ runner.os }}" = "Windows" ] && [ "${{ runner.arch }}" = "X64" ]; then
-          BUNDLE="console2svg-${RID}-ffmpeg.zip"
-          FALLBACK_BUNDLE="console2svg-${RID}.zip"
-        fi
 
         download_bundle() {
           local bundle_name="$1"
@@ -118,30 +113,26 @@ runs:
         }
 
         if ! download_bundle "$BUNDLE"; then
-          if [ -n "$FALLBACK_BUNDLE" ] && download_bundle "$FALLBACK_BUNDLE"; then
-            :
-          else
-            FILE="console2svg-${RID}${EXT}"
-            URL="${RELEASE_BASE_URL}/${FILE}"
+          FILE="console2svg-${RID}${EXT}"
+          URL="${RELEASE_BASE_URL}/${FILE}"
 
-            echo "Falling back to legacy asset layout..."
-            echo "Downloading ${URL} ..."
-            curl -fsSL -L -o "${INSTALL_DIR}/console2svg${EXT}" "${URL}"
+          echo "Falling back to legacy asset layout..."
+          echo "Downloading ${URL} ..."
+          curl -fsSL -L -o "${INSTALL_DIR}/console2svg${EXT}" "${URL}"
 
-            case "$RID" in
-              linux-*)
-                curl -fsSL -L -o "${INSTALL_DIR}/libresvg_wrapper.so" "${RELEASE_BASE_URL}/libresvg_wrapper-${RID}.so"
-                ;;
-              osx-*)
-                curl -fsSL -L -o "${INSTALL_DIR}/libresvg_wrapper.dylib" "${RELEASE_BASE_URL}/libresvg_wrapper-${RID}.dylib"
-                ;;
-              win-*)
-                if curl -fsSL -L -o "${INSTALL_DIR}/resvg_wrapper.dll" "${RELEASE_BASE_URL}/resvg_wrapper-${RID}.dll"; then
-                  :
-                fi
-                ;;
-            esac
-          fi
+          case "$RID" in
+            linux-*)
+              curl -fsSL -L -o "${INSTALL_DIR}/libresvg_wrapper.so" "${RELEASE_BASE_URL}/libresvg_wrapper-${RID}.so"
+              ;;
+            osx-*)
+              curl -fsSL -L -o "${INSTALL_DIR}/libresvg_wrapper.dylib" "${RELEASE_BASE_URL}/libresvg_wrapper-${RID}.dylib"
+              ;;
+            win-*)
+              if curl -fsSL -L -o "${INSTALL_DIR}/resvg_wrapper.dll" "${RELEASE_BASE_URL}/resvg_wrapper-${RID}.dll"; then
+                :
+              fi
+              ;;
+          esac
         fi
 
         [ -z "${EXT}" ] && chmod +x "${INSTALL_DIR}/console2svg"

--- a/action.yml
+++ b/action.yml
@@ -74,18 +74,76 @@ runs:
             ;;
         esac
 
-        FILE="console2svg-${RID}${EXT}"
-        if [ "$VERSION" = "latest" ]; then
-          URL="https://github.com/arika0093/console2svg/releases/latest/download/${FILE}"
+        if [ "${{ runner.os }}" = "Windows" ]; then
+          ARCHIVE_EXT=".zip"
         else
-          URL="https://github.com/arika0093/console2svg/releases/download/v${VERSION}/${FILE}"
+          ARCHIVE_EXT=".tar.gz"
+        fi
+
+        if [ "$VERSION" = "latest" ]; then
+          RELEASE_BASE_URL="https://github.com/arika0093/console2svg/releases/latest/download"
+        else
+          RELEASE_BASE_URL="https://github.com/arika0093/console2svg/releases/download/v${VERSION}"
         fi
 
         INSTALL_DIR="${{ runner.tool_cache }}/console2svg/${VERSION}/${{ runner.arch }}"
         mkdir -p "$INSTALL_DIR"
 
-        echo "Downloading ${URL} ..."
-        curl -fsSL -L -o "${INSTALL_DIR}/console2svg${EXT}" "${URL}"
+        BUNDLE="console2svg-${RID}${ARCHIVE_EXT}"
+        FALLBACK_BUNDLE=""
+        if [ "${{ runner.os }}" = "Windows" ] && [ "${{ runner.arch }}" = "X64" ]; then
+          BUNDLE="console2svg-${RID}-ffmpeg.zip"
+          FALLBACK_BUNDLE="console2svg-${RID}.zip"
+        fi
+
+        download_bundle() {
+          local bundle_name="$1"
+          local archive_path="${INSTALL_DIR}/${bundle_name}"
+          local bundle_url="${RELEASE_BASE_URL}/${bundle_name}"
+
+          echo "Downloading ${bundle_url} ..."
+          if ! curl -fsSL -L -o "${archive_path}" "${bundle_url}"; then
+            rm -f "${archive_path}"
+            return 1
+          fi
+
+          if [ "${ARCHIVE_EXT}" = ".zip" ]; then
+            unzip -q -o "${archive_path}" -d "${INSTALL_DIR}"
+          else
+            tar -xzf "${archive_path}" -C "${INSTALL_DIR}"
+          fi
+
+          rm -f "${archive_path}"
+          return 0
+        }
+
+        if ! download_bundle "$BUNDLE"; then
+          if [ -n "$FALLBACK_BUNDLE" ] && download_bundle "$FALLBACK_BUNDLE"; then
+            :
+          else
+            FILE="console2svg-${RID}${EXT}"
+            URL="${RELEASE_BASE_URL}/${FILE}"
+
+            echo "Falling back to legacy asset layout..."
+            echo "Downloading ${URL} ..."
+            curl -fsSL -L -o "${INSTALL_DIR}/console2svg${EXT}" "${URL}"
+
+            case "$RID" in
+              linux-*)
+                curl -fsSL -L -o "${INSTALL_DIR}/libresvg_wrapper.so" "${RELEASE_BASE_URL}/libresvg_wrapper-${RID}.so"
+                ;;
+              osx-*)
+                curl -fsSL -L -o "${INSTALL_DIR}/libresvg_wrapper.dylib" "${RELEASE_BASE_URL}/libresvg_wrapper-${RID}.dylib"
+                ;;
+              win-*)
+                if curl -fsSL -L -o "${INSTALL_DIR}/resvg_wrapper.dll" "${RELEASE_BASE_URL}/resvg_wrapper-${RID}.dll"; then
+                  :
+                fi
+                ;;
+            esac
+          fi
+        fi
+
         [ -z "${EXT}" ] && chmod +x "${INSTALL_DIR}/console2svg"
 
         echo "${INSTALL_DIR}" >> "$GITHUB_PATH"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env sh
+set -eu
+
+REPOSITORY="${REPOSITORY:-arika0093/console2svg}"
+VERSION="${VERSION:-latest}"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "install.sh: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+normalize_arch() {
+  case "$1" in
+    x86_64|amd64)
+      printf '%s' "x64"
+      ;;
+    aarch64|arm64)
+      printf '%s' "arm64"
+      ;;
+    *)
+      echo "install.sh: unsupported architecture: $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+uname_s="$(uname -s)"
+uname_m="$(uname -m)"
+arch="$(normalize_arch "$uname_m")"
+
+case "$uname_s" in
+  Linux)
+    rid="linux-${arch}"
+    archive_ext=".tar.gz"
+    runtime_name="libresvg_wrapper.so"
+    ;;
+  Darwin)
+    rid="osx-${arch}"
+    archive_ext=".tar.gz"
+    runtime_name="libresvg_wrapper.dylib"
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    rid="win-${arch}"
+    archive_ext=".zip"
+    runtime_name="resvg_wrapper.dll"
+    ;;
+  *)
+    echo "install.sh: unsupported platform: $uname_s" >&2
+    exit 1
+    ;;
+esac
+
+if [ "${INSTALL_DIR:-}" = "" ]; then
+  if [ "$archive_ext" = ".zip" ]; then
+    INSTALL_DIR="${HOME}/bin"
+  elif [ -w /usr/local/bin ]; then
+    INSTALL_DIR="/usr/local/bin"
+  else
+    INSTALL_DIR="${HOME}/.local/bin"
+  fi
+fi
+
+mkdir -p "$INSTALL_DIR"
+
+case "$VERSION" in
+  latest)
+    release_base_url="https://github.com/${REPOSITORY}/releases/latest/download"
+    ;;
+  v*)
+    release_base_url="https://github.com/${REPOSITORY}/releases/download/${VERSION}"
+    ;;
+  *)
+    release_base_url="https://github.com/${REPOSITORY}/releases/download/v${VERSION}"
+    ;;
+esac
+
+archive_name="console2svg-${rid}${archive_ext}"
+archive_url="${release_base_url}/${archive_name}"
+
+require_command curl
+if [ "$archive_ext" = ".zip" ]; then
+  require_command unzip
+else
+  require_command tar
+fi
+
+tmpdir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT INT TERM
+
+archive_path="${tmpdir}/${archive_name}"
+extract_dir="${tmpdir}/extract"
+mkdir -p "$extract_dir"
+
+echo "Installing ${archive_name} from ${archive_url}"
+curl -fsSL -o "$archive_path" "$archive_url"
+
+if [ "$archive_ext" = ".zip" ]; then
+  unzip -q "$archive_path" -d "$extract_dir"
+else
+  tar -xzf "$archive_path" -C "$extract_dir"
+fi
+
+binary_name="console2svg"
+if [ "$archive_ext" = ".zip" ]; then
+  binary_name="${binary_name}.exe"
+fi
+
+if [ ! -f "${extract_dir}/${binary_name}" ]; then
+  echo "install.sh: expected ${binary_name} in ${archive_name}" >&2
+  exit 1
+fi
+
+cp -f "${extract_dir}/${binary_name}" "${INSTALL_DIR}/${binary_name}"
+
+if [ -f "${extract_dir}/${runtime_name}" ]; then
+  cp -f "${extract_dir}/${runtime_name}" "${INSTALL_DIR}/${runtime_name}"
+fi
+
+if [ "$archive_ext" = ".zip" ]; then
+  if [ -f "${extract_dir}/ffmpeg.exe" ]; then
+    cp -f "${extract_dir}/ffmpeg.exe" "${INSTALL_DIR}/ffmpeg.exe"
+  fi
+  if [ -f "${extract_dir}/ffmpeg-LICENSE.txt" ]; then
+    cp -f "${extract_dir}/ffmpeg-LICENSE.txt" "${INSTALL_DIR}/ffmpeg-LICENSE.txt"
+  fi
+else
+  chmod 755 "${INSTALL_DIR}/${binary_name}"
+fi
+
+echo "Installed ${binary_name} to ${INSTALL_DIR}"
+case ":${PATH}:" in
+  *:"${INSTALL_DIR}":*)
+    ;;
+  *)
+    echo "Add ${INSTALL_DIR} to PATH if it is not already there." >&2
+    ;;
+esac

--- a/install.sh
+++ b/install.sh
@@ -34,17 +34,14 @@ case "$uname_s" in
   Linux)
     rid="linux-${arch}"
     archive_ext=".tar.gz"
-    runtime_name="libresvg_wrapper.so"
     ;;
   Darwin)
     rid="osx-${arch}"
     archive_ext=".tar.gz"
-    runtime_name="libresvg_wrapper.dylib"
     ;;
   MINGW*|MSYS*|CYGWIN*)
     rid="win-${arch}"
     archive_ext=".zip"
-    runtime_name="resvg_wrapper.dll"
     ;;
   *)
     echo "install.sh: unsupported platform: $uname_s" >&2
@@ -93,16 +90,14 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 archive_path="${tmpdir}/${archive_name}"
-extract_dir="${tmpdir}/extract"
-mkdir -p "$extract_dir"
 
 echo "Installing ${archive_name} from ${archive_url}"
 curl -fsSL -o "$archive_path" "$archive_url"
 
 if [ "$archive_ext" = ".zip" ]; then
-  unzip -q "$archive_path" -d "$extract_dir"
+  unzip -q -o "$archive_path" -d "$INSTALL_DIR"
 else
-  tar -xzf "$archive_path" -C "$extract_dir"
+  tar -xzf "$archive_path" -C "$INSTALL_DIR"
 fi
 
 binary_name="console2svg"
@@ -110,25 +105,12 @@ if [ "$archive_ext" = ".zip" ]; then
   binary_name="${binary_name}.exe"
 fi
 
-if [ ! -f "${extract_dir}/${binary_name}" ]; then
+if [ ! -f "${INSTALL_DIR}/${binary_name}" ]; then
   echo "install.sh: expected ${binary_name} in ${archive_name}" >&2
   exit 1
 fi
 
-cp -f "${extract_dir}/${binary_name}" "${INSTALL_DIR}/${binary_name}"
-
-if [ -f "${extract_dir}/${runtime_name}" ]; then
-  cp -f "${extract_dir}/${runtime_name}" "${INSTALL_DIR}/${runtime_name}"
-fi
-
-if [ "$archive_ext" = ".zip" ]; then
-  if [ -f "${extract_dir}/ffmpeg.exe" ]; then
-    cp -f "${extract_dir}/ffmpeg.exe" "${INSTALL_DIR}/ffmpeg.exe"
-  fi
-  if [ -f "${extract_dir}/ffmpeg-LICENSE.txt" ]; then
-    cp -f "${extract_dir}/ffmpeg-LICENSE.txt" "${INSTALL_DIR}/ffmpeg-LICENSE.txt"
-  fi
-else
+if [ "$archive_ext" != ".zip" ]; then
   chmod 755 "${INSTALL_DIR}/${binary_name}"
 fi
 

--- a/scripts/release-action/build-release-assets.sh
+++ b/scripts/release-action/build-release-assets.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${RELEASE_UPLOAD_DIR:?}"
+: "${NATIVE_ARTIFACTS_DIR:?}"
+: "${PACKAGE_VERSION:?}"
+: "${PACKAGE_ITERATION:?}"
+: "${GITHUB_REPOSITORY:?}"
+
+mkdir -p "$RELEASE_UPLOAD_DIR"
+release_upload_dir="$(cd "$RELEASE_UPLOAD_DIR" && pwd)"
+
+require_file() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    echo "Required file not found: $path" >&2
+    exit 1
+  fi
+}
+
+binary_name_for_rid() {
+  local rid="$1"
+  local tool_name="$2"
+
+  if [[ "$rid" == win-* ]]; then
+    printf '%s.exe' "$tool_name"
+  else
+    printf '%s' "$tool_name"
+  fi
+}
+
+archive_extension_for_rid() {
+  local rid="$1"
+
+  if [[ "$rid" == win-* ]]; then
+    printf '.zip'
+  else
+    printf '.tar.gz'
+  fi
+}
+
+native_runtime_name_for_rid() {
+  local rid="$1"
+
+  case "$rid" in
+    win-*)
+      printf '%s' "resvg_wrapper.dll"
+      ;;
+    linux-*)
+      printf '%s' "libresvg_wrapper.so"
+      ;;
+    osx-*)
+      printf '%s' "libresvg_wrapper.dylib"
+      ;;
+    *)
+      echo "Unsupported RID for native runtime lookup: $rid" >&2
+      exit 1
+      ;;
+  esac
+}
+
+console_binary_path() {
+  local rid="$1"
+  printf '%s/native-%s/%s' \
+    "$NATIVE_ARTIFACTS_DIR" \
+    "$rid" \
+    "$(binary_name_for_rid "$rid" console2svg)"
+}
+
+native_runtime_path() {
+  local rid="$1"
+  local runtime_name
+  runtime_name="$(native_runtime_name_for_rid "$rid")"
+
+  local candidate="${NATIVE_ARTIFACTS_DIR}/native-${rid}/${runtime_name}"
+  if [[ -f "$candidate" ]]; then
+    printf '%s' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+stage_native_runtime_if_available() {
+  local rid="$1"
+  local staging_dir="$2"
+  local runtime_src runtime_name
+
+  if ! runtime_src="$(native_runtime_path "$rid")"; then
+    return 1
+  fi
+
+  runtime_name="$(native_runtime_name_for_rid "$rid")"
+  cp "$runtime_src" "$staging_dir/$runtime_name"
+}
+
+create_standard_bundle() {
+  local rid="$1"
+  local console_src archive_ext archive_path bundle_dir
+
+  console_src="$(console_binary_path "$rid")"
+  require_file "$console_src"
+
+  archive_ext="$(archive_extension_for_rid "$rid")"
+  archive_path="${release_upload_dir}/console2svg-${rid}${archive_ext}"
+  bundle_dir="$(mktemp -d)"
+
+  cp "$console_src" "$bundle_dir/$(binary_name_for_rid "$rid" console2svg)"
+  if [[ "$rid" != win-* ]]; then
+    chmod 755 "$bundle_dir/$(binary_name_for_rid "$rid" console2svg)"
+  fi
+
+  if ! stage_native_runtime_if_available "$rid" "$bundle_dir"; then
+    echo "No ResvgSharp native runtime asset for $rid; bundle will contain console2svg only."
+  fi
+
+  if [[ "$archive_ext" == ".zip" ]]; then
+    (
+      cd "$bundle_dir"
+      zip -q -r "$archive_path" .
+    )
+  else
+    tar -czf "$archive_path" -C "$bundle_dir" .
+  fi
+
+  rm -rf "$bundle_dir"
+  echo "Created standard bundle: $archive_path"
+}
+
+build_linux_package() {
+  local rid="$1"
+  local console_src runtime_src asset_arch deb_arch rpm_arch
+  local -a common_args package_inputs
+
+  console_src="$(console_binary_path "$rid")"
+  require_file "$console_src"
+
+  case "$rid" in
+    linux-x64)
+      asset_arch="x64"
+      deb_arch="amd64"
+      rpm_arch="x86_64"
+      ;;
+    linux-arm64)
+      asset_arch="arm64"
+      deb_arch="arm64"
+      rpm_arch="aarch64"
+      ;;
+    *)
+      echo "Unsupported Linux RID for packaging: $rid" >&2
+      exit 1
+      ;;
+  esac
+
+  chmod 755 "$console_src"
+  common_args=(
+    -s dir
+    -n console2svg
+    -v "$PACKAGE_VERSION"
+    --iteration "$PACKAGE_ITERATION"
+    --license Apache-2.0
+    --url "https://github.com/${GITHUB_REPOSITORY}"
+    --description "Convert terminal output to SVG images."
+  )
+  package_inputs=("$console_src=/usr/local/bin/console2svg")
+
+  if runtime_src="$(native_runtime_path "$rid")"; then
+    package_inputs+=("$runtime_src=/usr/local/bin/$(native_runtime_name_for_rid "$rid")")
+  else
+    echo "No ResvgSharp native runtime asset for $rid; Linux package will include console2svg only."
+  fi
+
+  fpm "${common_args[@]}" \
+    -t deb \
+    -a "$deb_arch" \
+    -p "${release_upload_dir}/console2svg.${asset_arch}.deb" \
+    "${package_inputs[@]}"
+
+  fpm "${common_args[@]}" \
+    -t rpm \
+    -a "$rpm_arch" \
+    -p "${release_upload_dir}/console2svg.${asset_arch}.rpm" \
+    "${package_inputs[@]}"
+
+  echo "Created Linux packages for $rid"
+}
+
+build_windows_ffmpeg_bundle() {
+  local rid="$1"
+  local console_src runtime_src ffmpeg_zip_url temp_root ffmpeg_zip ffmpeg_extract
+  local top_dir ffmpeg_bin_dir bundle_dir archive_path
+
+  console_src="$(console_binary_path "$rid")"
+  require_file "$console_src"
+
+  if ! runtime_src="$(native_runtime_path "$rid")"; then
+    echo "No ResvgSharp native runtime asset for $rid; skipping Windows ffmpeg bundle."
+    return 0
+  fi
+
+  case "$rid" in
+    win-x64)
+      ffmpeg_zip_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-lgpl.zip"
+      ;;
+    win-arm64)
+      ffmpeg_zip_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-winarm64-lgpl.zip"
+      ;;
+    *)
+      echo "Unsupported Windows RID for ffmpeg bundle: $rid" >&2
+      exit 1
+      ;;
+  esac
+
+  archive_path="${release_upload_dir}/console2svg-${rid}-ffmpeg.zip"
+  temp_root="$(mktemp -d)"
+  ffmpeg_zip="${temp_root}/ffmpeg.zip"
+  ffmpeg_extract="${temp_root}/ffmpeg"
+  bundle_dir="${temp_root}/bundle"
+
+  curl -fsSL -o "$ffmpeg_zip" "$ffmpeg_zip_url"
+  unzip -q "$ffmpeg_zip" -d "$ffmpeg_extract"
+
+  top_dir="$(find "$ffmpeg_extract" -mindepth 1 -maxdepth 1 -type d | sort | head -n 1)"
+  if [[ -z "$top_dir" ]]; then
+    echo "Unable to determine extracted ffmpeg directory for $rid" >&2
+    exit 1
+  fi
+
+  ffmpeg_bin_dir="${top_dir}/bin"
+  require_file "${ffmpeg_bin_dir}/ffmpeg.exe"
+  require_file "${top_dir}/LICENSE.txt"
+
+  mkdir -p "$bundle_dir"
+  cp "$console_src" "$bundle_dir/console2svg.exe"
+  cp "$runtime_src" "$bundle_dir/resvg_wrapper.dll"
+  cp "${ffmpeg_bin_dir}/ffmpeg.exe" "$bundle_dir/ffmpeg.exe"
+  cp "${top_dir}/LICENSE.txt" "$bundle_dir/ffmpeg-LICENSE.txt"
+
+  (
+    cd "$bundle_dir"
+    zip -q -r "$archive_path" .
+  )
+
+  rm -rf "$temp_root"
+  echo "Created Windows ffmpeg bundle: $archive_path"
+}
+
+for rid in linux-x64 linux-arm64 win-x64 win-arm64 osx-x64 osx-arm64; do
+  if [[ -f "$(console_binary_path "$rid")" ]]; then
+    create_standard_bundle "$rid"
+  fi
+done
+
+for rid in linux-x64 linux-arm64; do
+  if [[ -f "$(console_binary_path "$rid")" ]]; then
+    build_linux_package "$rid"
+  fi
+done
+
+for rid in win-x64 win-arm64; do
+  if [[ -f "$(console_binary_path "$rid")" ]]; then
+    build_windows_ffmpeg_bundle "$rid"
+  fi
+done

--- a/scripts/release-action/build-release-assets.sh
+++ b/scripts/release-action/build-release-assets.sh
@@ -94,6 +94,52 @@ stage_native_runtime_if_available() {
   cp "$runtime_src" "$staging_dir/$runtime_name"
 }
 
+ffmpeg_bundle_url_for_windows_rid() {
+  local rid="$1"
+
+  case "$rid" in
+    win-x64)
+      printf '%s' "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-lgpl.zip"
+      ;;
+    win-arm64)
+      printf '%s' "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-winarm64-lgpl.zip"
+      ;;
+    *)
+      echo "Unsupported Windows RID for ffmpeg bundle: $rid" >&2
+      exit 1
+      ;;
+  esac
+}
+
+stage_windows_ffmpeg() {
+  local rid="$1"
+  local staging_dir="$2"
+  local ffmpeg_zip_url temp_root ffmpeg_zip ffmpeg_extract top_dir ffmpeg_bin_dir
+
+  ffmpeg_zip_url="$(ffmpeg_bundle_url_for_windows_rid "$rid")"
+  temp_root="$(mktemp -d)"
+  ffmpeg_zip="${temp_root}/ffmpeg.zip"
+  ffmpeg_extract="${temp_root}/ffmpeg"
+
+  curl -fsSL -o "$ffmpeg_zip" "$ffmpeg_zip_url"
+  unzip -q "$ffmpeg_zip" -d "$ffmpeg_extract"
+
+  top_dir="$(find "$ffmpeg_extract" -mindepth 1 -maxdepth 1 -type d | sort | head -n 1)"
+  if [[ -z "$top_dir" ]]; then
+    echo "Unable to determine extracted ffmpeg directory for $rid" >&2
+    exit 1
+  fi
+
+  ffmpeg_bin_dir="${top_dir}/bin"
+  require_file "${ffmpeg_bin_dir}/ffmpeg.exe"
+  require_file "${top_dir}/LICENSE.txt"
+
+  cp "${ffmpeg_bin_dir}/ffmpeg.exe" "$staging_dir/ffmpeg.exe"
+  cp "${top_dir}/LICENSE.txt" "$staging_dir/ffmpeg-LICENSE.txt"
+
+  rm -rf "$temp_root"
+}
+
 create_standard_bundle() {
   local rid="$1"
   local console_src archive_ext archive_path bundle_dir
@@ -111,7 +157,11 @@ create_standard_bundle() {
   fi
 
   if ! stage_native_runtime_if_available "$rid" "$bundle_dir"; then
-    echo "No ResvgSharp native runtime asset for $rid; bundle will contain console2svg only."
+    echo "No ResvgSharp native runtime asset for $rid; bundle will omit the native runtime sidecar."
+  fi
+
+  if [[ "$rid" == win-* ]]; then
+    stage_windows_ffmpeg "$rid" "$bundle_dir"
   fi
 
   if [[ "$archive_ext" == ".zip" ]]; then
@@ -185,66 +235,6 @@ build_linux_package() {
   echo "Created Linux packages for $rid"
 }
 
-build_windows_ffmpeg_bundle() {
-  local rid="$1"
-  local console_src runtime_src ffmpeg_zip_url temp_root ffmpeg_zip ffmpeg_extract
-  local top_dir ffmpeg_bin_dir bundle_dir archive_path
-
-  console_src="$(console_binary_path "$rid")"
-  require_file "$console_src"
-
-  if ! runtime_src="$(native_runtime_path "$rid")"; then
-    echo "No ResvgSharp native runtime asset for $rid; skipping Windows ffmpeg bundle."
-    return 0
-  fi
-
-  case "$rid" in
-    win-x64)
-      ffmpeg_zip_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-lgpl.zip"
-      ;;
-    win-arm64)
-      ffmpeg_zip_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-winarm64-lgpl.zip"
-      ;;
-    *)
-      echo "Unsupported Windows RID for ffmpeg bundle: $rid" >&2
-      exit 1
-      ;;
-  esac
-
-  archive_path="${release_upload_dir}/console2svg-${rid}-ffmpeg.zip"
-  temp_root="$(mktemp -d)"
-  ffmpeg_zip="${temp_root}/ffmpeg.zip"
-  ffmpeg_extract="${temp_root}/ffmpeg"
-  bundle_dir="${temp_root}/bundle"
-
-  curl -fsSL -o "$ffmpeg_zip" "$ffmpeg_zip_url"
-  unzip -q "$ffmpeg_zip" -d "$ffmpeg_extract"
-
-  top_dir="$(find "$ffmpeg_extract" -mindepth 1 -maxdepth 1 -type d | sort | head -n 1)"
-  if [[ -z "$top_dir" ]]; then
-    echo "Unable to determine extracted ffmpeg directory for $rid" >&2
-    exit 1
-  fi
-
-  ffmpeg_bin_dir="${top_dir}/bin"
-  require_file "${ffmpeg_bin_dir}/ffmpeg.exe"
-  require_file "${top_dir}/LICENSE.txt"
-
-  mkdir -p "$bundle_dir"
-  cp "$console_src" "$bundle_dir/console2svg.exe"
-  cp "$runtime_src" "$bundle_dir/resvg_wrapper.dll"
-  cp "${ffmpeg_bin_dir}/ffmpeg.exe" "$bundle_dir/ffmpeg.exe"
-  cp "${top_dir}/LICENSE.txt" "$bundle_dir/ffmpeg-LICENSE.txt"
-
-  (
-    cd "$bundle_dir"
-    zip -q -r "$archive_path" .
-  )
-
-  rm -rf "$temp_root"
-  echo "Created Windows ffmpeg bundle: $archive_path"
-}
-
 for rid in linux-x64 linux-arm64 win-x64 win-arm64 osx-x64 osx-arm64; do
   if [[ -f "$(console_binary_path "$rid")" ]]; then
     create_standard_bundle "$rid"
@@ -254,11 +244,5 @@ done
 for rid in linux-x64 linux-arm64; do
   if [[ -f "$(console_binary_path "$rid")" ]]; then
     build_linux_package "$rid"
-  fi
-done
-
-for rid in win-x64 win-arm64; do
-  if [[ -f "$(console_binary_path "$rid")" ]]; then
-    build_windows_ffmpeg_bundle "$rid"
   fi
 done

--- a/scripts/release-action/build-release-assets.sh
+++ b/scripts/release-action/build-release-assets.sh
@@ -39,59 +39,19 @@ archive_extension_for_rid() {
   fi
 }
 
-native_runtime_name_for_rid() {
+publish_dir_for_rid() {
   local rid="$1"
-
-  case "$rid" in
-    win-*)
-      printf '%s' "resvg_wrapper.dll"
-      ;;
-    linux-*)
-      printf '%s' "libresvg_wrapper.so"
-      ;;
-    osx-*)
-      printf '%s' "libresvg_wrapper.dylib"
-      ;;
-    *)
-      echo "Unsupported RID for native runtime lookup: $rid" >&2
-      exit 1
-      ;;
-  esac
+  local base_dir="${NATIVE_ARTIFACTS_DIR}/native-${rid}"
+  if [[ -d "${base_dir}/${rid}" ]]; then
+    printf '%s' "${base_dir}/${rid}"
+  else
+    printf '%s' "$base_dir"
+  fi
 }
 
 console_binary_path() {
   local rid="$1"
-  printf '%s/native-%s/%s' \
-    "$NATIVE_ARTIFACTS_DIR" \
-    "$rid" \
-    "$(binary_name_for_rid "$rid" console2svg)"
-}
-
-native_runtime_path() {
-  local rid="$1"
-  local runtime_name
-  runtime_name="$(native_runtime_name_for_rid "$rid")"
-
-  local candidate="${NATIVE_ARTIFACTS_DIR}/native-${rid}/${runtime_name}"
-  if [[ -f "$candidate" ]]; then
-    printf '%s' "$candidate"
-    return 0
-  fi
-
-  return 1
-}
-
-stage_native_runtime_if_available() {
-  local rid="$1"
-  local staging_dir="$2"
-  local runtime_src runtime_name
-
-  if ! runtime_src="$(native_runtime_path "$rid")"; then
-    return 1
-  fi
-
-  runtime_name="$(native_runtime_name_for_rid "$rid")"
-  cp "$runtime_src" "$staging_dir/$runtime_name"
+  printf '%s/%s' "$(publish_dir_for_rid "$rid")" "$(binary_name_for_rid "$rid" console2svg)"
 }
 
 ffmpeg_bundle_url_for_windows_rid() {
@@ -142,22 +102,20 @@ stage_windows_ffmpeg() {
 
 create_standard_bundle() {
   local rid="$1"
-  local console_src archive_ext archive_path bundle_dir
+  local publish_dir console_src archive_ext archive_path bundle_dir binary_name
 
+  publish_dir="$(publish_dir_for_rid "$rid")"
   console_src="$(console_binary_path "$rid")"
   require_file "$console_src"
 
   archive_ext="$(archive_extension_for_rid "$rid")"
   archive_path="${release_upload_dir}/console2svg-${rid}${archive_ext}"
   bundle_dir="$(mktemp -d)"
+  binary_name="$(binary_name_for_rid "$rid" console2svg)"
 
-  cp "$console_src" "$bundle_dir/$(binary_name_for_rid "$rid" console2svg)"
+  cp -a "${publish_dir}/." "$bundle_dir/"
   if [[ "$rid" != win-* ]]; then
-    chmod 755 "$bundle_dir/$(binary_name_for_rid "$rid" console2svg)"
-  fi
-
-  if ! stage_native_runtime_if_available "$rid" "$bundle_dir"; then
-    echo "No ResvgSharp native runtime asset for $rid; bundle will omit the native runtime sidecar."
+    chmod 755 "$bundle_dir/$binary_name"
   fi
 
   if [[ "$rid" == win-* ]]; then
@@ -179,9 +137,10 @@ create_standard_bundle() {
 
 build_linux_package() {
   local rid="$1"
-  local console_src runtime_src asset_arch deb_arch rpm_arch
+  local publish_dir console_src asset_arch deb_arch rpm_arch published_file
   local -a common_args package_inputs
 
+  publish_dir="$(publish_dir_for_rid "$rid")"
   console_src="$(console_binary_path "$rid")"
   require_file "$console_src"
 
@@ -212,12 +171,14 @@ build_linux_package() {
     --url "https://github.com/${GITHUB_REPOSITORY}"
     --description "Convert terminal output to SVG images."
   )
-  package_inputs=("$console_src=/usr/local/bin/console2svg")
+  package_inputs=()
+  while IFS= read -r published_file; do
+    package_inputs+=("$published_file=/usr/local/bin/$(basename "$published_file")")
+  done < <(find "$publish_dir" -maxdepth 1 -type f | sort)
 
-  if runtime_src="$(native_runtime_path "$rid")"; then
-    package_inputs+=("$runtime_src=/usr/local/bin/$(native_runtime_name_for_rid "$rid")")
-  else
-    echo "No ResvgSharp native runtime asset for $rid; Linux package will include console2svg only."
+  if [[ "${#package_inputs[@]}" -eq 0 ]]; then
+    echo "No published files found for $rid in $publish_dir" >&2
+    exit 1
   fi
 
   fpm "${common_args[@]}" \

--- a/src/ConsoleToSvg/AssemblyInfo.cs
+++ b/src/ConsoleToSvg/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ConsoleToSvg.Tests")]

--- a/src/ConsoleToSvg/Cli/OptionParser.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.cs
@@ -16,7 +16,8 @@ public static class OptionParser
 
             Major options:
                 -o, --out <path>          Output file path (default: output.svg).
-                                          Non-SVG extensions trigger ffmpeg conversion (e.g. output.png, output.mp4).
+                                          Non-SVG extensions trigger raster/video conversion
+                                          (e.g. output.png via ResvgSharp, output.mp4 via ffmpeg).
                 -w, --width <int|adjust>  Terminal width in characters (default: auto[pipe], 100[pty]).
                 -h, --height <int|adjust> Terminal height in rows (default: auto).
                 -v                        Output animated SVG (alias for --mode video).
@@ -45,9 +46,12 @@ public static class OptionParser
             Options (Common):
                 -o, --out <path>          Output file path (default: output.svg).
                                           Extension determines format:
-                                            .svg          – SVG output (default, no external tools required).
-                                            .png/.jpg/…   – Raster image via ffmpeg (ffmpeg must be installed).
-                                            .mp4/.webm/…  – Video via ffmpeg using frame sequences (ffmpeg must be installed).
+                                             .svg          – SVG output (default, no external tools required).
+                                             .png          – Raster image via built-in ResvgSharp renderer.
+                                             .jpg/.jpeg/…  – Direct ffmpeg SVG conversion when ffmpeg has --enable-librsvg,
+                                                             otherwise ResvgSharp -> PNG -> ffmpeg.
+                                             .mp4/.webm/…  – Video via ffmpeg; uses SVG frames when ffmpeg has --enable-librsvg,
+                                                             otherwise ResvgSharp-rendered PNG frames.
                 --stdout                  Write SVG to stdout instead of a file.
                                           PTY output forwarding is suppressed so the pipe receives only SVG.
                 -m, --mode <image|video|repeat>  Output mode (default: image).

--- a/src/ConsoleToSvg/ConsoleToSvg.csproj
+++ b/src/ConsoleToSvg/ConsoleToSvg.csproj
@@ -33,6 +33,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Quick.PtyNet" Version="1.0.4" />
+    <PackageReference Include="ResvgSharp" Version="1.0.3" />
     <PackageReference Include="ZLogger" Version="2.5.10" />
   </ItemGroup>
 </Project>

--- a/src/ConsoleToSvg/Conversion/OutputConverter.cs
+++ b/src/ConsoleToSvg/Conversion/OutputConverter.cs
@@ -140,6 +140,7 @@ internal static class OutputConverter
                         toolchain.FfmpegPath!,
                         svgPath,
                         outputPath,
+                        resourcesDirectory,
                         logger,
                         cancellationToken,
                         "Ensure ffmpeg supports SVG input or use the ResvgSharp fallback."
@@ -179,6 +180,7 @@ internal static class OutputConverter
                             toolchain.FfmpegPath!,
                             tempPng,
                             outputPath,
+                            workingDirectory: null,
                             logger,
                             cancellationToken
                         )
@@ -220,6 +222,7 @@ internal static class OutputConverter
                     fps,
                     outputPath,
                     GetVideoFrameExtension(ffmpegSupportsSvgInput: true),
+                    resourcesDirectory,
                     logger,
                     cancellationToken,
                     "Ensure ffmpeg supports SVG input or use the ResvgSharp fallback."
@@ -245,6 +248,7 @@ internal static class OutputConverter
                     fps,
                     outputPath,
                     GetVideoFrameExtension(ffmpegSupportsSvgInput: false),
+                    workingDirectory: null,
                     logger,
                     cancellationToken
                 )
@@ -342,6 +346,7 @@ internal static class OutputConverter
         string ffmpeg,
         string inputPath,
         string outputPath,
+        string? workingDirectory,
         ILogger logger,
         CancellationToken cancellationToken,
         string exitFailureMessage = "Ensure ffmpeg supports the requested output format."
@@ -349,6 +354,7 @@ internal static class OutputConverter
         RunFfmpegAsync(
             ffmpeg,
             ["-y", "-i", inputPath, "-frames:v", "1", "-update", "1", outputPath],
+            workingDirectory,
             logger,
             cancellationToken,
             exitFailureMessage
@@ -360,6 +366,7 @@ internal static class OutputConverter
         double fps,
         string outputPath,
         string frameExtension,
+        string? workingDirectory,
         ILogger logger,
         CancellationToken cancellationToken,
         string exitFailureMessage = "Ensure ffmpeg supports the requested output format."
@@ -370,6 +377,7 @@ internal static class OutputConverter
         return RunFfmpegAsync(
             ffmpeg,
             ["-y", "-framerate", fpsValue, "-i", framePattern, outputPath],
+            workingDirectory,
             logger,
             cancellationToken,
             exitFailureMessage
@@ -379,6 +387,7 @@ internal static class OutputConverter
     private static Task RunFfmpegAsync(
         string ffmpeg,
         string[] args,
+        string? workingDirectory,
         ILogger logger,
         CancellationToken cancellationToken,
         string exitFailureMessage
@@ -387,6 +396,7 @@ internal static class OutputConverter
             toolDisplayName: "ffmpeg",
             executablePath: ffmpeg,
             args,
+            workingDirectory,
             logger,
             cancellationToken,
             startFailureMessage:
@@ -488,6 +498,7 @@ internal static class OutputConverter
         string toolDisplayName,
         string executablePath,
         string[] args,
+        string? workingDirectory,
         ILogger logger,
         CancellationToken cancellationToken,
         string startFailureMessage,
@@ -499,6 +510,10 @@ internal static class OutputConverter
         using var process = new Process();
         process.StartInfo.FileName = executablePath;
         process.StartInfo.UseShellExecute = false;
+        if (!string.IsNullOrWhiteSpace(workingDirectory))
+        {
+            process.StartInfo.WorkingDirectory = workingDirectory;
+        }
         foreach (var arg in args)
         {
             process.StartInfo.ArgumentList.Add(arg);

--- a/src/ConsoleToSvg/Conversion/OutputConverter.cs
+++ b/src/ConsoleToSvg/Conversion/OutputConverter.cs
@@ -1,0 +1,576 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using ConsoleToSvg.Raster;
+using Microsoft.Extensions.Logging;
+using ZLogger;
+
+namespace ConsoleToSvg.Conversion;
+
+internal enum RasterConversionStrategy
+{
+    DirectSvgWithFfmpeg,
+    ResvgPngOnly,
+    ResvgThenFfmpeg,
+}
+
+internal sealed class ConversionToolchain
+{
+    internal ConversionToolchain(string? ffmpegPath, bool ffmpegSupportsSvgInput)
+    {
+        FfmpegPath = ffmpegPath;
+        FfmpegSupportsSvgInput = ffmpegSupportsSvgInput;
+    }
+
+    internal string? FfmpegPath { get; }
+
+    internal bool FfmpegSupportsSvgInput { get; }
+
+    internal bool HasFfmpeg => !string.IsNullOrWhiteSpace(FfmpegPath);
+}
+
+internal static class OutputConverter
+{
+    private static readonly HashSet<string> VideoExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "mp4", "webm", "avi", "mov", "mkv", "ogv", "flv", "ts", "wmv", "m4v", "gif",
+    };
+
+    private const string FfmpegInstallHint =
+        "Install ffmpeg with SVG input support (librsvg-enabled build), or use a standard ffmpeg build together with the bundled ResvgSharp runtime assets.";
+
+    internal static bool IsVideoFormat(string extension) => VideoExtensions.Contains(extension);
+
+    internal static string GetExecutableFileName(string toolName, bool isWindows) =>
+        isWindows ? $"{toolName}.exe" : toolName;
+
+    internal static string? TryResolveExecutable(string toolName)
+        => TryResolveExecutable(
+            toolName,
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            Environment.ProcessPath,
+            Environment.GetEnvironmentVariable("PATH")
+        );
+
+    internal static string? TryResolveExecutable(
+        string toolName,
+        bool isWindows,
+        string? processPath,
+        string? pathEnvironment
+    )
+    {
+        var fileName = GetExecutableFileName(toolName, isWindows);
+
+        var bundled = TryResolveDirectoryExecutable(fileName, Path.GetDirectoryName(processPath));
+        if (bundled is not null)
+        {
+            return bundled;
+        }
+
+        if (string.IsNullOrWhiteSpace(pathEnvironment))
+        {
+            return null;
+        }
+
+        foreach (var rawDirectory in pathEnvironment.Split(
+                     Path.PathSeparator,
+                     StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+                 ))
+        {
+            var directory = rawDirectory.Trim('"');
+            var candidate = TryResolveDirectoryExecutable(fileName, directory);
+            if (candidate is not null)
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    internal static bool HelpOutputEnablesLibrsvg(string helpOutput) =>
+        helpOutput.Contains("--enable-librsvg", StringComparison.Ordinal);
+
+    internal static RasterConversionStrategy GetRasterConversionStrategy(
+        string outputPath,
+        bool ffmpegSupportsSvgInput
+    )
+    {
+        var outputExtension = Path.GetExtension(outputPath).TrimStart('.').ToLowerInvariant();
+        if (outputExtension == "png")
+        {
+            return RasterConversionStrategy.ResvgPngOnly;
+        }
+
+        return ffmpegSupportsSvgInput
+            ? RasterConversionStrategy.DirectSvgWithFfmpeg
+            : RasterConversionStrategy.ResvgThenFfmpeg;
+    }
+
+    internal static string GetVideoFrameExtension(bool ffmpegSupportsSvgInput) =>
+        ffmpegSupportsSvgInput ? "svg" : "png";
+
+    internal static async Task ConvertSvgToRasterAsync(
+        string svgPath,
+        string outputPath,
+        string? resourcesDirectory,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        var toolchain = await DetectToolchainAsync(logger, cancellationToken).ConfigureAwait(false);
+        var strategy = GetRasterConversionStrategy(outputPath, toolchain.FfmpegSupportsSvgInput);
+
+        switch (strategy)
+        {
+            case RasterConversionStrategy.DirectSvgWithFfmpeg:
+                if (!toolchain.HasFfmpeg)
+                {
+                    throw new InvalidOperationException(BuildUnavailableToolsMessage(outputPath));
+                }
+
+                logger.ZLogDebug($"Raster output via ffmpeg SVG input. Out={outputPath}");
+                await RunFfmpegImageAsync(
+                        toolchain.FfmpegPath!,
+                        svgPath,
+                        outputPath,
+                        logger,
+                        cancellationToken,
+                        "Ensure ffmpeg supports SVG input or use the ResvgSharp fallback."
+                    )
+                    .ConfigureAwait(false);
+                return;
+
+            case RasterConversionStrategy.ResvgPngOnly:
+                logger.ZLogDebug($"Raster output via ResvgSharp PNG render. Out={outputPath}");
+                await RasterImageRenderer.WritePngFileAsync(
+                        svgPath,
+                        outputPath,
+                        resourcesDirectory,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+                return;
+
+            case RasterConversionStrategy.ResvgThenFfmpeg:
+                if (!toolchain.HasFfmpeg)
+                {
+                    throw new InvalidOperationException(BuildUnavailableToolsMessage(outputPath));
+                }
+
+                logger.ZLogDebug($"Raster output via ResvgSharp + ffmpeg. Out={outputPath}");
+                var tempPng = Path.Combine(Path.GetTempPath(), $"c2s-{Guid.NewGuid():N}.png");
+                try
+                {
+                    await RasterImageRenderer.WritePngFileAsync(
+                            svgPath,
+                            tempPng,
+                            resourcesDirectory,
+                            cancellationToken
+                        )
+                        .ConfigureAwait(false);
+                    await RunFfmpegImageAsync(
+                            toolchain.FfmpegPath!,
+                            tempPng,
+                            outputPath,
+                            logger,
+                            cancellationToken
+                        )
+                        .ConfigureAwait(false);
+                }
+                finally
+                {
+                    TryDeleteFile(tempPng, logger);
+                }
+
+                return;
+
+            default:
+                throw new InvalidOperationException($"Unexpected raster conversion strategy: {strategy}");
+        }
+    }
+
+    internal static async Task ConvertSvgFramesToVideoAsync(
+        string svgFramesDir,
+        double fps,
+        string outputPath,
+        string? resourcesDirectory,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        var toolchain = await DetectToolchainAsync(logger, cancellationToken).ConfigureAwait(false);
+        if (!toolchain.HasFfmpeg)
+        {
+            throw new InvalidOperationException(BuildUnavailableToolsMessage(outputPath));
+        }
+
+        if (toolchain.FfmpegSupportsSvgInput)
+        {
+            logger.ZLogDebug($"Video output via ffmpeg SVG input. Out={outputPath}");
+            await RunFfmpegVideoAsync(
+                    toolchain.FfmpegPath!,
+                    svgFramesDir,
+                    fps,
+                    outputPath,
+                    GetVideoFrameExtension(ffmpegSupportsSvgInput: true),
+                    logger,
+                    cancellationToken,
+                    "Ensure ffmpeg supports SVG input or use the ResvgSharp fallback."
+                )
+                .ConfigureAwait(false);
+            return;
+        }
+
+        logger.ZLogDebug($"Video output via ResvgSharp + ffmpeg. Out={outputPath}");
+        var pngFramesDir = Path.Combine(Path.GetTempPath(), $"c2s-{Guid.NewGuid():N}");
+        try
+        {
+            await ConvertSvgFramesToPngAsync(
+                    svgFramesDir,
+                    pngFramesDir,
+                    resourcesDirectory,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+            await RunFfmpegVideoAsync(
+                    toolchain.FfmpegPath!,
+                    pngFramesDir,
+                    fps,
+                    outputPath,
+                    GetVideoFrameExtension(ffmpegSupportsSvgInput: false),
+                    logger,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            TryDeleteDirectory(pngFramesDir, logger);
+        }
+    }
+
+    private static string? TryResolveDirectoryExecutable(string fileName, string? directory)
+    {
+        if (string.IsNullOrWhiteSpace(directory))
+        {
+            return null;
+        }
+
+        var candidate = Path.Combine(directory, fileName);
+        return File.Exists(candidate) ? Path.GetFullPath(candidate) : null;
+    }
+
+    private static async Task<ConversionToolchain> DetectToolchainAsync(
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        var ffmpegPath = TryResolveExecutable("ffmpeg");
+        var ffmpegSupportsSvgInput =
+            ffmpegPath is not null
+            && await ProbeFfmpegSvgInputSupportAsync(ffmpegPath, logger, cancellationToken)
+                .ConfigureAwait(false);
+
+        logger.ZLogDebug(
+            $"Toolchain detected. Ffmpeg={ffmpegPath ?? "(missing)"} FfmpegSvg={ffmpegSupportsSvgInput}"
+        );
+
+        return new ConversionToolchain(ffmpegPath, ffmpegSupportsSvgInput);
+    }
+
+    private static async Task<bool> ProbeFfmpegSvgInputSupportAsync(
+        string ffmpegPath,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            var helpOutput = await RunProcessForOutputAsync(
+                    toolDisplayName: "ffmpeg",
+                    executablePath: ffmpegPath,
+                    args: ["-h"],
+                    logger,
+                    cancellationToken,
+                    startFailureMessage:
+                        "Please ensure ffmpeg is installed (bundled with the application or available in PATH).",
+                    exitFailureMessage: "Failed to inspect ffmpeg build configuration."
+                )
+                .ConfigureAwait(false);
+
+            var supportsLibrsvg = HelpOutputEnablesLibrsvg(helpOutput);
+            logger.ZLogDebug(
+                $"ffmpeg SVG input support detected. Path={ffmpegPath} SupportsLibrsvg={supportsLibrsvg}"
+            );
+            return supportsLibrsvg;
+        }
+        catch (InvalidOperationException ex)
+        {
+            logger.ZLogDebug(
+                $"Failed to probe ffmpeg SVG input support. Path={ffmpegPath} Error={ex.Message}"
+            );
+            return false;
+        }
+    }
+
+    private static string BuildUnavailableToolsMessage(string outputPath)
+    {
+        var extension = Path.GetExtension(outputPath)?.ToLowerInvariant();
+        var extLabel = extension?.TrimStart('.').ToUpperInvariant() ?? string.Empty;
+
+        return extension switch
+        {
+            ".png" =>
+                $"Cannot generate {outputPath} because the built-in ResvgSharp renderer could not be used.",
+            ".jpg" or ".jpeg" or ".bmp" or ".gif" or ".webp" =>
+                $"Cannot generate {outputPath} because {extLabel} output requires ffmpeg. {FfmpegInstallHint}",
+            ".mp4" or ".mov" or ".webm" or ".mkv" or ".avi" =>
+                $"Cannot generate {outputPath} because video output requires ffmpeg. {FfmpegInstallHint}",
+            _ =>
+                $"Cannot generate {outputPath} because the required conversion toolchain is unavailable for the requested output format.",
+        };
+    }
+
+    private static Task RunFfmpegImageAsync(
+        string ffmpeg,
+        string inputPath,
+        string outputPath,
+        ILogger logger,
+        CancellationToken cancellationToken,
+        string exitFailureMessage = "Ensure ffmpeg supports the requested output format."
+    ) =>
+        RunFfmpegAsync(
+            ffmpeg,
+            ["-y", "-i", inputPath, "-frames:v", "1", "-update", "1", outputPath],
+            logger,
+            cancellationToken,
+            exitFailureMessage
+        );
+
+    private static Task RunFfmpegVideoAsync(
+        string ffmpeg,
+        string framesDir,
+        double fps,
+        string outputPath,
+        string frameExtension,
+        ILogger logger,
+        CancellationToken cancellationToken,
+        string exitFailureMessage = "Ensure ffmpeg supports the requested output format."
+    )
+    {
+        var framePattern = Path.Combine(framesDir, $"frame-%04d.{frameExtension}");
+        var fpsValue = fps.ToString(CultureInfo.InvariantCulture);
+        return RunFfmpegAsync(
+            ffmpeg,
+            ["-y", "-framerate", fpsValue, "-i", framePattern, outputPath],
+            logger,
+            cancellationToken,
+            exitFailureMessage
+        );
+    }
+
+    private static Task RunFfmpegAsync(
+        string ffmpeg,
+        string[] args,
+        ILogger logger,
+        CancellationToken cancellationToken,
+        string exitFailureMessage
+    ) =>
+        RunProcessAsync(
+            toolDisplayName: "ffmpeg",
+            executablePath: ffmpeg,
+            args,
+            logger,
+            cancellationToken,
+            startFailureMessage:
+                "Please ensure ffmpeg is installed (bundled with the application or available in PATH).",
+            exitFailureMessage
+        );
+
+    private static async Task ConvertSvgFramesToPngAsync(
+        string svgFramesDir,
+        string pngFramesDir,
+        string? resourcesDirectory,
+        CancellationToken cancellationToken
+    )
+    {
+        Directory.CreateDirectory(pngFramesDir);
+        foreach (var svgFramePath in Directory
+                     .EnumerateFiles(svgFramesDir, "frame-*.svg")
+                     .OrderBy(path => path, StringComparer.Ordinal))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var pngFramePath = Path.Combine(
+                pngFramesDir,
+                $"{Path.GetFileNameWithoutExtension(svgFramePath)}.png"
+            );
+            await RasterImageRenderer.WritePngFileAsync(
+                    svgFramePath,
+                    pngFramePath,
+                    resourcesDirectory,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+        }
+    }
+
+    private static async Task<string> RunProcessForOutputAsync(
+        string toolDisplayName,
+        string executablePath,
+        string[] args,
+        ILogger logger,
+        CancellationToken cancellationToken,
+        string startFailureMessage,
+        string exitFailureMessage
+    )
+    {
+        logger.ZLogDebug($"Running {toolDisplayName} for output: {executablePath} {string.Join(' ', args)}");
+
+        using var process = new Process();
+        process.StartInfo.FileName = executablePath;
+        process.StartInfo.UseShellExecute = false;
+        process.StartInfo.RedirectStandardOutput = true;
+        process.StartInfo.RedirectStandardError = true;
+        foreach (var arg in args)
+        {
+            process.StartInfo.ArgumentList.Add(arg);
+        }
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Failed to start {toolDisplayName}. {startFailureMessage}\n{ex.Message}",
+                ex
+            );
+        }
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+
+        using var killOnCancel = cancellationToken.Register(() =>
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // Process may have already exited.
+            }
+        });
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        var stdout = await stdoutTask.ConfigureAwait(false);
+        var stderr = await stderrTask.ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"{toolDisplayName} exited with code {process.ExitCode}. {exitFailureMessage}"
+            );
+        }
+
+        return $"{stdout}\n{stderr}";
+    }
+
+    private static async Task RunProcessAsync(
+        string toolDisplayName,
+        string executablePath,
+        string[] args,
+        ILogger logger,
+        CancellationToken cancellationToken,
+        string startFailureMessage,
+        string exitFailureMessage
+    )
+    {
+        logger.ZLogDebug($"Running {toolDisplayName}: {executablePath} {string.Join(' ', args)}");
+
+        using var process = new Process();
+        process.StartInfo.FileName = executablePath;
+        process.StartInfo.UseShellExecute = false;
+        foreach (var arg in args)
+        {
+            process.StartInfo.ArgumentList.Add(arg);
+        }
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Failed to start {toolDisplayName}. {startFailureMessage}\n{ex.Message}",
+                ex
+            );
+        }
+
+        using var killOnCancel = cancellationToken.Register(() =>
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // Process may have already exited.
+            }
+        });
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"{toolDisplayName} exited with code {process.ExitCode}. {exitFailureMessage}"
+            );
+        }
+
+        logger.ZLogDebug($"{toolDisplayName} completed successfully.");
+    }
+
+    private static void TryDeleteFile(string path, ILogger logger)
+    {
+        if (!File.Exists(path))
+        {
+            return;
+        }
+
+        try
+        {
+            File.Delete(path);
+        }
+        catch (Exception ex)
+        {
+            logger.ZLogDebug(ex, $"Failed to delete temp file {path}: {ex.Message}");
+        }
+    }
+
+    private static void TryDeleteDirectory(string path, ILogger logger)
+    {
+        if (!Directory.Exists(path))
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch (Exception ex)
+        {
+            logger.ZLogDebug(ex, $"Failed to delete temp dir {path}: {ex.Message}");
+        }
+    }
+}

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -1,13 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using ConsoleToSvg.Cli;
+using ConsoleToSvg.Conversion;
 using ConsoleToSvg.Recording;
 using ConsoleToSvg.Svg;
 using Microsoft.Extensions.Logging;
@@ -169,22 +168,23 @@ internal static class Program
                 {
                     // Route based on explicit --mode if given, otherwise infer from output extension.
                     // Explicit --mode image overrides video extensions (e.g. static GIF with --frame).
-                    // No explicit mode: video extensions → frame-sequence path, others → ffmpeg image.
+                    // No explicit mode: video extensions → frame-sequence path, others → raster image path.
                     var useVideoPath =
                         options.IsModeExplicit
                             ? options.Mode is OutputMode.Video or OutputMode.Repeat
-                            : IsVideoFormat(outputExt);
+                            : OutputConverter.IsVideoFormat(outputExt);
 
                     if (useVideoPath)
                     {
-                        // Video format: save frames to a temp dir, then invoke ffmpeg.
+                        // Video format: save SVG frames, then let OutputConverter decide whether
+                        // ffmpeg can consume them directly or needs a ResvgSharp PNG fallback.
                         var tempDir = Path.Combine(
                             Path.GetTempPath(),
                             $"c2s-{Guid.NewGuid():N}"
                         );
                         try
                         {
-                            logger.ZLogDebug($"Video output: saving frames to temp dir {tempDir}");
+                            logger.ZLogDebug($"Video output: saving SVG frames to temp dir {tempDir}");
                             var frameCount = await SaveFramesAsync(
                                     session,
                                     renderOptions,
@@ -199,12 +199,11 @@ internal static class Program
                             // so ffmpeg receives valid input (e.g. commands that exit without output).
                             if (frameCount == 0)
                             {
-                                var utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
                                 var fallbackSvg = SvgRenderer.Render(session, renderOptions);
                                 await File.WriteAllTextAsync(
                                         Path.Combine(tempDir, "frame-0000.svg"),
                                         fallbackSvg,
-                                        utf8,
+                                        new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
                                         outputToken
                                     )
                                     .ConfigureAwait(false);
@@ -212,10 +211,11 @@ internal static class Program
                             }
 
                             EnsureDirectory(options.OutputPath);
-                            await RunFfmpegVideoAsync(
+                            await OutputConverter.ConvertSvgFramesToVideoAsync(
                                     tempDir,
                                     options.VideoFps,
                                     options.OutputPath,
+                                    Environment.CurrentDirectory,
                                     logger,
                                     outputToken
                                 )
@@ -238,7 +238,8 @@ internal static class Program
                     }
                     else
                     {
-                        // Raster image (png, jpg, …): render a static SVG then convert via ffmpeg.
+                        // Raster image (png, jpg, …): render a static SVG, then let OutputConverter
+                        // pick the direct ffmpeg or ResvgSharp-based conversion path.
                         // Always use the static renderer regardless of --mode, so the output reflects
                         // the last terminal frame by default (or the --frame index if specified).
                         var staticSvg = SvgRenderer.Render(session, renderOptions);
@@ -257,9 +258,10 @@ internal static class Program
                                 )
                                 .ConfigureAwait(false);
                             EnsureDirectory(options.OutputPath);
-                            await RunFfmpegImageAsync(
+                            await OutputConverter.ConvertSvgToRasterAsync(
                                     tempSvg,
                                     options.OutputPath,
+                                    Environment.CurrentDirectory,
                                     logger,
                                     outputToken
                                 )
@@ -499,127 +501,6 @@ internal static class Program
         }
     }
 
-    // Video file extensions that are handled by the frame-sequence → ffmpeg path.
-    // GIF is included here because the primary use-case for terminal recordings is
-    // an animated GIF; users who want a static GIF can specify --mode image separately.
-    private static readonly HashSet<string> VideoExtensions = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "mp4", "webm", "avi", "mov", "mkv", "ogv", "flv", "ts", "wmv", "m4v", "gif",
-    };
-
-    private static bool IsVideoFormat(string extension) => VideoExtensions.Contains(extension);
-
-    /// <summary>
-    /// Finds the ffmpeg executable to use for format conversion.
-    /// Preference order: binary next to this executable (bundled), then PATH.
-    /// </summary>
-    private static string FindFfmpegExecutable()
-    {
-        var exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "ffmpeg.exe" : "ffmpeg";
-
-        // 1. Check next to this binary (covers the bundled Windows distribution and npm dist/ layout)
-        var exeDir = Path.GetDirectoryName(Environment.ProcessPath ?? string.Empty);
-        if (!string.IsNullOrEmpty(exeDir))
-        {
-            var bundled = Path.Combine(exeDir, exeName);
-            if (File.Exists(bundled))
-            {
-                return bundled;
-            }
-        }
-
-        // 2. Rely on PATH
-        return exeName;
-    }
-
-    /// <summary>Runs ffmpeg with the given arguments and throws if the process exits non-zero.</summary>
-    private static async Task RunFfmpegAsync(
-        string[] args,
-        ILogger logger,
-        CancellationToken cancellationToken
-    )
-    {
-        var ffmpeg = FindFfmpegExecutable();
-        logger.ZLogDebug($"Running ffmpeg: {ffmpeg} {string.Join(' ', args)}");
-
-        using var process = new Process();
-        process.StartInfo.FileName = ffmpeg;
-        process.StartInfo.UseShellExecute = false;
-        foreach (var arg in args)
-        {
-            process.StartInfo.ArgumentList.Add(arg);
-        }
-
-        try
-        {
-            process.Start();
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidOperationException(
-                $"Failed to start ffmpeg. Please ensure ffmpeg is installed "
-                + "(bundled with the application or available in PATH).\n"
-                + ex.Message,
-                ex
-            );
-        }
-
-        using var killOnCancel = cancellationToken.Register(() =>
-        {
-            try { process.Kill(entireProcessTree: true); }
-            catch { /* process may have already exited */ }
-        });
-
-        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-
-        if (process.ExitCode != 0)
-        {
-            throw new InvalidOperationException(
-                $"ffmpeg exited with code {process.ExitCode}. "
-                + "Ensure ffmpeg supports the requested output format."
-            );
-        }
-
-        logger.ZLogDebug($"ffmpeg completed successfully.");
-    }
-
-    /// <summary>Converts a directory of frame-NNNN.svg files into a video using ffmpeg.</summary>
-    private static async Task RunFfmpegVideoAsync(
-        string framesDir,
-        double fps,
-        string outputPath,
-        ILogger logger,
-        CancellationToken cancellationToken
-    )
-    {
-        var framePattern = Path.Combine(framesDir, "frame-%04d.svg");
-        var fpsStr = fps.ToString(CultureInfo.InvariantCulture);
-        await RunFfmpegAsync(
-                ["-y", "-framerate", fpsStr, "-i", framePattern, outputPath],
-                logger,
-                cancellationToken
-            )
-            .ConfigureAwait(false);
-    }
-
-    /// <summary>Converts a single SVG file to an image format using ffmpeg.</summary>
-    private static async Task RunFfmpegImageAsync(
-        string svgPath,
-        string outputPath,
-        ILogger logger,
-        CancellationToken cancellationToken
-    )
-    {
-        await RunFfmpegAsync(
-                // -frames:v 1 -update 1 ensure a single frame is written without
-                // the "image sequence pattern" warning from ffmpeg.
-                ["-y", "-i", svgPath, "-frames:v", "1", "-update", "1", outputPath],
-                logger,
-                cancellationToken
-            )
-            .ConfigureAwait(false);
-    }
-
     /// <returns>The number of frame files written to <paramref name="directory"/>.</returns>
     private static async Task<int> SaveFramesAsync(
         RecordingSession session,
@@ -629,11 +510,36 @@ internal static class Program
         ILogger logger,
         CancellationToken cancellationToken
     )
+        => await SaveFramesCoreAsync(
+                session,
+                baseOptions,
+                directory,
+                fps,
+                logger,
+                cancellationToken,
+                "svg",
+                static (framePath, frameSvg, token) =>
+                {
+                    var utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+                    return File.WriteAllTextAsync(framePath, frameSvg, utf8, token);
+                }
+            )
+            .ConfigureAwait(false);
+
+    private static async Task<int> SaveFramesCoreAsync(
+        RecordingSession session,
+        SvgRenderOptions baseOptions,
+        string directory,
+        double fps,
+        ILogger logger,
+        CancellationToken cancellationToken,
+        string extension,
+        Func<string, string, CancellationToken, Task> writeFrameAsync
+    )
     {
         Directory.CreateDirectory(directory);
-        var utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
         var eventCount = session.Events.Count;
-        logger.ZLogDebug($"Saving individual frames to {directory}. Events={eventCount} Fps={fps}");
+        logger.ZLogDebug($"Saving individual {extension.ToUpperInvariant()} frames to {directory}. Events={eventCount} Fps={fps}");
 
         if (fps > 0 && eventCount > 0)
         {
@@ -659,8 +565,8 @@ internal static class Program
 
                 baseOptions.Frame = eventIndex >= 0 ? eventIndex : 0;
                 var frameSvg = SvgRenderer.Render(session, baseOptions);
-                var framePath = Path.Combine(directory, $"frame-{f:D4}.svg");
-                await File.WriteAllTextAsync(framePath, frameSvg, utf8, cancellationToken)
+                var framePath = Path.Combine(directory, $"frame-{f:D4}.{extension}");
+                await writeFrameAsync(framePath, frameSvg, cancellationToken)
                     .ConfigureAwait(false);
             }
 
@@ -688,8 +594,8 @@ internal static class Program
                 }
 
                 previousSvg = frameSvg;
-                var framePath = Path.Combine(directory, $"frame-{savedCount:D4}.svg");
-                await File.WriteAllTextAsync(framePath, frameSvg, utf8, cancellationToken)
+                var framePath = Path.Combine(directory, $"frame-{savedCount:D4}.{extension}");
+                await writeFrameAsync(framePath, frameSvg, cancellationToken)
                     .ConfigureAwait(false);
                 savedCount++;
             }

--- a/src/ConsoleToSvg/Raster/RasterImageRenderer.cs
+++ b/src/ConsoleToSvg/Raster/RasterImageRenderer.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using ResvgSharp;
+
+namespace ConsoleToSvg.Raster;
+
+internal static class RasterImageRenderer
+{
+    internal static byte[] RenderPng(string svg, string? resourcesDirectory)
+    {
+        var options = new ResvgOptions
+        {
+            ExportAreaPage = true,
+            ExportAreaDrawing = false,
+            ResourcesDir = string.IsNullOrWhiteSpace(resourcesDirectory)
+                ? null
+                : Path.GetFullPath(resourcesDirectory),
+        };
+
+        try
+        {
+            return Resvg.RenderToPng(svg, options);
+        }
+        catch (DllNotFoundException ex)
+        {
+            throw CreateNativeLoadException(ex);
+        }
+        catch (BadImageFormatException ex)
+        {
+            throw CreateNativeLoadException(ex);
+        }
+    }
+
+    internal static async Task WritePngFileAsync(
+        string svgPath,
+        string pngPath,
+        string? resourcesDirectory,
+        CancellationToken cancellationToken
+    )
+    {
+        var effectiveResourcesDirectory =
+            string.IsNullOrWhiteSpace(resourcesDirectory)
+                ? Path.GetDirectoryName(Path.GetFullPath(svgPath))
+                : resourcesDirectory;
+
+        var svg = await File.ReadAllTextAsync(svgPath, cancellationToken).ConfigureAwait(false);
+        var pngBytes = RenderPng(svg, effectiveResourcesDirectory);
+        await File.WriteAllBytesAsync(pngPath, pngBytes, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static InvalidOperationException CreateNativeLoadException(Exception innerException)
+    {
+        return new InvalidOperationException(
+            $"Failed to load the ResvgSharp native library for {RuntimeInformation.OSDescription} ({RuntimeInformation.ProcessArchitecture}). "
+                + "Ensure the matching resvg_wrapper runtime asset is present in the build or publish output.",
+            innerException
+        );
+    }
+}

--- a/tests/ConsoleToSvg.Tests/Conversion/OutputConverterTests.cs
+++ b/tests/ConsoleToSvg.Tests/Conversion/OutputConverterTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.IO;
+using ConsoleToSvg.Conversion;
+
+namespace ConsoleToSvg.Tests.Conversion;
+
+public sealed class OutputConverterTests
+{
+    [Test]
+    public void GetExecutableFileName_AppendsExeOnWindows()
+    {
+        OutputConverter.GetExecutableFileName("resvg", isWindows: true).ShouldBe("resvg.exe");
+        OutputConverter.GetExecutableFileName("resvg", isWindows: false).ShouldBe("resvg");
+    }
+
+    [Test]
+    public void TryResolveExecutable_PrefersBundledBinaryOverPath()
+    {
+        var tempRoot = CreateTempDirectory();
+        try
+        {
+            var appDir = Path.Combine(tempRoot, "app");
+            var pathDir = Path.Combine(tempRoot, "path");
+            Directory.CreateDirectory(appDir);
+            Directory.CreateDirectory(pathDir);
+
+            var bundled = Path.Combine(appDir, "resvg");
+            var onPath = Path.Combine(pathDir, "resvg");
+            File.WriteAllText(bundled, string.Empty);
+            File.WriteAllText(onPath, string.Empty);
+
+            var resolved = OutputConverter.TryResolveExecutable(
+                "resvg",
+                isWindows: false,
+                processPath: Path.Combine(appDir, "console2svg"),
+                pathEnvironment: pathDir
+            );
+
+            resolved.ShouldBe(bundled);
+        }
+        finally
+        {
+            DeleteTempDirectory(tempRoot);
+        }
+    }
+
+    [Test]
+    public void TryResolveExecutable_IgnoresCurrentDirectoryAndChecksPath()
+    {
+        var tempRoot = CreateTempDirectory();
+        try
+        {
+            var currentDir = Path.Combine(tempRoot, "cwd");
+            var pathDir = Path.Combine(tempRoot, "path");
+            Directory.CreateDirectory(currentDir);
+            Directory.CreateDirectory(pathDir);
+
+            var fromCurrentDirectory = Path.Combine(currentDir, "ffmpeg.exe");
+            var onPath = Path.Combine(pathDir, "ffmpeg.exe");
+            File.WriteAllText(fromCurrentDirectory, string.Empty);
+            File.WriteAllText(onPath, string.Empty);
+
+            var resolved = OutputConverter.TryResolveExecutable(
+                "ffmpeg",
+                isWindows: true,
+                processPath: null,
+                pathEnvironment: pathDir
+            );
+
+            resolved.ShouldBe(onPath);
+        }
+        finally
+        {
+            DeleteTempDirectory(tempRoot);
+        }
+    }
+
+    [Test]
+    public void GetRasterConversionStrategy_SelectsExpectedPipelines()
+    {
+        OutputConverter.GetRasterConversionStrategy(
+                "output.png",
+                ffmpegSupportsSvgInput: true
+            )
+            .ShouldBe(RasterConversionStrategy.ResvgPngOnly);
+        OutputConverter.GetRasterConversionStrategy(
+                "output.png",
+                ffmpegSupportsSvgInput: false
+            )
+            .ShouldBe(RasterConversionStrategy.ResvgPngOnly);
+        OutputConverter.GetRasterConversionStrategy(
+                "output.jpg",
+                ffmpegSupportsSvgInput: true
+            )
+            .ShouldBe(RasterConversionStrategy.DirectSvgWithFfmpeg);
+        OutputConverter.GetRasterConversionStrategy(
+                "output.jpg",
+                ffmpegSupportsSvgInput: false
+            )
+            .ShouldBe(RasterConversionStrategy.ResvgThenFfmpeg);
+    }
+
+    [Test]
+    public void GetVideoFrameExtension_UsesSvgWhenDirectFfmpegIsAvailable()
+    {
+        OutputConverter.GetVideoFrameExtension(ffmpegSupportsSvgInput: true).ShouldBe("svg");
+        OutputConverter.GetVideoFrameExtension(ffmpegSupportsSvgInput: false).ShouldBe("png");
+    }
+
+    [Test]
+    public void HelpOutputEnablesLibrsvg_DetectsBuildFlag()
+    {
+        OutputConverter.HelpOutputEnablesLibrsvg("configuration: --enable-gpl --enable-librsvg")
+            .ShouldBeTrue();
+        OutputConverter.HelpOutputEnablesLibrsvg("configuration: --enable-gpl").ShouldBeFalse();
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"c2s-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void DeleteTempDirectory(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+}

--- a/tests/ConsoleToSvg.Tests/Raster/RasterImageOutputTests.cs
+++ b/tests/ConsoleToSvg.Tests/Raster/RasterImageOutputTests.cs
@@ -9,6 +9,17 @@ using ConsoleToSvg.Recording;
 
 namespace ConsoleToSvg.Tests.Raster;
 
+sealed class LinuxOnlyAttribute : SkipAttribute
+{
+    public LinuxOnlyAttribute()
+        : base("Requires Linux-specific ffmpeg shim behavior.")
+    {
+    }
+
+    public override Task<bool> ShouldSkip(TUnit.Core.TestRegisteredContext testContext) =>
+        Task.FromResult(!OperatingSystem.IsLinux());
+}
+
 [SuppressMessage("Interoperability", "CA1416", Justification = "These shell-script-based ffmpeg shim tests run in the Linux test environment.")]
 public sealed class RasterImageOutputTests
 {
@@ -50,6 +61,7 @@ public sealed class RasterImageOutputTests
     }
 
     [Test]
+    [LinuxOnly]
     public async Task JpegOutputUsesDirectSvgWhenFfmpegSupportsLibrsvg()
     {
         var tempDirectory = Directory.CreateTempSubdirectory("console2svg-raster-direct-");
@@ -88,6 +100,7 @@ public sealed class RasterImageOutputTests
     }
 
     [Test]
+    [LinuxOnly]
     public async Task JpegOutputUsesResvgFallbackWhenFfmpegLacksLibrsvg()
     {
         var tempDirectory = Directory.CreateTempSubdirectory("console2svg-raster-fallback-");
@@ -126,6 +139,7 @@ public sealed class RasterImageOutputTests
     }
 
     [Test]
+    [LinuxOnly]
     public async Task VideoOutputUsesSvgFramesWhenFfmpegSupportsLibrsvg()
     {
         var tempDirectory = Directory.CreateTempSubdirectory("console2svg-video-direct-");
@@ -165,6 +179,7 @@ public sealed class RasterImageOutputTests
     }
 
     [Test]
+    [LinuxOnly]
     public async Task VideoOutputUsesPngFramesWhenFfmpegLacksLibrsvg()
     {
         var tempDirectory = Directory.CreateTempSubdirectory("console2svg-video-fallback-");

--- a/tests/ConsoleToSvg.Tests/Raster/RasterImageOutputTests.cs
+++ b/tests/ConsoleToSvg.Tests/Raster/RasterImageOutputTests.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using ConsoleToSvg.Cli;
+using ConsoleToSvg.Recording;
+
+namespace ConsoleToSvg.Tests.Raster;
+
+[SuppressMessage("Interoperability", "CA1416", Justification = "These shell-script-based ffmpeg shim tests run in the Linux test environment.")]
+public sealed class RasterImageOutputTests
+{
+    private static readonly SemaphoreSlim EnvironmentLock = new(initialCount: 1, maxCount: 1);
+    private static readonly byte[] PngSignature = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+    [Test]
+    public async Task PngOutputDoesNotRequireFfmpeg()
+    {
+        var tempDirectory = Directory.CreateTempSubdirectory("console2svg-raster-");
+
+        try
+        {
+            var castPath = Path.Combine(tempDirectory.FullName, "input.cast");
+            var outputPath = Path.Combine(tempDirectory.FullName, "output.png");
+
+            var session = CreateSession();
+            await AsciicastWriter.WriteToFileAsync(castPath, session, CancellationToken.None);
+
+            var exitCode = await InvokeProgramWithPathAsync(
+                tempDirectory.FullName,
+                "--in",
+                castPath,
+                "--out",
+                outputPath
+            );
+
+            exitCode.ShouldBe(0);
+            File.Exists(outputPath).ShouldBeTrue();
+
+            var pngBytes = await File.ReadAllBytesAsync(outputPath);
+            pngBytes.Length.ShouldBeGreaterThanOrEqualTo(PngSignature.Length);
+            pngBytes.AsSpan(0, PngSignature.Length).SequenceEqual(PngSignature).ShouldBeTrue();
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task JpegOutputUsesDirectSvgWhenFfmpegSupportsLibrsvg()
+    {
+        var tempDirectory = Directory.CreateTempSubdirectory("console2svg-raster-direct-");
+
+        try
+        {
+            var castPath = Path.Combine(tempDirectory.FullName, "input.cast");
+            var outputPath = Path.Combine(tempDirectory.FullName, "output.jpg");
+            var argsLogPath = Path.Combine(tempDirectory.FullName, "ffmpeg.args");
+
+            await AsciicastWriter.WriteToFileAsync(castPath, CreateSession(), CancellationToken.None);
+            await CreateFakeFfmpegAsync(
+                Path.Combine(tempDirectory.FullName, "ffmpeg"),
+                argsLogPath,
+                supportsLibrsvg: true
+            );
+
+            var exitCode = await InvokeProgramWithPathAsync(
+                tempDirectory.FullName,
+                "--in",
+                castPath,
+                "--out",
+                outputPath
+            );
+
+            exitCode.ShouldBe(0);
+
+            var ffmpegArgs = await File.ReadAllTextAsync(argsLogPath);
+            ffmpegArgs.ShouldContain(".svg");
+            ffmpegArgs.ShouldNotContain(".png");
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task JpegOutputUsesResvgFallbackWhenFfmpegLacksLibrsvg()
+    {
+        var tempDirectory = Directory.CreateTempSubdirectory("console2svg-raster-fallback-");
+
+        try
+        {
+            var castPath = Path.Combine(tempDirectory.FullName, "input.cast");
+            var outputPath = Path.Combine(tempDirectory.FullName, "output.jpg");
+            var argsLogPath = Path.Combine(tempDirectory.FullName, "ffmpeg.args");
+
+            await AsciicastWriter.WriteToFileAsync(castPath, CreateSession(), CancellationToken.None);
+            await CreateFakeFfmpegAsync(
+                Path.Combine(tempDirectory.FullName, "ffmpeg"),
+                argsLogPath,
+                supportsLibrsvg: false
+            );
+
+            var exitCode = await InvokeProgramWithPathAsync(
+                tempDirectory.FullName,
+                "--in",
+                castPath,
+                "--out",
+                outputPath
+            );
+
+            exitCode.ShouldBe(0);
+
+            var ffmpegArgs = await File.ReadAllTextAsync(argsLogPath);
+            ffmpegArgs.ShouldContain(".png");
+            ffmpegArgs.ShouldNotContain(".svg");
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task VideoOutputUsesSvgFramesWhenFfmpegSupportsLibrsvg()
+    {
+        var tempDirectory = Directory.CreateTempSubdirectory("console2svg-video-direct-");
+
+        try
+        {
+            var castPath = Path.Combine(tempDirectory.FullName, "input.cast");
+            var outputPath = Path.Combine(tempDirectory.FullName, "output.mp4");
+            var argsLogPath = Path.Combine(tempDirectory.FullName, "ffmpeg.args");
+
+            await AsciicastWriter.WriteToFileAsync(castPath, CreateSession(), CancellationToken.None);
+            await CreateFakeFfmpegAsync(
+                Path.Combine(tempDirectory.FullName, "ffmpeg"),
+                argsLogPath,
+                supportsLibrsvg: true
+            );
+
+            var exitCode = await InvokeProgramWithPathAsync(
+                tempDirectory.FullName,
+                "-v",
+                "--in",
+                castPath,
+                "--out",
+                outputPath
+            );
+
+            exitCode.ShouldBe(0);
+
+            var ffmpegArgs = await File.ReadAllTextAsync(argsLogPath);
+            ffmpegArgs.ShouldContain("frame-%04d.svg");
+            ffmpegArgs.ShouldNotContain("frame-%04d.png");
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task VideoOutputUsesPngFramesWhenFfmpegLacksLibrsvg()
+    {
+        var tempDirectory = Directory.CreateTempSubdirectory("console2svg-video-fallback-");
+
+        try
+        {
+            var castPath = Path.Combine(tempDirectory.FullName, "input.cast");
+            var outputPath = Path.Combine(tempDirectory.FullName, "output.mp4");
+            var argsLogPath = Path.Combine(tempDirectory.FullName, "ffmpeg.args");
+
+            await AsciicastWriter.WriteToFileAsync(castPath, CreateSession(), CancellationToken.None);
+            await CreateFakeFfmpegAsync(
+                Path.Combine(tempDirectory.FullName, "ffmpeg"),
+                argsLogPath,
+                supportsLibrsvg: false
+            );
+
+            var exitCode = await InvokeProgramWithPathAsync(
+                tempDirectory.FullName,
+                "-v",
+                "--in",
+                castPath,
+                "--out",
+                outputPath
+            );
+
+            exitCode.ShouldBe(0);
+
+            var ffmpegArgs = await File.ReadAllTextAsync(argsLogPath);
+            ffmpegArgs.ShouldContain("frame-%04d.png");
+            ffmpegArgs.ShouldNotContain("frame-%04d.svg");
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    private static RecordingSession CreateSession()
+    {
+        var session = new RecordingSession(width: 8, height: 2);
+        session.AddEvent(0.01, "A");
+        session.AddEvent(0.10, "B");
+        return session;
+    }
+
+    private static async Task CreateFakeFfmpegAsync(
+        string ffmpegPath,
+        string argsLogPath,
+        bool supportsLibrsvg
+    )
+    {
+        var helpLine = supportsLibrsvg
+            ? "configuration: --enable-gpl --enable-librsvg"
+            : "configuration: --enable-gpl";
+
+        await File.WriteAllTextAsync(
+            ffmpegPath,
+            "#!/bin/bash\n"
+                + "if [ \"$1\" = \"-h\" ]; then\n"
+                + $"  echo '{helpLine}'\n"
+                + "  exit 0\n"
+                + "fi\n"
+                + $"printf '%s\\n' \"$@\" > \"{argsLogPath}\"\n"
+                + ": > \"${@: -1}\"\n",
+            CancellationToken.None
+        );
+
+        File.SetUnixFileMode(
+            ffmpegPath,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+        );
+    }
+
+    private static async Task<int> InvokeProgramWithPathAsync(string pathOverride, params string[] args)
+    {
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+        await EnvironmentLock.WaitAsync();
+        try
+        {
+            Environment.SetEnvironmentVariable("PATH", pathOverride);
+            return await InvokeProgramAsync(args);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+            EnvironmentLock.Release();
+        }
+    }
+
+    private static async Task<int> InvokeProgramAsync(params string[] args)
+    {
+        var programType = typeof(OptionParser).Assembly.GetType("ConsoleToSvg.Program")
+            ?? throw new InvalidOperationException("ConsoleToSvg.Program was not found.");
+        var mainMethod = programType.GetMethod(
+            "Main",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static
+        ) ?? throw new InvalidOperationException("ConsoleToSvg.Program.Main was not found.");
+
+        var task = (Task<int>?)mainMethod.Invoke(null, [args])
+            ?? throw new InvalidOperationException("ConsoleToSvg.Program.Main did not return Task<int>.");
+
+        return await task.ConfigureAwait(false);
+    }
+}

--- a/wrapper/npm/cli/install.js
+++ b/wrapper/npm/cli/install.js
@@ -41,8 +41,11 @@ if (platform === 'win32') {
 const isWin = platform === 'win32';
 const distDir = path.join(__dirname, '..', 'dist');
 const destPath = path.join(distDir, `console2svg${isWin ? '.exe' : ''}`);
+const nativeLibPath = isWin
+  ? null
+  : path.join(distDir, platform === 'linux' ? 'libresvg_wrapper.so' : 'libresvg_wrapper.dylib');
 
-if (fs.existsSync(destPath)) {
+if (fs.existsSync(destPath) && (isWin || fs.existsSync(nativeLibPath))) {
   process.exit(0);
 }
 
@@ -57,16 +60,19 @@ function fail(message, err) {
   process.exit(1);
 }
 
-function download(downloadUrl, redirects, onFinish) {
+function download(downloadUrl, tempPath, redirects, onFinish, onFailure) {
   if (redirects > 5) {
-    fail('console2svg: too many redirects while downloading.');
+    const err = new Error('console2svg: too many redirects while downloading.');
+    if (onFailure) {
+      onFailure(err);
+      return;
+    }
+    fail(err.message);
   }
 
   const proxy = getProxyForUrl(downloadUrl);
   const agent = proxy ? new HttpsProxyAgent(proxy) : undefined;
   const urlObj = new URL(downloadUrl);
-
-  const tempPath = `${destPath}.tmp`;
 
   const request = https.get(
     {
@@ -83,13 +89,18 @@ function download(downloadUrl, redirects, onFinish) {
     (res) => {
       if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
         res.resume();
-        download(res.headers.location, redirects + 1, onFinish);
+        download(res.headers.location, tempPath, redirects + 1, onFinish, onFailure);
         return;
       }
 
       if (res.statusCode !== 200) {
         res.resume();
-        fail(`console2svg: download failed (${res.statusCode}) from ${downloadUrl}`);
+        const err = new Error(`console2svg: download failed (${res.statusCode}) from ${downloadUrl}`);
+        if (onFailure) {
+          onFailure(err);
+          return;
+        }
+        fail(err.message);
       }
 
       const file = fs.createWriteStream(tempPath);
@@ -115,51 +126,137 @@ function download(downloadUrl, redirects, onFinish) {
   );
 
   request.on('error', (err) => {
+    if (onFailure) {
+      onFailure(err);
+      return;
+    }
     fail('console2svg: request failed.', err);
   });
 }
 
-if (isWin) {
-  // On Windows: download the ffmpeg bundle zip (console2svg.exe + ffmpeg.exe + DLLs)
-  const zipFileName = `console2svg-${rid}-ffmpeg.zip`;
-  const zipUrl = `https://github.com/arika0093/console2svg/releases/download/v${version}/${zipFileName}`;
+const releaseBaseUrl = `https://github.com/arika0093/console2svg/releases/download/v${version}`;
 
-  download(zipUrl, 0, (tempZipPath) => {
-    // Escape single quotes in paths for PowerShell single-quoted string literals.
-    const psEscape = (p) => p.replace(/'/g, "''");
-    // Extract the zip into distDir using PowerShell
-    const result = spawnSync(
-      'powershell',
-      [
-        '-NoProfile',
-        '-NonInteractive',
-        '-Command',
-        `Expand-Archive -LiteralPath '${psEscape(tempZipPath)}' -DestinationPath '${psEscape(distDir)}' -Force`
-      ],
-      { stdio: 'inherit' }
-    );
+function extractZip(tempZipPath) {
+  const psEscape = (p) => p.replace(/'/g, "''");
+  const result = spawnSync(
+    'powershell',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      `Expand-Archive -LiteralPath '${psEscape(tempZipPath)}' -DestinationPath '${psEscape(distDir)}' -Force`
+    ],
+    { stdio: 'inherit' }
+  );
 
-    try { fs.unlinkSync(tempZipPath); } catch { /* ignore */ }
+  try { fs.unlinkSync(tempZipPath); } catch { /* ignore */ }
 
-    if (result.status !== 0) {
-      fail('console2svg: failed to extract zip bundle.');
-    }
+  if (result.status !== 0) {
+    fail('console2svg: failed to extract zip bundle.');
+  }
+}
 
-    if (!fs.existsSync(destPath)) {
-      fail('console2svg: console2svg.exe not found after extraction.');
-    }
+function extractTarGz(tempArchivePath) {
+  const result = spawnSync(
+    'tar',
+    ['-xzf', tempArchivePath, '-C', distDir],
+    { stdio: 'inherit' }
+  );
 
-    process.exit(0);
-  });
-} else {
-  // On Linux/macOS: download the single binary
-  const fileName = `console2svg-${rid}`;
-  const url = `https://github.com/arika0093/console2svg/releases/download/v${version}/${fileName}`;
+  try { fs.unlinkSync(tempArchivePath); } catch { /* ignore */ }
 
-  download(url, 0, (tempPath) => {
-    fs.renameSync(tempPath, destPath);
+  if (result.status !== 0) {
+    fail('console2svg: failed to extract tar.gz bundle.');
+  }
+}
+
+function finishBundleInstall() {
+  if (!fs.existsSync(destPath)) {
+    fail(`console2svg: ${path.basename(destPath)} not found after extraction.`);
+  }
+
+  if (!isWin) {
     fs.chmodSync(destPath, 0o755);
-    process.exit(0);
+  }
+
+  process.exit(0);
+}
+
+function downloadBundle(bundleNames, extractArchive, onAllMissing) {
+  const tryNext = (index) => {
+    if (index >= bundleNames.length) {
+      onAllMissing();
+      return;
+    }
+
+    const bundleName = bundleNames[index];
+    const bundleUrl = `${releaseBaseUrl}/${bundleName}`;
+    const tempPath = path.join(distDir, `${bundleName}.tmp`);
+
+    download(
+      bundleUrl,
+      tempPath,
+      0,
+      (downloadedPath) => {
+        extractArchive(downloadedPath);
+        finishBundleInstall();
+      },
+      () => {
+        try { fs.unlinkSync(tempPath); } catch { /* ignore */ }
+        tryNext(index + 1);
+      }
+    );
+  };
+
+  tryNext(0);
+}
+
+function downloadLegacyAssets() {
+  const fileName = `console2svg-${rid}${isWin ? '.exe' : ''}`;
+  const url = `${releaseBaseUrl}/${fileName}`;
+
+  download(url, `${destPath}.tmp`, 0, (tempPath) => {
+    fs.renameSync(tempPath, destPath);
+    if (!isWin) {
+      fs.chmodSync(destPath, 0o755);
+    }
+
+    if (isWin) {
+      const dllName = `resvg_wrapper-${rid}.dll`;
+      download(
+        `${releaseBaseUrl}/${dllName}`,
+        path.join(distDir, `${dllName}.tmp`),
+        0,
+        (tempDllPath) => {
+          fs.renameSync(tempDllPath, path.join(distDir, 'resvg_wrapper.dll'));
+          process.exit(0);
+        },
+        () => process.exit(0)
+      );
+      return;
+    }
+
+    const nativeLibFileName =
+      platform === 'linux'
+        ? `libresvg_wrapper-${rid}.so`
+        : `libresvg_wrapper-${rid}.dylib`;
+    download(
+      `${releaseBaseUrl}/${nativeLibFileName}`,
+      `${nativeLibPath}.tmp`,
+      0,
+      (tempLibPath) => {
+        fs.renameSync(tempLibPath, nativeLibPath);
+        process.exit(0);
+      }
+    );
   });
 }
 
+if (isWin) {
+  const bundleNames = archSuffix === 'x64'
+    ? [`console2svg-${rid}-ffmpeg.zip`, `console2svg-${rid}.zip`]
+    : [`console2svg-${rid}.zip`];
+  downloadBundle(bundleNames, extractZip, downloadLegacyAssets);
+} else {
+  downloadBundle([`console2svg-${rid}.tar.gz`], extractTarGz, downloadLegacyAssets);
+}

--- a/wrapper/npm/cli/install.js
+++ b/wrapper/npm/cli/install.js
@@ -41,11 +41,13 @@ if (platform === 'win32') {
 const isWin = platform === 'win32';
 const distDir = path.join(__dirname, '..', 'dist');
 const destPath = path.join(distDir, `console2svg${isWin ? '.exe' : ''}`);
-const nativeLibPath = isWin
-  ? null
-  : path.join(distDir, platform === 'linux' ? 'libresvg_wrapper.so' : 'libresvg_wrapper.dylib');
+const nativeLibPath = path.join(
+  distDir,
+  isWin ? 'resvg_wrapper.dll' : platform === 'linux' ? 'libresvg_wrapper.so' : 'libresvg_wrapper.dylib'
+);
+const bundledFfmpegPath = isWin ? path.join(distDir, 'ffmpeg.exe') : null;
 
-if (fs.existsSync(destPath) && (isWin || fs.existsSync(nativeLibPath))) {
+if (fs.existsSync(destPath) && fs.existsSync(nativeLibPath)) {
   process.exit(0);
 }
 
@@ -175,6 +177,14 @@ function finishBundleInstall() {
     fail(`console2svg: ${path.basename(destPath)} not found after extraction.`);
   }
 
+  if (!fs.existsSync(nativeLibPath)) {
+    fail(`console2svg: ${path.basename(nativeLibPath)} not found after extraction.`);
+  }
+
+  if (isWin && !fs.existsSync(bundledFfmpegPath)) {
+    fail('console2svg: ffmpeg.exe not found after extraction.');
+  }
+
   if (!isWin) {
     fs.chmodSync(destPath, 0o755);
   }
@@ -231,7 +241,13 @@ function downloadLegacyAssets() {
           fs.renameSync(tempDllPath, path.join(distDir, 'resvg_wrapper.dll'));
           process.exit(0);
         },
-        () => process.exit(0)
+        () => {
+          console.error(
+            `console2svg: failed to download required Windows sidecar DLL: ${dllName}. ` +
+              'The install cannot complete because PNG output support would be unavailable.'
+          );
+          process.exit(1);
+        }
       );
       return;
     }

--- a/wrapper/npm/cli/install.js
+++ b/wrapper/npm/cli/install.js
@@ -253,10 +253,7 @@ function downloadLegacyAssets() {
 }
 
 if (isWin) {
-  const bundleNames = archSuffix === 'x64'
-    ? [`console2svg-${rid}-ffmpeg.zip`, `console2svg-${rid}.zip`]
-    : [`console2svg-${rid}.zip`];
-  downloadBundle(bundleNames, extractZip, downloadLegacyAssets);
+  downloadBundle([`console2svg-${rid}.zip`], extractZip, downloadLegacyAssets);
 } else {
   downloadBundle([`console2svg-${rid}.tar.gz`], extractTarGz, downloadLegacyAssets);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Built-in PNG rendering using the bundled native renderer (no ffmpeg required)
  * Support for JPEG/other raster and video outputs with automatic ffmpeg fallback
  * New installer script (install.sh) and archive-based release bundles (.zip on Windows, .tar.gz elsewhere)

* **Documentation**
  * Revised README with single-step installer guidance, updated Windows ffmpeg notes, and clearer output-format behavior and examples

* **Chores**
  * Release packaging moved to a dedicated release-assets build step producing archive bundles and platform packages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->