### PR TITLE
feat: add --time option for user-friendly image specification

### DIFF
--- a/src/ConsoleToSvg/Cli/AppOptions.cs
+++ b/src/ConsoleToSvg/Cli/AppOptions.cs
@@ -42,6 +42,15 @@ public sealed class AppOptions
 
     public int? Frame { get; set; }
 
+    /// <summary>Single time point in seconds (mutually exclusive with --frame).</summary>
+    public double? Time { get; set; }
+
+    /// <summary>Range start in seconds (used with --time 1.5-3.0).</summary>
+    public double? TimeStart { get; set; }
+
+    /// <summary>Range end in seconds (used with --time 1.5-3.0).</summary>
+    public double? TimeEnd { get; set; }
+
     public string CropTop { get; set; } = "0";
 
     public string CropRight { get; set; } = "0";

--- a/src/ConsoleToSvg/Cli/OptionParser.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.cs
@@ -95,6 +95,9 @@ public static class OptionParser
 
             Options (Image mode):
                 --frame <int>             Frame index for image mode.
+                --time <sec>              Time in seconds for image mode (e.g. --time 3.5).
+                                          Alternatively, a range: --time 1.5-3.0 (works with --save-frames and --video).
+                                          Mutually exclusive with --frame.
                 --size <WxH>              Output image pixel dimensions. Formats:
                                             800         – width only (height scaled proportionally).
                                             800x*       – width only (height scaled proportionally).
@@ -428,6 +431,57 @@ public static class OptionParser
                 }
 
                 options.Frame = frame;
+                return true;
+            case "--time":
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    error = "--time requires a value.";
+                    return false;
+                }
+
+                // Range: 1.5-3.0
+                var dashIndex = value.IndexOf('-');
+                if (dashIndex > 0 && dashIndex < value.Length - 1)
+                {
+                    var startPart = value[..dashIndex];
+                    var endPart = value[(dashIndex + 1)..];
+                    if (
+                        !TryParseDouble(startPart, "--time", out var timeStart, out error)
+                        || !TryParseDouble(endPart, "--time", out var timeEnd, out error)
+                    )
+                    {
+                        return false;
+                    }
+
+                    if (timeStart < 0 || timeEnd < 0)
+                    {
+                        error = "--time values must be non-negative.";
+                        return false;
+                    }
+
+                    if (timeEnd < timeStart)
+                    {
+                        error = "--time range end must be greater than or equal to start.";
+                        return false;
+                    }
+
+                    options.TimeStart = timeStart;
+                    options.TimeEnd = timeEnd;
+                    return true;
+                }
+
+                if (!TryParseDouble(value, "--time", out var timeVal, out error))
+                {
+                    return false;
+                }
+
+                if (timeVal < 0)
+                {
+                    error = "--time must be non-negative.";
+                    return false;
+                }
+
+                options.Time = timeVal;
                 return true;
             case "--crop-top":
                 options.CropTop = value ?? "0";
@@ -866,6 +920,26 @@ public static class OptionParser
         if (options.Frame is < 0)
         {
             error = "--frame must be non-negative.";
+            return false;
+        }
+
+        var hasTimeSingle = options.Time.HasValue;
+        var hasTimeRange = options.TimeStart.HasValue || options.TimeEnd.HasValue;
+        if (hasTimeSingle && hasTimeRange)
+        {
+            error = "--time cannot specify both a single value and a range.";
+            return false;
+        }
+
+        if ((hasTimeSingle || hasTimeRange) && options.Frame.HasValue)
+        {
+            error = "--time and --frame are mutually exclusive.";
+            return false;
+        }
+
+        if (hasTimeRange && (!options.TimeStart.HasValue || !options.TimeEnd.HasValue))
+        {
+            error = "--time range requires both start and end (e.g. --time 1.5-3.0).";
             return false;
         }
 

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -652,9 +652,13 @@ internal static class Program
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var t = f * interval;
-                if (t < rangeStart - 1e-9 || t > rangeEnd + 1e-9)
+                if (t < rangeStart - 1e-9)
                 {
                     continue;
+                }
+                if (t > rangeEnd + 1e-9)
+                {
+                    break;
                 }
 
                 // Find the last event index at or before time t
@@ -698,7 +702,7 @@ internal static class Program
                 }
                 if (baseOptions.TimeEnd.HasValue && eventTime > baseOptions.TimeEnd.Value + 1e-9)
                 {
-                    continue;
+                    break;
                 }
 
                 baseOptions.Frame = i;

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -642,11 +642,21 @@ internal static class Program
             var totalFrames = (int)Math.Floor(totalTime * fps) + 1;
             var interval = 1.0 / fps;
 
+            // When a time range is specified, skip frames outside [TimeStart, TimeEnd].
+            var rangeStart = baseOptions.TimeStart ?? 0.0;
+            var rangeEnd = baseOptions.TimeEnd ?? totalTime;
+
+            var savedCount = 0;
             for (var f = 0; f < totalFrames; f++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var t = f * interval;
+                if (t < rangeStart - 1e-9 || t > rangeEnd + 1e-9)
+                {
+                    continue;
+                }
+
                 // Find the last event index at or before time t
                 var eventIndex = -1;
                 for (var i = 0; i < eventCount; i++)
@@ -659,15 +669,16 @@ internal static class Program
 
                 baseOptions.Frame = eventIndex >= 0 ? eventIndex : 0;
                 var frameSvg = SvgRenderer.Render(session, baseOptions);
-                var framePath = Path.Combine(directory, $"frame-{f:D4}.svg");
+                var framePath = Path.Combine(directory, $"frame-{savedCount:D4}.svg");
                 await File.WriteAllTextAsync(framePath, frameSvg, utf8, cancellationToken)
                     .ConfigureAwait(false);
+                savedCount++;
             }
 
             baseOptions.Frame = null;
-            logger.ZLogDebug($"Saved {totalFrames} frames to {directory}");
-            await Console.Error.WriteLineAsync($"Saved {totalFrames} frames to {directory}");
-            return totalFrames;
+            logger.ZLogDebug($"Saved {savedCount} frames to {directory}");
+            await Console.Error.WriteLineAsync($"Saved {savedCount} frames to {directory}");
+            return savedCount;
         }
         else
         {
@@ -678,6 +689,17 @@ internal static class Program
             for (var i = 0; i < eventCount; i++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+
+                // Skip frames outside the time range if specified.
+                var eventTime = session.Events[i].Time;
+                if (baseOptions.TimeStart.HasValue && eventTime < baseOptions.TimeStart.Value - 1e-9)
+                {
+                    continue;
+                }
+                if (baseOptions.TimeEnd.HasValue && eventTime > baseOptions.TimeEnd.Value + 1e-9)
+                {
+                    continue;
+                }
 
                 baseOptions.Frame = i;
                 var frameSvg = SvgRenderer.Render(session, baseOptions);

--- a/src/ConsoleToSvg/Svg/AnimatedSvgRenderer.cs
+++ b/src/ConsoleToSvg/Svg/AnimatedSvgRenderer.cs
@@ -30,6 +30,28 @@ public static class AnimatedSvgRenderer
         var reducedFrames = ReduceFrames(frames, options.VideoFps);
         reducedFrames = SpreadCollapsedFrameTimes(reducedFrames, options.VideoFps);
 
+        // Filter frames by time range when --time is specified in video mode.
+        if (options.TimeStart.HasValue || options.TimeEnd.HasValue)
+        {
+            var rangeStart = options.TimeStart ?? double.MinValue;
+            var rangeEnd = options.TimeEnd ?? double.MaxValue;
+            var filtered = new System.Collections.Generic.List<TerminalFrame>(reducedFrames.Count);
+            foreach (var f in reducedFrames)
+            {
+                if (f.Time >= rangeStart - 1e-9 && f.Time <= rangeEnd + 1e-9)
+                {
+                    filtered.Add(f);
+                }
+            }
+
+            if (filtered.Count == 0)
+            {
+                return SvgRenderer.Render(session, options);
+            }
+
+            reducedFrames = filtered;
+        }
+
         // Build a dedup map: visual-hash → index of the first reduced frame with that hash.
         // Frames that are visually identical (e.g. in a looping animation) will share a single
         // <defs> entry and be referenced via <use>, dramatically reducing file size.

--- a/src/ConsoleToSvg/Svg/AnimatedSvgRenderer.cs
+++ b/src/ConsoleToSvg/Svg/AnimatedSvgRenderer.cs
@@ -36,11 +36,39 @@ public static class AnimatedSvgRenderer
             var rangeStart = options.TimeStart ?? double.MinValue;
             var rangeEnd = options.TimeEnd ?? double.MaxValue;
             var filtered = new System.Collections.Generic.List<TerminalFrame>(reducedFrames.Count);
+
+            // Keep track of the last frame before rangeStart so the clip
+            // starts with the terminal state visible at rangeStart.
+            TerminalFrame? lastBeforeRange = null;
+
             foreach (var f in reducedFrames)
             {
-                if (f.Time >= rangeStart - 1e-9 && f.Time <= rangeEnd + 1e-9)
+                if (f.Time < rangeStart - 1e-9)
+                {
+                    lastBeforeRange = f;
+                }
+                else if (f.Time >= rangeStart - 1e-9 && f.Time <= rangeEnd + 1e-9)
                 {
                     filtered.Add(f);
+                }
+                // Frames after rangeEnd are skipped (times are monotonically increasing)
+            }
+
+            // Prepend the last frame before rangeStart so the clip shows the
+            // correct terminal state at the start of the time window.
+            if (lastBeforeRange is not null)
+            {
+                filtered.Insert(0, lastBeforeRange);
+            }
+
+            // Rebase timestamps so the clip starts at t=0 instead of the
+            // original absolute time (e.g., --time 5-6 → clip from 0 to 1s).
+            if (filtered.Count > 0)
+            {
+                var baseTime = filtered[0].Time;
+                for (var i = 0; i < filtered.Count; i++)
+                {
+                    filtered[i] = new TerminalFrame(filtered[i].Time - baseTime, filtered[i].Buffer);
                 }
             }
 

--- a/src/ConsoleToSvg/Svg/SvgRenderOptions.cs
+++ b/src/ConsoleToSvg/Svg/SvgRenderOptions.cs
@@ -11,6 +11,15 @@ public sealed class SvgRenderOptions
 
     public int? Frame { get; set; }
 
+    /// <summary>Single time point in seconds; converted to frame index internally.</summary>
+    public double? Time { get; set; }
+
+    /// <summary>Range start in seconds for filtering frames in video/save-frames mode.</summary>
+    public double? TimeStart { get; set; }
+
+    /// <summary>Range end in seconds for filtering frames in video/save-frames mode.</summary>
+    public double? TimeEnd { get; set; }
+
     public string? Font { get; set; }
 
     public double FontSize { get; set; } = 14d;
@@ -98,6 +107,9 @@ public sealed class SvgRenderOptions
                 appOptions.CropLeft
             ),
             Frame = appOptions.Frame,
+            Time = appOptions.Time,
+            TimeStart = appOptions.TimeStart,
+            TimeEnd = appOptions.TimeEnd,
             Font = appOptions.Font,
             FontSize = appOptions.FontSize ?? 14d,
             Chrome = chrome,

--- a/src/ConsoleToSvg/Svg/SvgRenderer.cs
+++ b/src/ConsoleToSvg/Svg/SvgRenderer.cs
@@ -31,7 +31,7 @@ public static class SvgRenderer
         }
 
         var commandHeaderRows = string.IsNullOrEmpty(options.CommandHeader) ? 0 : 1;
-        var includeScrollback = options.Frame == null;
+        var includeScrollback = effectiveFrame == null;
         var context = SvgRenderShared.CreateContext(
             emulator.Buffer,
             options,
@@ -115,7 +115,7 @@ public static class SvgRenderer
         var events = session.Events;
         if (events.Count == 0)
         {
-            return 0;
+            return -1;
         }
 
         if (timeSeconds <= events[0].Time)
@@ -163,8 +163,6 @@ public static class SvgRenderer
             return lo;
         }
 
-        var diffAfter = Math.Abs(events[lo].Time - timeSeconds);
-        var diffBefore = Math.Abs(events[hi].Time - timeSeconds);
-        return diffBefore <= diffAfter ? hi : lo;
+        return hi;
     }
 }

--- a/src/ConsoleToSvg/Svg/SvgRenderer.cs
+++ b/src/ConsoleToSvg/Svg/SvgRenderer.cs
@@ -1,3 +1,4 @@
+using System;
 using ConsoleToSvg.Recording;
 using ConsoleToSvg.Terminal;
 using ConsoleToSvg.Utils;
@@ -10,8 +11,16 @@ public static class SvgRenderer
     {
         var theme = SvgRenderShared.ResolveTheme(options);
         var emulator = new TerminalEmulator(session.Header.width, session.Header.height, theme);
+
+        // If --time is specified, convert to a frame index using binary search.
+        int? effectiveFrame = options.Frame;
+        if (!effectiveFrame.HasValue && options.Time.HasValue)
+        {
+            effectiveFrame = TimeToFrameIndex(session, options.Time.Value);
+        }
+
         var targetFrame =
-            options.Frame
+            effectiveFrame
             ?? ResolveDefaultTargetFrame(
                 session,
                 new TerminalEmulator(session.Header.width, session.Header.height, theme)
@@ -96,4 +105,66 @@ public static class SvgRenderer
     }
 
     // Blank/trailing-frame detection moved to SvgRenderShared.
+
+    /// <summary>
+    /// Finds the index of the event whose timestamp is closest to the requested time.
+    /// Uses binary search for efficiency.
+    /// </summary>
+    public static int TimeToFrameIndex(RecordingSession session, double timeSeconds)
+    {
+        var events = session.Events;
+        if (events.Count == 0)
+        {
+            return 0;
+        }
+
+        if (timeSeconds <= events[0].Time)
+        {
+            return 0;
+        }
+
+        var lastIndex = events.Count - 1;
+        if (timeSeconds >= events[lastIndex].Time)
+        {
+            return lastIndex;
+        }
+
+        // Binary search for the closest event time.
+        var lo = 0;
+        var hi = lastIndex;
+        while (lo <= hi)
+        {
+            var mid = lo + (hi - lo) / 2;
+            var midTime = events[mid].Time;
+            if (Math.Abs(midTime - timeSeconds) < 1e-9)
+            {
+                return mid;
+            }
+
+            if (midTime < timeSeconds)
+            {
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid - 1;
+            }
+        }
+
+        // lo points to the first event after the requested time; hi points to the last event before it.
+        // Pick whichever is closer.
+        if (lo >= events.Count)
+        {
+            return hi;
+        }
+
+        if (hi < 0)
+        {
+            return lo;
+        }
+
+        var diffAfter = Math.Abs(events[lo].Time - timeSeconds);
+        var diffBefore = Math.Abs(events[hi].Time - timeSeconds);
+        return diffBefore <= diffAfter ? hi : lo;
+    }
 }


### PR DESCRIPTION
## Implements #68

Adds `--time` option to specify frames by seconds instead of frame index:

- `--time 3.5`: Retrieve image at 3.5 seconds
- `--time 1.5-3.0`: Generate images in the range 1.5–3.0 seconds (works with `--save-frames` and `--video`)
- `--time` and `--frame` are mutually exclusive

The time-to-frame conversion uses binary search over the recording session event timestamps.

Fixes #68

🤖 Generated with [Copilot](https://github.com/features/copilot)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added time-based rendering with `--time <seconds>`.
  * Supports selecting a single point in time or a start-to-end time range.
  * Added nearest-frame selection when rendering at a specified time.
  * Frame export now supports filtering output to a specified time range.

* **Bug Fixes**
  * Improved exported frame numbering and counts when time filtering is applied.
  * Added validation for invalid ranges, negative values, missing endpoints, and conflicts with `--frame`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->