### PR TITLE
feat: add fallback for ffmpeg without librsvg support

### DIFF
--- a/src/ConsoleToSvg/Cli/AppOptions.cs
+++ b/src/ConsoleToSvg/Cli/AppOptions.cs
@@ -1,3 +1,6 @@
+using System;
+using ConsoleToSvg.Svg;
+
 namespace ConsoleToSvg.Cli;
 
 public enum OutputMode
@@ -15,7 +18,7 @@ public enum VideoTimingMode
 
 public sealed class AppOptions
 {
-    public bool Verbose { get; set; }
+        public bool Verbose { get; set; }
 
     public string? VerboseLogPath { get; set; }
 
@@ -118,4 +121,10 @@ public sealed class AppOptions
 
     /// <summary>Target output image height in pixels. null = auto (derived from content).</summary>
     public double? SizeHeight { get; set; }
+
+    /// <summary>
+    /// Which SVG → raster converter to use. Default: <see cref="SvgConverterMode.Auto"/>,
+    /// which prefers ffmpeg+librsvg, then rsvg-convert, then ResvgSharp.
+    /// </summary>
+    public SvgConverterMode SvgConverter { get; set; } = SvgConverterMode.Auto;
 }

--- a/src/ConsoleToSvg/Cli/OptionParser.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using ConsoleToSvg.Svg;
 
 namespace ConsoleToSvg.Cli;
 
@@ -118,6 +119,15 @@ public static class OptionParser
                                           Video timing mode (default: deterministic).
                                           deterministic: normalize frame times to reduce output diffs.
                                           realtime: preserve measured event timing as-is.
+
+            Options (Conversion):
+                --svg-converter <auto|ffmpeg|rsvg-convert|resvg>
+                                          SVG → raster converter (default: auto).
+                                          auto: prefer ffmpeg+librsvg, then rsvg-convert, then ResvgSharp.
+                                          ffmpeg: force ffmpeg (requires librsvg input device).
+                                          rsvg-convert: force the rsvg-convert CLI tool (librsvg2-bin / brew install librsvg).
+                                          resvg: force the managed ResvgSharp library.
+                                          When a fallback handles SVG→PNG, ffmpeg is only used for subsequent format conversion.
             """;
 
     public static bool TryParse(
@@ -663,10 +673,58 @@ public static class OptionParser
                 options.SizeWidth = sizeWidth;
                 options.SizeHeight = sizeHeight;
                 return true;
+            case "--svg-converter":
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    error = $"{name} requires a value.";
+                    return false;
+                }
+                if (!TryParseSvgConverterMode(value, out var svgConverter, out error))
+                {
+                    return false;
+                }
+                options.SvgConverter = svgConverter;
+                return true;
             default:
                 error = $"Unknown option: {name}";
                 return false;
         }
+    }
+
+    private static bool TryParseSvgConverterMode(
+        string value,
+        out SvgConverterMode mode,
+        out string? error
+    )
+    {
+        error = null;
+        if (string.Equals(value, "auto", StringComparison.OrdinalIgnoreCase))
+        {
+            mode = SvgConverterMode.Auto;
+            return true;
+        }
+        if (string.Equals(value, "ffmpeg", StringComparison.OrdinalIgnoreCase))
+        {
+            mode = SvgConverterMode.Ffmpeg;
+            return true;
+        }
+        if (
+            string.Equals(value, "rsvg-convert", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, "rsvg", StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            mode = SvgConverterMode.RsvgConvert;
+            return true;
+        }
+        if (string.Equals(value, "resvg", StringComparison.OrdinalIgnoreCase))
+        {
+            mode = SvgConverterMode.Resvg;
+            return true;
+        }
+        mode = SvgConverterMode.Auto;
+        error =
+            "--svg-converter must be auto, ffmpeg, rsvg-convert, or resvg.";
+        return false;
     }
 
     private static bool TryParseInt(

--- a/src/ConsoleToSvg/ConsoleToSvg.csproj
+++ b/src/ConsoleToSvg/ConsoleToSvg.csproj
@@ -33,6 +33,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Quick.PtyNet" Version="1.0.4" />
+    <PackageReference Include="ResvgSharp" Version="1.0.3" />
     <PackageReference Include="ZLogger" Version="2.5.10" />
   </ItemGroup>
 </Project>

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -182,6 +182,7 @@ internal static class Program
                     // unconditionally (it is simply unused when a fallback converter
                     // produces PNG directly).
                     var ffmpegPath = FindFfmpegExecutable();
+                    SvgConverter.SetFfmpegPath(ffmpegPath);
                     var converter = SvgConverter.ResolveConverter(
                         options.SvgConverter,
                         ffmpegAvailableOverride: true,

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -68,7 +68,7 @@ internal static class Program
             $"Verbose={options.Verbose} VerboseLogPath={options.VerboseLogPath ?? "(default)"} Args={string.Join(' ', args)}"
         );
         logger.ZLogDebug(
-            $"Parsed options: Mode={options.Mode} Out={options.OutputPath} In={options.InputCastPath ?? ""} Command={options.Command ?? ""} Width={options.Width} Height={options.Height} Frame={options.Frame} Theme={options.Theme} ForeColor={options.ForeColor ?? ""} Window={options.Window} Padding={options.Padding} SaveCast={options.SaveCastPath ?? ""} Font={options.Font ?? ""} LengthAdjust={options.LengthAdjust} Prompt={options.Prompt} Header={options.Header ?? ""} NoColorEnv={options.NoColorEnv} NoDeleteEnvs={options.NoDeleteEnvs} VideoTiming={options.VideoTiming} CoalesceMs={options.OutputCoalesceMs}"
+            $"Parsed options: Mode={options.Mode} Out={options.OutputPath} In={options.InputCastPath ?? ""} Command={options.Command ?? ""} Width={options.Width} Height={options.Height} Frame={options.Frame} Theme={options.Theme} ForeColor={options.ForeColor ?? ""} Window={options.Window} Padding={options.Padding} SaveCast={options.SaveCastPath ?? ""} Font={options.Font ?? ""} LengthAdjust={options.LengthAdjust} Prompt={options.Prompt} Header={options.Header ?? ""} NoColorEnv={options.NoColorEnv} NoDeleteEnvs={options.NoDeleteEnvs} VideoTiming={options.VideoTiming} CoalesceMs={options.OutputCoalesceMs} SvgConverter={options.SvgConverter}"
         );
         using var environmentScope = ApplyProcessEnvironmentOverrides(options, logger);
 
@@ -175,6 +175,22 @@ internal static class Program
                             ? options.Mode is OutputMode.Video or OutputMode.Repeat
                             : IsVideoFormat(outputExt);
 
+                    // Resolve the SVG → raster converter once. This detects whether
+                    // ffmpeg has librsvg support and falls back to rsvg-convert /
+                    // ResvgSharp as needed. FfmpegPath is still needed for the PNG →
+                    // final-format step in the fallback pipeline, so we resolve it
+                    // unconditionally (it is simply unused when a fallback converter
+                    // produces PNG directly).
+                    var ffmpegPath = FindFfmpegExecutable();
+                    var converter = SvgConverter.ResolveConverter(
+                        options.SvgConverter,
+                        ffmpegAvailableOverride: true,
+                        logger
+                    );
+                    logger.ZLogDebug(
+                        $"Resolved converter: {converter} FfmpegPath={ffmpegPath}"
+                    );
+
                     if (useVideoPath)
                     {
                         // Video format: save frames to a temp dir, then invoke ffmpeg.
@@ -212,10 +228,14 @@ internal static class Program
                             }
 
                             EnsureDirectory(options.OutputPath);
-                            await RunFfmpegVideoAsync(
+                            await SvgConverter.ConvertFramesToVideoAsync(
                                     tempDir,
                                     options.VideoFps,
                                     options.OutputPath,
+                                    converter,
+                                    ffmpegPath,
+                                    options.SizeWidth,
+                                    options.SizeHeight,
                                     logger,
                                     outputToken
                                 )
@@ -257,9 +277,13 @@ internal static class Program
                                 )
                                 .ConfigureAwait(false);
                             EnsureDirectory(options.OutputPath);
-                            await RunFfmpegImageAsync(
+                            await SvgConverter.ConvertSvgToImageAsync(
                                     tempSvg,
                                     options.OutputPath,
+                                    converter,
+                                    ffmpegPath,
+                                    options.SizeWidth,
+                                    options.SizeHeight,
                                     logger,
                                     outputToken
                                 )
@@ -530,94 +554,6 @@ internal static class Program
 
         // 2. Rely on PATH
         return exeName;
-    }
-
-    /// <summary>Runs ffmpeg with the given arguments and throws if the process exits non-zero.</summary>
-    private static async Task RunFfmpegAsync(
-        string[] args,
-        ILogger logger,
-        CancellationToken cancellationToken
-    )
-    {
-        var ffmpeg = FindFfmpegExecutable();
-        logger.ZLogDebug($"Running ffmpeg: {ffmpeg} {string.Join(' ', args)}");
-
-        using var process = new Process();
-        process.StartInfo.FileName = ffmpeg;
-        process.StartInfo.UseShellExecute = false;
-        foreach (var arg in args)
-        {
-            process.StartInfo.ArgumentList.Add(arg);
-        }
-
-        try
-        {
-            process.Start();
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidOperationException(
-                $"Failed to start ffmpeg. Please ensure ffmpeg is installed "
-                + "(bundled with the application or available in PATH).\n"
-                + ex.Message,
-                ex
-            );
-        }
-
-        using var killOnCancel = cancellationToken.Register(() =>
-        {
-            try { process.Kill(entireProcessTree: true); }
-            catch { /* process may have already exited */ }
-        });
-
-        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-
-        if (process.ExitCode != 0)
-        {
-            throw new InvalidOperationException(
-                $"ffmpeg exited with code {process.ExitCode}. "
-                + "Ensure ffmpeg supports the requested output format."
-            );
-        }
-
-        logger.ZLogDebug($"ffmpeg completed successfully.");
-    }
-
-    /// <summary>Converts a directory of frame-NNNN.svg files into a video using ffmpeg.</summary>
-    private static async Task RunFfmpegVideoAsync(
-        string framesDir,
-        double fps,
-        string outputPath,
-        ILogger logger,
-        CancellationToken cancellationToken
-    )
-    {
-        var framePattern = Path.Combine(framesDir, "frame-%04d.svg");
-        var fpsStr = fps.ToString(CultureInfo.InvariantCulture);
-        await RunFfmpegAsync(
-                ["-y", "-framerate", fpsStr, "-i", framePattern, outputPath],
-                logger,
-                cancellationToken
-            )
-            .ConfigureAwait(false);
-    }
-
-    /// <summary>Converts a single SVG file to an image format using ffmpeg.</summary>
-    private static async Task RunFfmpegImageAsync(
-        string svgPath,
-        string outputPath,
-        ILogger logger,
-        CancellationToken cancellationToken
-    )
-    {
-        await RunFfmpegAsync(
-                // -frames:v 1 -update 1 ensure a single frame is written without
-                // the "image sequence pattern" warning from ffmpeg.
-                ["-y", "-i", svgPath, "-frames:v", "1", "-update", "1", outputPath],
-                logger,
-                cancellationToken
-            )
-            .ConfigureAwait(false);
     }
 
     /// <returns>The number of frame files written to <paramref name="directory"/>.</returns>

--- a/src/ConsoleToSvg/Svg/SvgConverter.cs
+++ b/src/ConsoleToSvg/Svg/SvgConverter.cs
@@ -1,0 +1,730 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ResvgSharp;
+using ZLogger;
+
+namespace ConsoleToSvg.Svg;
+
+/// <summary>Selection mode for the SVG → raster converter.</summary>
+public enum SvgConverterMode
+{
+    /// <summary>Auto-detect: prefer ffmpeg+librsvg, then rsvg-convert, then ResvgSharp.</summary>
+    Auto,
+
+    /// <summary>Force ffmpeg (requires librsvg). Fails if ffmpeg can't read SVG.</summary>
+    Ffmpeg,
+
+    /// <summary>Force the rsvg-convert CLI tool.</summary>
+    RsvgConvert,
+
+    /// <summary>Force the managed ResvgSharp library.</summary>
+    Resvg,
+}
+
+/// <summary>
+/// Handles detection of available SVG-to-PNG converters and performs the
+/// SVG → raster pipeline, falling back from ffmpeg (librsvg) to rsvg-convert
+/// or ResvgSharp when ffmpeg cannot read SVG directly. See issue #43.
+/// </summary>
+internal static class SvgConverter
+{
+    // Reuse ffmpeg discovery from Program. We pass the ffmpeg path in to avoid
+    // duplicating logic; detection helpers here only need to know whether the
+    // binary exists and what it supports.
+
+    private static readonly Lazy<bool> _rsvgConvertAvailable = new(
+        () => !string.IsNullOrEmpty(FindRsvgConvertExecutable())
+    );
+
+    private static readonly Lazy<bool> _resvgAvailable = new(DetectResvg);
+
+    private static readonly Lazy<bool> _ffmpegAvailable = new(
+        () => !string.IsNullOrEmpty(FindExecutable(
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "ffmpeg.exe" : "ffmpeg"
+        ))
+    );
+
+    // Cached so we don't shell out to `ffmpeg -formats` on every call.
+    private static readonly Lazy<bool> _ffmpegSupportsSvg = new(CheckFfmpegSvgSupport);
+
+    /// <summary>
+    /// Resolves the converter to use given the user's preference and the
+    /// local environment. Throws <see cref="InvalidOperationException"/> when
+    /// the forced converter is unavailable.
+    /// </summary>
+    public static SvgConverterMode ResolveConverter(SvgConverterMode wanted, bool ffmpegAvailableOverride, ILogger logger)
+    {
+        if (wanted == SvgConverterMode.Ffmpeg)
+        {
+            if (!ffmpegAvailableOverride && !_ffmpegAvailable.Value)
+            {
+                throw new InvalidOperationException(
+                    "--svg-converter ffmpeg was requested but ffmpeg is not installed or not on PATH."
+                );
+            }
+            if (!_ffmpegSupportsSvg.Value)
+            {
+                logger.ZLogDebug(
+                    $"ffmpeg forced but lacks librsvg; SVG input will likely fail."
+                );
+            }
+            return SvgConverterMode.Ffmpeg;
+        }
+
+        if (wanted == SvgConverterMode.RsvgConvert)
+        {
+            if (!_rsvgConvertAvailable.Value)
+            {
+                throw new InvalidOperationException(
+                    "--svg-converter rsvg-convert was requested but rsvg-convert is not installed "
+                    + "(install 'librsvg2-bin' on Debian/Ubuntu or 'librsvg' via Homebrew)."
+                );
+            }
+            return SvgConverterMode.RsvgConvert;
+        }
+
+        if (wanted == SvgConverterMode.Resvg)
+        {
+            if (!_resvgAvailable.Value)
+            {
+                throw new InvalidOperationException(
+                    "--svg-converter resvg was requested but the ResvgSharp native library is not available."
+                );
+            }
+            return SvgConverterMode.Resvg;
+        }
+
+        // Auto: prefer ffmpeg+librsvg, then rsvg-convert, then ResvgSharp.
+        // When ffmpeg is present but lacks SVG support, prefer the fallback
+        // converters so that PNG output works (ffmpeg can still be used for
+        // PNG → JPG/MP4 onwards).
+        if (_ffmpegAvailable.Value && _ffmpegSupportsSvg.Value)
+        {
+            logger.ZLogDebug($"Auto-selected ffmpeg (librsvg) for SVG conversion.");
+            return SvgConverterMode.Ffmpeg;
+        }
+
+        if (_rsvgConvertAvailable.Value)
+        {
+            logger.ZLogDebug($"Auto-selected rsvg-convert for SVG conversion.");
+            return SvgConverterMode.RsvgConvert;
+        }
+
+        if (_resvgAvailable.Value)
+        {
+            logger.ZLogDebug($"Auto-selected ResvgSharp for SVG conversion.");
+            return SvgConverterMode.Resvg;
+        }
+
+        // Last resort: ffmpeg is available but can't read SVG. We still return
+        // Ffmpeg so that the call surfaces a clear error, instead of silently
+        // doing nothing.
+        if (_ffmpegAvailable.Value)
+        {
+            logger.ZLogDebug(
+                $"No SVG-capable fallback found; falling through to ffmpeg (will likely fail)."
+            );
+            return SvgConverterMode.Ffmpeg;
+        }
+
+        throw new InvalidOperationException(
+            "No SVG-to-PNG converter available. Install ffmpeg (with librsvg), "
+            + "rsvg-convert ('librsvg2-bin' / 'brew install librsvg'), or build "
+            + "with the ResvgSharp native runtime."
+        );
+    }
+
+    /// <summary>
+    /// Converts a single SVG file to a raster image (png/jpg/…).
+    /// When a fallback converter is used, SVG → PNG is rendered first, then
+    /// ffmpeg (if needed) takes PNG → final format.
+    /// </summary>
+    public static async Task ConvertSvgToImageAsync(
+        string svgPath,
+        string outputPath,
+        SvgConverterMode converter,
+        string ffmpegPath,
+        double? width,
+        double? height,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        var outputExt = Path.GetExtension(outputPath)
+            .TrimStart('.')
+            .ToLowerInvariant();
+        var isPng = string.Equals(outputExt, "png", StringComparison.Ordinal);
+
+        // When ffmpeg (librsvg) handles SVG, just delegate to the legacy path.
+        if (converter == SvgConverterMode.Ffmpeg)
+        {
+            await RunFfmpegAsync(
+                    ffmpegPath,
+                    ["-y", "-i", svgPath, "-frames:v", "1", "-update", "1", outputPath],
+                    logger,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+            return;
+        }
+
+        // Fallback path: SVG → PNG → (optionally) final format.
+        // Render to a temp PNG, then pipe to ffmpeg if the target isn't PNG.
+        var tempPng = isPng
+            ? outputPath
+            : Path.Combine(
+                Path.GetTempPath(),
+                $"c2s-{Guid.NewGuid():N}.png"
+            );
+
+        try
+        {
+            await ConvertSvgToPngAsync(
+                    svgPath,
+                    tempPng,
+                    converter,
+                    width,
+                    height,
+                    logger,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
+            if (isPng)
+            {
+                // PNG output: ffmpeg not needed.
+                logger.ZLogDebug($"PNG written via fallback converter: {tempPng}");
+                return;
+            }
+
+            // PNG → final format via ffmpeg. -frames:v 1 -update 1 avoid the
+            // "image sequence pattern" warning for single-frame outputs.
+            await RunFfmpegAsync(
+                    ffmpegPath,
+                    ["-y", "-i", tempPng, "-frames:v", "1", "-update", "1", outputPath],
+                    logger,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            if (!isPng && File.Exists(tempPng))
+            {
+                try { File.Delete(tempPng); }
+                catch (Exception ex)
+                {
+                    logger.ZLogDebug(ex, $"Failed to delete temp PNG {tempPng}: {ex.Message}");
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Converts a directory of <c>frame-NNNN.svg</c> files into a video.
+    /// When ffmpeg can't read SVG, frames are first transcoded to PNG via
+    /// the fallback converter, then ffmpeg reads the PNG sequence.
+    /// </summary>
+    public static async Task ConvertFramesToVideoAsync(
+        string framesDir,
+        double fps,
+        string outputPath,
+        SvgConverterMode converter,
+        string ffmpegPath,
+        double? width,
+        double? height,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        string framePattern;
+
+        if (converter == SvgConverterMode.Ffmpeg)
+        {
+            framePattern = Path.Combine(framesDir, "frame-%04d.svg");
+        }
+        else
+        {
+            // Pre-convert all SVG frames to PNG so ffmpeg can ingest them.
+            var svgFiles = Directory.EnumerateFiles(framesDir, "frame-*.svg")
+                .OrderBy(f => f, StringComparer.Ordinal)
+                .ToList();
+
+            if (svgFiles.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"No SVG frames found in {framesDir} for video conversion."
+                );
+            }
+
+            logger.ZLogDebug(
+                $"Pre-converting {svgFiles.Count} SVG frame(s) to PNG via {converter}."
+            );
+
+            var parallelOpts = new ParallelOptions
+            {
+                CancellationToken = cancellationToken,
+                // Keep CPU/native-library contention bounded.
+                MaxDegreeOfParallelism = Math.Min(8, Environment.ProcessorCount),
+            };
+
+            await Parallel
+                .ForEachAsync(
+                    svgFiles,
+                    parallelOpts,
+                    async (svgFile, ct) =>
+                    {
+                        var pngFile = Path.Combine(
+                            framesDir,
+                            Path.GetFileNameWithoutExtension(svgFile) + ".png"
+                        );
+                        await ConvertSvgToPngAsync(
+                                svgFile,
+                                pngFile,
+                                converter,
+                                width,
+                                height,
+                                logger,
+                                ct
+                            )
+                            .ConfigureAwait(false);
+
+                        // Remove the SVG so ffmpeg's pattern doesn't pick it up.
+                        try { File.Delete(svgFile); }
+                        catch (Exception ex)
+                        {
+                            logger.ZLogDebug(
+                                ex,
+                                $"Failed to delete frame SVG {svgFile}: {ex.Message}"
+                            );
+                        }
+                    }
+                )
+                .ConfigureAwait(false);
+
+            framePattern = Path.Combine(framesDir, "frame-%04d.png");
+        }
+
+        var fpsStr = fps.ToString(CultureInfo.InvariantCulture);
+        await RunFfmpegAsync(
+                ffmpegPath,
+                ["-y", "-framerate", fpsStr, "-i", framePattern, outputPath],
+                logger,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>Renders a single SVG file to a PNG file using the chosen fallback.</summary>
+    private static async Task ConvertSvgToPngAsync(
+        string svgPath,
+        string pngPath,
+        SvgConverterMode converter,
+        double? width,
+        double? height,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        EnsureDirectoryFor(pngPath);
+
+        if (converter == SvgConverterMode.RsvgConvert)
+        {
+            await ConvertSvgToPngViaRsvgAsync(
+                    svgPath,
+                    pngPath,
+                    width,
+                    height,
+                    logger,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+            return;
+        }
+
+        if (converter == SvgConverterMode.Resvg)
+        {
+            await ConvertSvgToPngViaResvgAsync(
+                    svgPath,
+                    pngPath,
+                    width,
+                    height,
+                    logger,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Converter {converter} cannot directly produce PNG (use ffmpeg for SVG-capable builds)."
+        );
+    }
+
+    /// <summary>
+    /// Runs <c>rsvg-convert</c> to render an SVG to PNG. Width/height, when
+    /// given, are forwarded; otherwise the SVG's intrinsic size is used.
+    /// </summary>
+    private static async Task ConvertSvgToPngViaRsvgAsync(
+        string svgPath,
+        string pngPath,
+        double? width,
+        double? height,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        var exe = FindRsvgConvertExecutable()!;
+        var args = new List<string>();
+        if (width.HasValue)
+        {
+            args.AddRange(["-w", FormatPx(width.Value)]);
+        }
+        if (height.HasValue)
+        {
+            args.AddRange(["-h", FormatPx(height.Value)]);
+        }
+        args.Add(svgPath);
+        args.AddRange(["-o", pngPath]);
+
+        logger.ZLogDebug($"Running rsvg-convert: {exe} {string.Join(' ', args)}");
+
+        using var process = new Process();
+        process.StartInfo.FileName = exe;
+        process.StartInfo.UseShellExecute = false;
+        foreach (var a in args)
+        {
+            process.StartInfo.ArgumentList.Add(a);
+        }
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                "Failed to start rsvg-convert. Install 'librsvg2-bin' (Debian/Ubuntu) "
+                + "or 'librsvg' (Homebrew).\n"
+                + ex.Message,
+                ex
+            );
+        }
+
+        using var killOnCancel = cancellationToken.Register(() =>
+        {
+            try { process.Kill(entireProcessTree: true); }
+            catch { /* process may have already exited */ }
+        });
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"rsvg-convert exited with code {process.ExitCode}."
+            );
+        }
+    }
+
+    /// <summary>
+    /// Renders an SVG to PNG using the managed ResvgSharp library. The native
+    /// library is loaded lazily; if it's missing, an informative error is
+    /// thrown instead of crashing at startup.
+    /// </summary>
+    private static async Task ConvertSvgToPngViaResvgAsync(
+        string svgPath,
+        string pngPath,
+        double? width,
+        double? height,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        // ResvgSharp's API is synchronous and CPU-bound. Run it on a thread
+        // pool thread so the caller's async flow can observe the cancellation.
+        var svg = await File.ReadAllTextAsync(svgPath, cancellationToken)
+            .ConfigureAwait(false);
+
+        logger.ZLogDebug(
+            $"Rendering SVG ({svg.Length} chars) via ResvgSharp → {pngPath}"
+        );
+
+        await Task
+            .Run(
+                () =>
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var options = new ResvgOptions
+                    {
+                        // Render the entire SVG viewport.
+                        ExportAreaPage = true,
+                    };
+                    if (width.HasValue)
+                    {
+                        options.Width = ToPxInt(width.Value);
+                    }
+                    if (height.HasValue)
+                    {
+                        options.Height = ToPxInt(height.Value);
+                    }
+
+                    byte[] pngBytes;
+                    try
+                    {
+                        pngBytes = Resvg.RenderToPng(svg, options);
+                    }
+                    catch (Exception ex)
+                        when (IsResvgLoadFailure(ex))
+                    {
+                        throw new InvalidOperationException(
+                            "ResvgSharp native library failed to load. Falling back "
+                            + "requires the resvg native runtime shipped with this build.",
+                            ex
+                        );
+                    }
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                    EnsureDirectoryFor(pngPath);
+                    File.WriteAllBytes(pngPath, pngBytes);
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Detects whether the ResvgSharp managed wrapper can load its native
+    /// counterpart. We do a tiny throwaway render rather than probing for the
+    /// native lib on disk so the check works portably across RIDs.
+    /// </summary>
+    private static bool DetectResvg()
+    {
+        try
+        {
+            var tiny = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"1\" height=\"1\"/>";
+            _ = Resvg.RenderToPng(tiny);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Returns true when an exception looks like a native-lib load failure.</summary>
+    private static bool IsResvgLoadFailure(Exception ex)
+    {
+        for (var e = ex; e != null; e = e.InnerException)
+        {
+            if (e is DllNotFoundException || e is TypeLoadException)
+            {
+                return true;
+            }
+
+            var msg = e.Message ?? string.Empty;
+            if (
+                msg.Contains("libresvg", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("Cannot find", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("shared object", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("DllNotFoundException", StringComparison.OrdinalIgnoreCase)
+            )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>Throws if ffmpeg exits non-zero. Describes the invocation in debug logs.</summary>
+    private static async Task RunFfmpegAsync(
+        string ffmpegPath,
+        string[] args,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        logger.ZLogDebug($"Running ffmpeg: {ffmpegPath} {string.Join(' ', args)}");
+
+        using var process = new Process();
+        process.StartInfo.FileName = ffmpegPath;
+        process.StartInfo.UseShellExecute = false;
+        foreach (var arg in args)
+        {
+            process.StartInfo.ArgumentList.Add(arg);
+        }
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                "Failed to start ffmpeg. Please ensure ffmpeg is installed "
+                + "(bundled with the application or available in PATH).\n"
+                + ex.Message,
+                ex
+            );
+        }
+
+        using var killOnCancel = cancellationToken.Register(() =>
+        {
+            try { process.Kill(entireProcessTree: true); }
+            catch { /* process may have already exited */ }
+        });
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"ffmpeg exited with code {process.ExitCode}. "
+                + "Ensure ffmpeg supports the requested output format "
+                + "(SVG input requires the librsvg input device)."
+            );
+        }
+
+        logger.ZLogDebug($"ffmpeg completed successfully.");
+    }
+
+    /// <summary>
+    /// Runs <c>ffmpeg -hide_banner -formats</c> (or <c>-codecs</c>) and checks
+    /// whether SVG is listed as a supported input demuxer. Cached so the
+    /// process is only spawned once per session.
+    /// </summary>
+    private static bool CheckFfmpegSvgSupport()
+    {
+        var exe = FindExecutable(
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "ffmpeg.exe" : "ffmpeg"
+        );
+        if (string.IsNullOrEmpty(exe))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var process = new Process();
+            process.StartInfo.FileName = exe;
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.ArgumentList.Add("-hide_banner");
+            process.StartInfo.ArgumentList.Add("-formats");
+            process.Start();
+
+            var output = process.StandardOutput.ReadToEnd();
+            // `-formats` entries look like:
+            //   "  svg_pipe           svg    Scalable Vector Graphics (SVG)"
+            // Some builds advertise "svg_pipe" (file format) rather than "svg"
+            // We accept either token, on a word boundary, to avoid false hits
+            // like "mssvg" or unrelated format descriptions.
+            var lines = output
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (var line in lines)
+            {
+                // demuxer/format lines start with a 2-char flags column.
+                if (line.Length <= 3)
+                {
+                    continue;
+                }
+
+                var rest = line.AsSpan().Slice(3).Trim();
+                // Take everything up to the first run of whitespace: that's the
+                // format name token. Match "svg" or "svg_pipe" (case-insensitive).
+                var spaceIdx = rest.IndexOf(' ');
+                var name = spaceIdx < 0 ? rest : rest.Slice(0, spaceIdx);
+                if (
+                    name.Equals("svg", StringComparison.OrdinalIgnoreCase)
+                    || name.Equals("svg_pipe", StringComparison.OrdinalIgnoreCase)
+                )
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Finds rsvg-convert (or rsvg-convert.exe) on PATH.</summary>
+    private static string FindRsvgConvertExecutable()
+    {
+        var exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "rsvg-convert.exe"
+            : "rsvg-convert";
+
+        // 1. next to this binary (bundled layout)
+        var exeDir = Path.GetDirectoryName(Environment.ProcessPath ?? string.Empty);
+        if (!string.IsNullOrEmpty(exeDir))
+        {
+            var bundled = Path.Combine(exeDir, exeName);
+            if (File.Exists(bundled))
+            {
+                return bundled;
+            }
+        }
+
+        // 2. PATH
+        return FindExecutable(exeName);
+    }
+
+    /// <summary>
+    /// Resolves a binary name to its full path using <c>which</c> semantics
+    /// across platforms. Returns an empty string when not found.
+    /// </summary>
+    private static string FindExecutable(string name)
+    {
+        if (File.Exists(name))
+        {
+            return Path.GetFullPath(name);
+        }
+
+        var pathEnv = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathEnv))
+        {
+            return string.Empty;
+        }
+
+        var separator = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ';' : ':';
+        foreach (var dir in pathEnv.Split(separator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var full = Path.Combine(dir, name);
+            if (File.Exists(full))
+            {
+                return full;
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static void EnsureDirectoryFor(string path)
+    {
+        var dir = Path.GetDirectoryName(Path.GetFullPath(path));
+        if (!string.IsNullOrWhiteSpace(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+    }
+
+    private static string FormatPx(double px) =>
+        Math.Round(px, MidpointRounding.AwayFromZero)
+            .ToString("0", CultureInfo.InvariantCulture);
+
+    private static int ToPxInt(double px) => (int)Math.Round(px, MidpointRounding.AwayFromZero);
+}

--- a/src/ConsoleToSvg/Svg/SvgConverter.cs
+++ b/src/ConsoleToSvg/Svg/SvgConverter.cs
@@ -46,13 +46,16 @@ internal static class SvgConverter
 
     private static readonly Lazy<bool> _resvgAvailable = new(DetectResvg);
 
+    // Resolved bundled ffmpeg path set by Program.Main (which checks the
+    // bundled layout next to the binary). When null/empty, detection falls
+    // back to the bundled dir and PATH.
+    private static string? _resolvedFfmpegPath;
+
     private static readonly Lazy<bool> _ffmpegAvailable = new(
-        () => !string.IsNullOrEmpty(FindExecutable(
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "ffmpeg.exe" : "ffmpeg"
-        ))
+        () => !string.IsNullOrEmpty(FindFfmpegForDetection())
     );
 
-    // Cached so we don't shell out to `ffmpeg -formats` on every call.
+    // Cached so we don't shell out to ffmpeg on every call.
     private static readonly Lazy<bool> _ffmpegSupportsSvg = new(CheckFfmpegSvgSupport);
 
     /// <summary>
@@ -597,67 +600,98 @@ internal static class SvgConverter
     }
 
     /// <summary>
-    /// Runs <c>ffmpeg -hide_banner -formats</c> (or <c>-codecs</c>) and checks
-    /// whether SVG is listed as a supported input demuxer. Cached so the
-    /// process is only spawned once per session.
+    /// Sets the resolved bundled ffmpeg path so that lazy auto-detection in
+    /// <see cref="SvgConverter"/> finds ffmpeg even when not on PATH.
+    /// Called by Program.Main (which uses FindFfmpegExecutable that checks
+    /// the bundled layout next to the binary AND PATH).
+    /// </summary>
+    public static void SetFfmpegPath(string path)
+    {
+        _resolvedFfmpegPath = string.IsNullOrEmpty(path) ? null : path;
+    }
+
+    /// <summary>
+    /// Finds the ffmpeg binary for support detection.
+    /// Prefers the path resolved by Program.Main, then checks the bundled
+    /// layout next to this binary, then falls back to PATH.
+    /// </summary>
+    private static string FindFfmpegForDetection()
+    {
+        if (!string.IsNullOrEmpty(_resolvedFfmpegPath) && File.Exists(_resolvedFfmpegPath))
+        {
+            return _resolvedFfmpegPath;
+        }
+
+        var exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "ffmpeg.exe"
+            : "ffmpeg";
+
+        // Check next to this binary (bundled / npm layout)
+        var exeDir = Path.GetDirectoryName(Environment.ProcessPath ?? string.Empty);
+        if (!string.IsNullOrEmpty(exeDir))
+        {
+            var bundled = Path.Combine(exeDir, exeName);
+            if (File.Exists(bundled))
+            {
+                return bundled;
+            }
+        }
+
+        // PATH
+        return FindExecutable(exeName);
+    }
+
+    /// <summary>
+    /// Probes whether ffmpeg can actually decode SVG (rasterize via librsvg)
+    /// by doing a minimal SVG → PNG test conversion. <c>ffmpeg -formats</c>
+    /// lists <c>svg_pipe</c> even when librsvg decoder is NOT enabled
+    /// (false positive), so only a real conversion confirms support.
+    /// Result is cached via <see cref="_ffmpegSupportsSvg"/>.
     /// </summary>
     private static bool CheckFfmpegSvgSupport()
     {
-        var exe = FindExecutable(
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "ffmpeg.exe" : "ffmpeg"
-        );
+        var exe = FindFfmpegForDetection();
         if (string.IsNullOrEmpty(exe))
         {
             return false;
         }
 
+        var tempDir = Path.GetTempPath();
+        var tempSvg = Path.Combine(tempDir, $"c2s-probe-{Guid.NewGuid():N}.svg");
+        var tempPng = Path.Combine(tempDir, $"c2s-probe-{Guid.NewGuid():N}.png");
+
         try
         {
+            File.WriteAllText(tempSvg, "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"1\" height=\"1\"/>");
+
             using var process = new Process();
             process.StartInfo.FileName = exe;
             process.StartInfo.UseShellExecute = false;
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.RedirectStandardError = true;
             process.StartInfo.ArgumentList.Add("-hide_banner");
-            process.StartInfo.ArgumentList.Add("-formats");
+            process.StartInfo.ArgumentList.Add("-i");
+            process.StartInfo.ArgumentList.Add(tempSvg);
+            process.StartInfo.ArgumentList.Add("-y");
+            process.StartInfo.ArgumentList.Add("-frames:v");
+            process.StartInfo.ArgumentList.Add("1");
+            process.StartInfo.ArgumentList.Add("-update");
+            process.StartInfo.ArgumentList.Add("1");
+            process.StartInfo.ArgumentList.Add(tempPng);
+
             process.Start();
+            process.WaitForExit();
 
-            var output = process.StandardOutput.ReadToEnd();
-            // `-formats` entries look like:
-            //   "  svg_pipe           svg    Scalable Vector Graphics (SVG)"
-            // Some builds advertise "svg_pipe" (file format) rather than "svg"
-            // We accept either token, on a word boundary, to avoid false hits
-            // like "mssvg" or unrelated format descriptions.
-            var lines = output
-                .Split('\n', StringSplitOptions.RemoveEmptyEntries);
-
-            foreach (var line in lines)
-            {
-                // demuxer/format lines start with a 2-char flags column.
-                if (line.Length <= 3)
-                {
-                    continue;
-                }
-
-                var rest = line.AsSpan().Slice(3).Trim();
-                // Take everything up to the first run of whitespace: that's the
-                // format name token. Match "svg" or "svg_pipe" (case-insensitive).
-                var spaceIdx = rest.IndexOf(' ');
-                var name = spaceIdx < 0 ? rest : rest.Slice(0, spaceIdx);
-                if (
-                    name.Equals("svg", StringComparison.OrdinalIgnoreCase)
-                    || name.Equals("svg_pipe", StringComparison.OrdinalIgnoreCase)
-                )
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return process.ExitCode == 0 && File.Exists(tempPng);
         }
         catch
         {
             return false;
+        }
+        finally
+        {
+            try { if (File.Exists(tempSvg)) File.Delete(tempSvg); } catch { }
+            try { if (File.Exists(tempPng)) File.Delete(tempPng); } catch { }
         }
     }
 

--- a/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.cs
+++ b/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.cs
@@ -1,3 +1,4 @@
+using System;
 using ConsoleToSvg.Cli;
 using ConsoleToSvg.Svg;
 
@@ -79,6 +80,71 @@ public sealed class OptionParserTests
         );
         ok.ShouldBeTrue();
         options!.LengthAdjust.ShouldBe("spacingAndGlyphs");
+    }
+
+    [Test]
+    public void SvgConverterDefaultsToAuto()
+    {
+        var ok = OptionParser.TryParse(
+            Array.Empty<string>(),
+            out var options,
+            out _,
+            out _
+        );
+        ok.ShouldBeTrue();
+        options!.SvgConverter.ShouldBe(SvgConverterMode.Auto);
+    }
+
+    [Test]
+    public void SvgConverterFfmpegParsed()
+    {
+        var ok = OptionParser.TryParse(
+            new[] { "--svg-converter", "ffmpeg" },
+            out var options,
+            out _,
+            out _
+        );
+        ok.ShouldBeTrue();
+        options!.SvgConverter.ShouldBe(SvgConverterMode.Ffmpeg);
+    }
+
+    [Test]
+    public void SvgConverterRsvgConvertParsed()
+    {
+        var ok = OptionParser.TryParse(
+            new[] { "--svg-converter", "rsvg-convert" },
+            out var options,
+            out _,
+            out _
+        );
+        ok.ShouldBeTrue();
+        options!.SvgConverter.ShouldBe(SvgConverterMode.RsvgConvert);
+    }
+
+    [Test]
+    public void SvgConverterResvgParsed()
+    {
+        var ok = OptionParser.TryParse(
+            new[] { "--svg-converter", "resvg" },
+            out var options,
+            out _,
+            out _
+        );
+        ok.ShouldBeTrue();
+        options!.SvgConverter.ShouldBe(SvgConverterMode.Resvg);
+    }
+
+    [Test]
+    public void SvgConverterInvalidValueRejected()
+    {
+        var ok = OptionParser.TryParse(
+            new[] { "--svg-converter", "foobar" },
+            out _,
+            out var error,
+            out _
+        );
+        ok.ShouldBeFalse();
+        error!.ShouldContain("svg-converter");
     }
 
     [Test]


### PR DESCRIPTION
## Implements #43

### Problem
ffmpeg requires \`librsvg\` to be enabled to directly convert SVG files, but many platforms don't have it enabled by default. This makes console2svg fail in environments without librsvg support.

### Solution
Added automatic detection of ffmpeg's SVG support and fallback conversion paths:

1. **Detection**: Checks if ffmpeg can handle SVG input
2. **Fallback to rsvg-convert**: Uses the \`rsvg-convert\` CLI tool (available via \`apt install librsvg2-bin\` on Ubuntu, \`brew install librsvg\` on macOS)
3. **Fallback to ResvgSharp**: Uses the managed \`ResvgSharp\` library for cross-platform SVG rendering (if AOT-compatible)
4. **Pipeline**: \`SVG → (rsvg-convert/ResvgSharp) → PNG → (ffmpeg) → JPG/MP4/...\`

### New option
- \`--svg-converter <auto|ffmpeg|rsvg-convert|resvg>\`: Force a specific converter (default: \`auto\`)

When a fallback converter handles SVG→PNG conversion and the target format is PNG, ffmpeg is not invoked at all.

Fixes #43

🤖 Generated with [Copilot](https://github.com/features/copilot)