### PR TITLE
feat: check ffmpeg and converter availability before starting PTY recording

### DIFF
--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -106,6 +106,36 @@ internal static class Program
 
         try
         {
+            // Pre-check: verify ffmpeg and converter availability BEFORE starting
+            // the recording, so a missing tool surfaces immediately instead of
+            // wasting the recorded session (issue #78). Only raster/video outputs
+            // need conversion tools; pure SVG output (including --stdout) does not.
+            if (!options.StdOut)
+            {
+                var preCheckExt = Path.GetExtension(options.OutputPath)
+                    .TrimStart('.')
+                    .ToLowerInvariant();
+                if (
+                    !string.IsNullOrEmpty(preCheckExt)
+                    && !string.Equals(preCheckExt, "svg", StringComparison.Ordinal)
+                )
+                {
+                    // Resolve ffmpeg and the converter early; the lazy caches survive
+                    // to the post-recording conversion step, so this is not duplicated work.
+                    var preFfmpegPath = FindFfmpegExecutable();
+                    SvgConverter.SetFfmpegPath(preFfmpegPath);
+
+                    SvgConverter.VerifyConversionPipeline(
+                        options.SvgConverter,
+                        RequiresFfmpeg(options, preCheckExt),
+                        logger
+                    );
+                    logger.ZLogDebug(
+                        $"Pre-conversion check passed: converter verified for .{preCheckExt} output."
+                    );
+                }
+            }
+
             var session = await LoadOrRecordAsync(
                     options,
                     loggerFactory,
@@ -185,7 +215,7 @@ internal static class Program
                     SvgConverter.SetFfmpegPath(ffmpegPath);
                     var converter = SvgConverter.ResolveConverter(
                         options.SvgConverter,
-                        ffmpegAvailableOverride: true,
+                        ffmpegAvailableOverride: SvgConverter.IsFfmpegAvailable,
                         logger
                     );
                     logger.ZLogDebug(
@@ -533,6 +563,22 @@ internal static class Program
     };
 
     private static bool IsVideoFormat(string extension) => VideoExtensions.Contains(extension);
+
+    /// <summary>
+    /// Determines whether ffmpeg is required to produce the final output format.
+    /// Video formats always need ffmpeg; PNG can be produced via rsvg-convert or
+    /// ResvgSharp alone; all other raster formats (gif, jpg, webp, etc.) also need ffmpeg.
+    /// If <see cref="AppOptions.IsModeExplicit"/> is set, the explicit mode takes
+    /// precedence over the extension (e.g. <c>--mode image</c> for a static .gif).
+    /// </summary>
+    private static bool RequiresFfmpeg(AppOptions options, string extension)
+    {
+        var useVideoPath = options.IsModeExplicit
+            ? options.Mode is OutputMode.Video or OutputMode.Repeat
+            : IsVideoFormat(extension);
+        var isPngOutput = string.Equals(extension, "png", StringComparison.Ordinal);
+        return useVideoPath || !isPngOutput;
+    }
 
     /// <summary>
     /// Finds the ffmpeg executable to use for format conversion.

--- a/src/ConsoleToSvg/Svg/SvgConverter.cs
+++ b/src/ConsoleToSvg/Svg/SvgConverter.cs
@@ -201,6 +201,39 @@ internal static class SvgConverter
     }
 
     /// <summary>
+    /// Verifies that all tools required for the requested output format are
+    /// available. Call this before starting a recording so that missing tools
+    /// are reported immediately, without wasting a recording session (issue #78).
+    /// Throws <see cref="InvalidOperationException"/> when a required tool is missing.
+    /// </summary>
+    /// <param name="wanted">User's converter preference (Auto / Ffmpeg / RsvgConvert / Resvg).</param>
+    /// <param name="requiresFfmpeg">True when the output format (video or non-PNG image) needs ffmpeg for the final encode step.</param>
+    /// <param name="logger">Logger for debug messages.</param>
+    public static void VerifyConversionPipeline(
+        SvgConverterMode wanted,
+        bool requiresFfmpeg,
+        ILogger logger)
+    {
+        // ResolveConverter throws when a forced converter is unavailable.
+        var converter = ResolveConverter(wanted, _ffmpegAvailable.Value, logger);
+
+        // ResolvePreConversionConverter throws when ffmpeg can't decode SVG
+        // and no fallback converter (rsvg-convert, ResvgSharp) is available.
+        _ = ResolvePreConversionConverter(converter);
+
+        // For video and non-PNG image output, ffmpeg is required for the final
+        // encoding step (PNG → video / SVG → video when ffmpeg supports SVG).
+        if (requiresFfmpeg && !_ffmpegAvailable.Value)
+        {
+            throw new InvalidOperationException(
+                "ffmpeg is required for the requested output format but was not found. "
+                + "Install ffmpeg (or bundle it next to this executable) and ensure it "
+                + "is on PATH."
+            );
+        }
+    }
+
+    /// <summary>
     /// Converts a single SVG file to a raster image (png/jpg/…).
     /// When a fallback converter is used, SVG → PNG is rendered first, then
     /// ffmpeg (if needed) takes PNG → final format.


### PR DESCRIPTION
## Problem

ffmpeg and converter tool discovery happened AFTER the PTY recording was complete. When tools were missing, the entire recording was wasted — the user would record a session only to find out at conversion time that ffmpeg wasn't installed.

## Fix

Add `SvgConverter.VerifyConversionPipeline()` and call it from `Program.Main` **before** `LoadOrRecordAsync`. This fails fast with a clear error message if:
- ffmpeg is required for the output format but not found
- The forced converter mode (`--svg-converter ffmpeg/rsvg/resvg`) is unavailable
- ffmpeg can't decode SVG and no fallback converter exists

### Changes
- Add `VerifyConversionPipeline()` public method to `SvgConverter`
- Add pre-check block in `Program.Main` before recording starts (gated by `!StdOut` and non-SVG extension)
- Extract `RequiresFfmpeg()` helper to determine if ffmpeg is needed for the output format
- Fix post-recording `ResolveConverter` to use `SvgConverter.IsFfmpegAvailable` instead of hard-coded `true`

> **Depends on #81** — this branch is based on `fix/issue-79-svg-ffmpeg-fallback` because it uses `IsFfmpegAvailable` and `ResolvePreConversionConverter` introduced there. Merge #81 first.

Closes #78

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added an early check to confirm required conversion tools are available before recording begins.
  * Improved handling of output formats, including video, repeat, PNG, and other raster formats.
  * Added clearer errors when required conversion software is unavailable.

* **Chores**
  * Updated the application version from 0.7.0 to 0.7.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->