### PR TITLE
feat!: bundle native libraries in release archives

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -155,30 +155,30 @@ jobs:
             rid=$(basename "$dir" | sed 's/^native-//')
             bundle_dir="./bundle-${rid}"
             rm -rf "$bundle_dir"
-            mkdir -p "$bundle_dir/bin"
+            mkdir -p "$bundle_dir"
 
             if [[ "$rid" == win-* ]]; then
-              cp "$dir/console2svg.exe" "$bundle_dir/bin/console2svg.exe"
+              cp "$dir/console2svg.exe" "$bundle_dir/console2svg.exe"
               # Copy native runtime libraries next to the executable (Windows loader).
               for f in "$dir"/*.dll; do
-                [ -f "$f" ] && cp "$f" "$bundle_dir/bin/"
+                [ -f "$f" ] && cp "$f" "$bundle_dir/"
               done
               # Copy child executables such as winpty-agent.exe.
               for f in "$dir"/*.exe; do
                 [ -f "$f" ] || continue
                 [ "$(basename "$f")" = "console2svg.exe" ] && continue
-                cp "$f" "$bundle_dir/bin/"
+                cp "$f" "$bundle_dir/"
               done
             else
-              cp "$dir/console2svg" "$bundle_dir/bin/console2svg"
-              chmod +x "$bundle_dir/bin/console2svg"
-              mkdir -p "$bundle_dir/lib"
+              cp "$dir/console2svg" "$bundle_dir/console2svg"
+              chmod +x "$bundle_dir/console2svg"
+              # Copy native runtime libraries next to the executable.
               for f in "$dir"/*.so "$dir"/*.dylib; do
-                [ -f "$f" ] && cp "$f" "$bundle_dir/lib/"
+                [ -f "$f" ] && cp "$f" "$bundle_dir/"
               done
             fi
 
-            # Windows: bundle ffmpeg inside bin/ffmpeg so console2svg can locate it.
+            # Windows: bundle ffmpeg in a subdirectory so console2svg can locate it.
             case "$rid" in
               win-x64)
                 ffmpeg_zip_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-lgpl-shared.zip"
@@ -203,10 +203,10 @@ jobs:
                 echo "ffmpeg.exe not found at $ffmpeg_bin_dir/ffmpeg.exe."
                 exit 1
               fi
-              mkdir -p "$bundle_dir/bin/ffmpeg"
-              cp "$ffmpeg_bin_dir"/*.exe "$bundle_dir/bin/ffmpeg/"
-              cp "$ffmpeg_bin_dir"/*.dll "$bundle_dir/bin/ffmpeg/"
-              cp "${top_dir}LICENSE.txt" "$bundle_dir/bin/ffmpeg/ffmpeg-LICENSE.txt"
+              mkdir -p "$bundle_dir/ffmpeg"
+              cp "$ffmpeg_bin_dir"/*.exe "$bundle_dir/ffmpeg/"
+              cp "$ffmpeg_bin_dir"/*.dll "$bundle_dir/ffmpeg/"
+              cp "${top_dir}LICENSE.txt" "$bundle_dir/ffmpeg/ffmpeg-LICENSE.txt"
             fi
 
             case "$rid" in

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -179,6 +179,9 @@ jobs:
             fi
 
             # Windows: bundle ffmpeg in a subdirectory so console2svg can locate it.
+            # BtbN publishes FFmpeg-Builds as a rolling 'latest' release, so the
+            # download URL points to the current latest build. There is no stable
+            # immutable URL available; we verify the archive integrity after download.
             case "$rid" in
               win-x64)
                 ffmpeg_zip_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-lgpl-shared.zip"
@@ -194,6 +197,15 @@ jobs:
             if [ -n "$ffmpeg_zip_url" ]; then
               ffmpeg_zip="./ffmpeg-${rid}.zip"
               curl -fsSL -o "$ffmpeg_zip" "$ffmpeg_zip_url"
+
+              # Verify zip integrity before extraction. (SHA-256 pinning is not
+              # feasible because BtbN overwrites the 'latest' release assets.)
+              if ! unzip -t "$ffmpeg_zip" >/dev/null; then
+                echo "Downloaded ffmpeg archive is corrupt: $ffmpeg_zip"
+                exit 1
+              fi
+              sha256sum "$ffmpeg_zip"
+
               ffmpeg_extract="./ffmpeg-extract-${rid}"
               mkdir -p "$ffmpeg_extract"
               unzip -q "$ffmpeg_zip" -d "$ffmpeg_extract"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -126,7 +126,10 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: native-${{ matrix.rid }}
-          path: ./native-publish/${{ matrix.rid }}/**
+          path: |
+            ./native-publish/${{ matrix.rid }}/**
+            !./native-publish/${{ matrix.rid }}/**/*.dbg
+            !./native-publish/${{ matrix.rid }}/**/*.pdb
 
   release-github:
     needs: [build-nupkg, build-aot]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -122,11 +122,11 @@ jobs:
             -p:WarningLevel=0 \
             -o ./native-publish/${{ matrix.rid }}
 
-      - name: Upload native binary
+      - name: Upload native publish output
         uses: actions/upload-artifact@v7
         with:
           name: native-${{ matrix.rid }}
-          path: ./native-publish/${{ matrix.rid }}/console2svg*
+          path: ./native-publish/${{ matrix.rid }}/**
 
   release-github:
     needs: [build-nupkg, build-aot]
@@ -139,28 +139,87 @@ jobs:
           name: nuget-packages
           path: ./release-upload
 
-      - name: Download all native binary artifacts
+      - name: Download all native publish artifacts
         uses: actions/download-artifact@v8
         with:
           pattern: native-*
           path: ./native-artifacts
           merge-multiple: false
 
-      - name: Collect native binaries
+      - name: Build native archives
         shell: bash
         run: |
+          sudo apt-get install -y unzip tar
+
           for dir in ./native-artifacts/native-*/; do
             rid=$(basename "$dir" | sed 's/^native-//')
+            bundle_dir="./bundle-${rid}"
+            rm -rf "$bundle_dir"
+            mkdir -p "$bundle_dir/bin"
+
             if [[ "$rid" == win-* ]]; then
-              src="$dir/console2svg.exe"
-              dst="./release-upload/console2svg-${rid}.exe"
+              cp "$dir/console2svg.exe" "$bundle_dir/bin/console2svg.exe"
+              # Copy native runtime libraries next to the executable (Windows loader).
+              for f in "$dir"/*.dll; do
+                [ -f "$f" ] && cp "$f" "$bundle_dir/bin/"
+              done
+              # Copy child executables such as winpty-agent.exe.
+              for f in "$dir"/*.exe; do
+                [ -f "$f" ] || continue
+                [ "$(basename "$f")" = "console2svg.exe" ] && continue
+                cp "$f" "$bundle_dir/bin/"
+              done
             else
-              src="$dir/console2svg"
-              dst="./release-upload/console2svg-${rid}"
+              cp "$dir/console2svg" "$bundle_dir/bin/console2svg"
+              chmod +x "$bundle_dir/bin/console2svg"
+              mkdir -p "$bundle_dir/lib"
+              for f in "$dir"/*.so "$dir"/*.dylib; do
+                [ -f "$f" ] && cp "$f" "$bundle_dir/lib/"
+              done
             fi
-            if [ -f "$src" ]; then
-              cp "$src" "$dst"
+
+            # Windows: bundle ffmpeg inside bin/ffmpeg so console2svg can locate it.
+            case "$rid" in
+              win-x64)
+                ffmpeg_zip_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-lgpl-shared.zip"
+                ;;
+              win-arm64)
+                ffmpeg_zip_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-winarm64-lgpl-shared.zip"
+                ;;
+              *)
+                ffmpeg_zip_url=""
+                ;;
+            esac
+
+            if [ -n "$ffmpeg_zip_url" ]; then
+              ffmpeg_zip="./ffmpeg-${rid}.zip"
+              curl -fsSL -o "$ffmpeg_zip" "$ffmpeg_zip_url"
+              ffmpeg_extract="./ffmpeg-extract-${rid}"
+              mkdir -p "$ffmpeg_extract"
+              unzip -q "$ffmpeg_zip" -d "$ffmpeg_extract"
+              top_dir=$(ls -d "$ffmpeg_extract"/*/ | head -1)
+              ffmpeg_bin_dir="${top_dir}bin"
+              if [ ! -f "$ffmpeg_bin_dir/ffmpeg.exe" ]; then
+                echo "ffmpeg.exe not found at $ffmpeg_bin_dir/ffmpeg.exe."
+                exit 1
+              fi
+              mkdir -p "$bundle_dir/bin/ffmpeg"
+              cp "$ffmpeg_bin_dir"/*.exe "$bundle_dir/bin/ffmpeg/"
+              cp "$ffmpeg_bin_dir"/*.dll "$bundle_dir/bin/ffmpeg/"
+              cp "${top_dir}LICENSE.txt" "$bundle_dir/bin/ffmpeg/ffmpeg-LICENSE.txt"
             fi
+
+            case "$rid" in
+              win-*)
+                archive_name="./release-upload/console2svg-${rid}.zip"
+                (cd "$bundle_dir" && zip -q -r "../${archive_name#./}" .)
+                ;;
+              *)
+                archive_name="./release-upload/console2svg-${rid}.tar.gz"
+                tar -czf "$archive_name" -C "$bundle_dir" .
+                ;;
+            esac
+            echo "Created $archive_name"
           done
 
       - name: Install Linux packaging tools
@@ -193,6 +252,12 @@ jobs:
 
             chmod 755 "$src"
 
+            so_src="./native-artifacts/native-${rid}/libresvg_wrapper.so"
+            if [ ! -f "$so_src" ]; then
+              echo "Native library not found: $so_src"
+              exit 1
+            fi
+
             common_args=(
               -s dir
               -n console2svg
@@ -203,60 +268,15 @@ jobs:
               --description "Convert terminal output to SVG images."
             )
 
-            fpm "${common_args[@]}" -t deb -a "$deb_arch" -p "./release-upload/console2svg.${asset_arch}.deb" "$src=/usr/local/bin/console2svg"
-            fpm "${common_args[@]}" -t rpm -a "$rpm_arch" -p "./release-upload/console2svg.${asset_arch}.rpm" "$src=/usr/local/bin/console2svg"
+            fpm "${common_args[@]}" -t deb -a "$deb_arch" -p "./release-upload/console2svg.${asset_arch}.deb" \
+              "$src=/usr/local/bin/console2svg" \
+              "$so_src=/usr/local/lib/console2svg/libresvg_wrapper.so"
+            fpm "${common_args[@]}" -t rpm -a "$rpm_arch" -p "./release-upload/console2svg.${asset_arch}.rpm" \
+              "$src=/usr/local/bin/console2svg" \
+              "$so_src=/usr/local/lib/console2svg/libresvg_wrapper.so"
           done
 
-      - name: Build Windows ffmpeg zip bundles
-        shell: bash
-        run: |
-          sudo apt-get install -y unzip
-
-          for rid in win-x64 win-arm64; do
-            case "$rid" in
-              win-x64)
-                ffmpeg_zip_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-lgpl-shared.zip"
-                ;;
-              win-arm64)
-                ffmpeg_zip_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-winarm64-lgpl-shared.zip"
-                ;;
-            esac
-
-            src="./native-artifacts/native-${rid}/console2svg.exe"
-            if [ ! -f "$src" ]; then
-              continue
-            fi
-
-            # Download and extract the ffmpeg bundle
-            ffmpeg_zip="./ffmpeg-${rid}.zip"
-            curl -fsSL -o "$ffmpeg_zip" "$ffmpeg_zip_url"
-
-            ffmpeg_dir="./ffmpeg-extract-${rid}"
-            mkdir -p "$ffmpeg_dir"
-            unzip -q "$ffmpeg_zip" -d "$ffmpeg_dir"
-
-            # The BtbN zip contains a top-level directory with a bin/ subdirectory
-            top_dir=$(ls -d "$ffmpeg_dir"/*/ | head -1)
-            ffmpeg_bin_dir="${top_dir}bin"
-            if [ ! -f "$ffmpeg_bin_dir/ffmpeg.exe" ]; then
-              echo "ffmpeg.exe not found at $ffmpeg_bin_dir/ffmpeg.exe."
-              exit 1
-            fi
-
-            # Build the bundle zip: console2svg.exe + ffmpeg/ subdirectory
-            bundle_dir="./console2svg-${rid}-ffmpeg"
-            mkdir -p "$bundle_dir/ffmpeg"
-            cp "$src" "$bundle_dir/console2svg.exe"
-            cp "$ffmpeg_bin_dir"/*.exe "$bundle_dir/ffmpeg/"
-            cp "$ffmpeg_bin_dir"/*.dll "$bundle_dir/ffmpeg/"
-            cp "${top_dir}LICENSE.txt" "$bundle_dir/ffmpeg/ffmpeg-LICENSE.txt"
-
-            zip_name="./release-upload/console2svg-${rid}-ffmpeg.zip"
-            # Create a zip with console2svg.exe at the root and ffmpeg isolated in a subdirectory.
-            # This keeps ffmpeg off the user's PATH while still allowing console2svg to locate it.
-            (cd "$bundle_dir" && zip -q -r "../${zip_name#./}" .)
-            echo "Created $zip_name"
-          done
+      # Windows ffmpeg bundling is handled in "Build native archives" above.
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/README.md
+++ b/README.md
@@ -59,49 +59,32 @@ console2svg -v -c -d macos -- copilot --banner
 
 ## Install
 [![NuGet Version](https://img.shields.io/nuget/v/ConsoleToSvg?style=flat-square&logo=NuGet&color=0080CC)](https://www.nuget.org/packages/ConsoleToSvg/) [![npm version](https://img.shields.io/npm/v/console2svg?style=flat-square&logo=npm&color=0080CC)](https://www.npmjs.com/package/console2svg) [![GitHub Release](https://img.shields.io/github/v/release/arika0093/console2svg?style=flat-square&logo=github&label=GitHub%20Release&color=%230080CC)](https://github.com/arika0093/console2svg/releases/latest)
- 
-You can install it as a global tool using the dotnet or npm package manager.
+
+The easiest way on Linux/macOS is the install script. Windows users can use npm or download the zip.
 
 ```sh
+# Linux / macOS
+curl -sSL https://raw.githubusercontent.com/arika0093/console2svg/main/install.sh | bash
+
 # dotnet global tool
 dotnet tool install -g ConsoleToSvg
-# npm global package
+
+# npm global package (Windows / Linux / macOS)
 npm install -g console2svg
 ```
 
-It is also available as a standalone archive that you can download from the releases page and add to your PATH.
+You can also install from the [release archives](https://github.com/arika0093/console2svg/releases/latest) manually, or use the `.deb` / `.rpm` packages on Linux.
 
 ```sh
 # ubuntu
 curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg.amd64.deb -o console2svg.deb
 dpkg -i console2svg.deb
 
-# linux
-case "$(uname -m)" in
-  x86_64)  RID="linux-x64" ;;
-  aarch64) RID="linux-arm64" ;;
-esac
-curl -sSL "https://github.com/arika0093/console2svg/releases/latest/download/console2svg-${RID}.tar.gz" -o console2svg.tar.gz
-mkdir -p /usr/local/lib/console2svg
-tar -xzf console2svg.tar.gz -C /usr/local/lib/console2svg
-ln -sf /usr/local/lib/console2svg/console2svg /usr/local/bin/console2svg
-
-# macos
-case "$(uname -m)" in
-  x86_64) RID="osx-x64" ;;
-  arm64)  RID="osx-arm64" ;;
-esac
-curl -sSL "https://github.com/arika0093/console2svg/releases/latest/download/console2svg-${RID}.tar.gz" -o console2svg.tar.gz
-mkdir -p /usr/local/lib/console2svg
-tar -xzf console2svg.tar.gz -C /usr/local/lib/console2svg
-ln -sf /usr/local/lib/console2svg/console2svg /usr/local/bin/console2svg
-
-# windows (bundled with ffmpeg)
-# PowerShell
+# windows (PowerShell, bundled with ffmpeg)
 $arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'win-arm64' } else { 'win-x64' }
 Invoke-WebRequest -Uri "https://github.com/arika0093/console2svg/releases/latest/download/console2svg-${arch}.zip" -OutFile console2svg.zip
 Expand-Archive -Path console2svg.zip -DestinationPath console2svg
-# Add console2svg\ to PATH, or use the full path console2svg\console2svg.exe
+# Add console2svg\ to PATH, or use console2svg\console2svg.exe
 ```
 
 ### GitHub Actions

--- a/README.md
+++ b/README.md
@@ -77,20 +77,30 @@ curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/cons
 dpkg -i console2svg.deb
 
 # linux
-curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-linux-x64.tar.gz -o console2svg.tar.gz
+case "$(uname -m)" in
+  x86_64)  RID="linux-x64" ;;
+  aarch64) RID="linux-arm64" ;;
+esac
+curl -sSL "https://github.com/arika0093/console2svg/releases/latest/download/console2svg-${RID}.tar.gz" -o console2svg.tar.gz
 mkdir -p /usr/local/lib/console2svg
 tar -xzf console2svg.tar.gz -C /usr/local/lib/console2svg
 ln -sf /usr/local/lib/console2svg/console2svg /usr/local/bin/console2svg
 
 # macos
-curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-osx-arm64.tar.gz -o console2svg.tar.gz
+case "$(uname -m)" in
+  x86_64) RID="osx-x64" ;;
+  arm64)  RID="osx-arm64" ;;
+esac
+curl -sSL "https://github.com/arika0093/console2svg/releases/latest/download/console2svg-${RID}.tar.gz" -o console2svg.tar.gz
 mkdir -p /usr/local/lib/console2svg
 tar -xzf console2svg.tar.gz -C /usr/local/lib/console2svg
 ln -sf /usr/local/lib/console2svg/console2svg /usr/local/bin/console2svg
 
 # windows (bundled with ffmpeg)
-curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64.zip -o console2svg.zip
-unzip console2svg.zip -d console2svg
+# PowerShell
+$arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'win-arm64' } else { 'win-x64' }
+Invoke-WebRequest -Uri "https://github.com/arika0093/console2svg/releases/latest/download/console2svg-${arch}.zip" -OutFile console2svg.zip
+Expand-Archive -Path console2svg.zip -DestinationPath console2svg
 # Add console2svg\ to PATH, or use the full path console2svg\console2svg.exe
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,18 +80,18 @@ dpkg -i console2svg.deb
 curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-linux-x64.tar.gz -o console2svg.tar.gz
 mkdir -p /usr/local/lib/console2svg
 tar -xzf console2svg.tar.gz -C /usr/local/lib/console2svg
-ln -sf /usr/local/lib/console2svg/bin/console2svg /usr/local/bin/console2svg
+ln -sf /usr/local/lib/console2svg/console2svg /usr/local/bin/console2svg
 
 # macos
 curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-osx-arm64.tar.gz -o console2svg.tar.gz
 mkdir -p /usr/local/lib/console2svg
 tar -xzf console2svg.tar.gz -C /usr/local/lib/console2svg
-ln -sf /usr/local/lib/console2svg/bin/console2svg /usr/local/bin/console2svg
+ln -sf /usr/local/lib/console2svg/console2svg /usr/local/bin/console2svg
 
 # windows (bundled with ffmpeg)
 curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64.zip -o console2svg.zip
 unzip console2svg.zip -d console2svg
-# Add console2svg\bin\ to PATH, or use the full path console2svg\bin\console2svg.exe
+# Add console2svg\ to PATH, or use the full path console2svg\console2svg.exe
 ```
 
 ### GitHub Actions

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For example, let's open [this image](https://raw.githubusercontent.com/arika0093
 
 There are similar tools, but console2svg stands out for:
 
-* [**No dependencies**](#install): no additional software or libraries required. available as npm, dotnet tool and static binary.
+* [**No dependencies**](#install): no additional software or libraries required. Everything you need is included.
 * [**Video mode**](#animated-svg): save command execution animations as SVG. great for documentation and blog posts.
 * [**Crop**](#static-svg-with-crop): trim specific parts of the output. Crop based on text patterns is also supported, making it easy to trim specific lines or sections.
 * [**Background and window**](#window-chrome): add background and window frames to produce presentation-ready SVGs for documentation, blogs, social media, etc.
@@ -282,7 +282,7 @@ The replay file is in a simple JSON format. If you make a mistake in the input, 
 
 ### Convert to other formats
 
-In v0.7 and later, you can specify the output format based on the file extension specified with `-o output.mp4`.
+In v0.8 and later, you can specify the output format based on the file extension specified with `-o output.mp4`.
 
 First, install `ffmpeg`.  
 On Linux/macOS, you can easily install it using a package manager.  
@@ -306,6 +306,9 @@ console2svg -o ./output.gif -w 100 -h 24 -v -c -d macos-pc --timeout 5 --fps 30 
 ![console2svg -o ./output.gif -w 100 -h 24 -v -c -d macos-pc --timeout 5 --fps 30 -- cmatrix -ab](./assets/cmd-matrix-video.gif)
 
 You can also output as MP4, WebM, or a static PNG/JPG by changing the extension.
+
+> [!WARNING]
+> If you downloaded it as a dotnet tool, you need to install `ffmpeg` separately and add it to your PATH.
 
 ## Appearance options
 ### Background and opacity

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ dotnet tool install -g ConsoleToSvg
 npm install -g console2svg
 ```
 
-It is also available as a standalone binary that you can download from the releases page and add to your PATH.
+It is also available as a standalone archive that you can download from the releases page and add to your PATH.
 
 ```sh
 # ubuntu
@@ -77,16 +77,21 @@ curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/cons
 dpkg -i console2svg.deb
 
 # linux
-curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-linux-x64 -o console2svg
-mv -f console2svg /usr/local/bin/
-chmod +x /usr/local/bin/console2svg
+curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-linux-x64.tar.gz -o console2svg.tar.gz
+mkdir -p /usr/local/lib/console2svg
+tar -xzf console2svg.tar.gz -C /usr/local/lib/console2svg
+ln -sf /usr/local/lib/console2svg/bin/console2svg /usr/local/bin/console2svg
 
-# windows (binary only)
-curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64.exe -o console2svg.exe
-# windows (with ffmpeg)
-curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64-ffmpeg.zip -o console2svg-win-x64-ffmpeg.zip
-unzip console2svg-win-x64-ffmpeg.zip -d console2svg
-cd console2svg
+# macos
+curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-osx-arm64.tar.gz -o console2svg.tar.gz
+mkdir -p /usr/local/lib/console2svg
+tar -xzf console2svg.tar.gz -C /usr/local/lib/console2svg
+ln -sf /usr/local/lib/console2svg/bin/console2svg /usr/local/bin/console2svg
+
+# windows (bundled with ffmpeg)
+curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64.zip -o console2svg.zip
+unzip console2svg.zip -d console2svg
+# Add console2svg\bin\ to PATH, or use the full path console2svg\bin\console2svg.exe
 ```
 
 ### GitHub Actions
@@ -281,17 +286,14 @@ In v0.7 and later, you can specify the output format based on the file extension
 
 First, install `ffmpeg`.  
 On Linux/macOS, you can easily install it using a package manager.  
-On Windows, it's a bit more involved, so you can use the bundled version of ffmpeg ([x64](https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64-ffmpeg.zip), [arm64](https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-arm64-ffmpeg.zip)).
+On Windows, ffmpeg is bundled in the release archive, so no separate installation is required.
 
 ```bash
 # ubuntu
 sudo apt install ffmpeg
 # macos
 brew install ffmpeg
-# windows 
-curl -sSL https://github.com/arika0093/console2svg/releases/latest/download/console2svg-win-x64-ffmpeg.zip -o console2svg-win-x64-ffmpeg.zip
-unzip console2svg-win-x64-ffmpeg.zip
-cd console2svg
+# windows: ffmpeg is included in console2svg-win-x64.zip
 ```
 
 Then, you can specify the output file with the desired extension. For example, to convert an animated command to any format, you can use the following command:

--- a/action.yml
+++ b/action.yml
@@ -33,8 +33,7 @@ runs:
 
         INSTALL_DIR="${{ runner.tool_cache }}/console2svg/develop/${{ runner.arch }}"
         rm -rf "$INSTALL_DIR"
-        mkdir -p "$INSTALL_DIR/bin"
-        mkdir -p "$INSTALL_DIR/lib"
+        mkdir -p "$INSTALL_DIR"
         publish_dir="$INSTALL_DIR/publish"
 
         export NBGV_GitEngine=Disabled
@@ -46,35 +45,34 @@ runs:
           -o "$publish_dir"
 
         if [ -f "$publish_dir/ConsoleToSvg${EXT}" ]; then
-          cp "$publish_dir/ConsoleToSvg${EXT}" "$INSTALL_DIR/bin/console2svg${EXT}"
+          cp "$publish_dir/ConsoleToSvg${EXT}" "$INSTALL_DIR/console2svg${EXT}"
         elif [ -f "$publish_dir/console2svg${EXT}" ]; then
-          cp "$publish_dir/console2svg${EXT}" "$INSTALL_DIR/bin/console2svg${EXT}"
+          cp "$publish_dir/console2svg${EXT}" "$INSTALL_DIR/console2svg${EXT}"
         else
           echo "Published binary not found in $publish_dir"
           ls -la "$publish_dir"
           exit 1
         fi
 
+        # Native runtime libraries and child executables must be next to the executable.
         if [ -n "${EXT}" ]; then
-          # Windows: native DLLs and child executables must be next to the executable.
           for f in "$publish_dir"/*.dll; do
-            [ -f "$f" ] && cp "$f" "$INSTALL_DIR/bin/"
+            [ -f "$f" ] && cp "$f" "$INSTALL_DIR/"
           done
           for f in "$publish_dir"/*.exe; do
             [ -f "$f" ] || continue
             [ "$(basename "$f")" = "console2svg${EXT}" ] && continue
-            cp "$f" "$INSTALL_DIR/bin/"
+            cp "$f" "$INSTALL_DIR/"
           done
         else
-          # Linux/macOS: native libraries go in lib/ so the RPATH lookup works.
           for f in "$publish_dir"/*.so "$publish_dir"/*.dylib; do
-            [ -f "$f" ] && cp "$f" "$INSTALL_DIR/lib/"
+            [ -f "$f" ] && cp "$f" "$INSTALL_DIR/"
           done
         fi
 
-        [ -z "${EXT}" ] && chmod +x "$INSTALL_DIR/bin/console2svg"
+        [ -z "${EXT}" ] && chmod +x "$INSTALL_DIR/console2svg"
         rm -rf "$publish_dir"
-        echo "$INSTALL_DIR/bin" >> "$GITHUB_PATH"
+        echo "$INSTALL_DIR" >> "$GITHUB_PATH"
 
     - name: Download and install console2svg
       if: ${{ inputs.version != 'develop' }}
@@ -121,6 +119,6 @@ runs:
         fi
         rm -f "$archive_path"
 
-        [ -z "${EXT}" ] && chmod +x "${INSTALL_DIR}/bin/console2svg"
+        [ -z "${EXT}" ] && chmod +x "${INSTALL_DIR}/console2svg"
 
-        echo "${INSTALL_DIR}/bin" >> "$GITHUB_PATH"
+        echo "$INSTALL_DIR" >> "$GITHUB_PATH"

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,10 @@ runs:
         esac
 
         INSTALL_DIR="${{ runner.tool_cache }}/console2svg/develop/${{ runner.arch }}"
-        mkdir -p "$INSTALL_DIR"
+        rm -rf "$INSTALL_DIR"
+        mkdir -p "$INSTALL_DIR/bin"
+        mkdir -p "$INSTALL_DIR/lib"
+        publish_dir="$INSTALL_DIR/publish"
 
         export NBGV_GitEngine=Disabled
         dotnet publish "${{ github.action_path }}/src/ConsoleToSvg/ConsoleToSvg.csproj" \
@@ -40,20 +43,38 @@ runs:
           -r "$RID" \
           -p:PublishAot=true \
           -p:SelfContained=true \
-          -o "$INSTALL_DIR"
+          -o "$publish_dir"
 
-        if [ -f "$INSTALL_DIR/ConsoleToSvg${EXT}" ]; then
-          cp "$INSTALL_DIR/ConsoleToSvg${EXT}" "$INSTALL_DIR/console2svg${EXT}"
-        elif [ -f "$INSTALL_DIR/console2svg${EXT}" ]; then
-          :
+        if [ -f "$publish_dir/ConsoleToSvg${EXT}" ]; then
+          cp "$publish_dir/ConsoleToSvg${EXT}" "$INSTALL_DIR/bin/console2svg${EXT}"
+        elif [ -f "$publish_dir/console2svg${EXT}" ]; then
+          cp "$publish_dir/console2svg${EXT}" "$INSTALL_DIR/bin/console2svg${EXT}"
         else
-          echo "Published binary not found in $INSTALL_DIR"
-          ls -la "$INSTALL_DIR"
+          echo "Published binary not found in $publish_dir"
+          ls -la "$publish_dir"
           exit 1
         fi
 
-        [ -z "${EXT}" ] && chmod +x "$INSTALL_DIR/console2svg"
-        echo "$INSTALL_DIR" >> "$GITHUB_PATH"
+        if [ -n "${EXT}" ]; then
+          # Windows: native DLLs and child executables must be next to the executable.
+          for f in "$publish_dir"/*.dll; do
+            [ -f "$f" ] && cp "$f" "$INSTALL_DIR/bin/"
+          done
+          for f in "$publish_dir"/*.exe; do
+            [ -f "$f" ] || continue
+            [ "$(basename "$f")" = "console2svg${EXT}" ] && continue
+            cp "$f" "$INSTALL_DIR/bin/"
+          done
+        else
+          # Linux/macOS: native libraries go in lib/ so the RPATH lookup works.
+          for f in "$publish_dir"/*.so "$publish_dir"/*.dylib; do
+            [ -f "$f" ] && cp "$f" "$INSTALL_DIR/lib/"
+          done
+        fi
+
+        [ -z "${EXT}" ] && chmod +x "$INSTALL_DIR/bin/console2svg"
+        rm -rf "$publish_dir"
+        echo "$INSTALL_DIR/bin" >> "$GITHUB_PATH"
 
     - name: Download and install console2svg
       if: ${{ inputs.version != 'develop' }}
@@ -74,7 +95,11 @@ runs:
             ;;
         esac
 
-        FILE="console2svg-${RID}${EXT}"
+        if [ -n "${EXT}" ]; then
+          FILE="console2svg-${RID}.zip"
+        else
+          FILE="console2svg-${RID}.tar.gz"
+        fi
         if [ "$VERSION" = "latest" ]; then
           URL="https://github.com/arika0093/console2svg/releases/latest/download/${FILE}"
         else
@@ -82,10 +107,20 @@ runs:
         fi
 
         INSTALL_DIR="${{ runner.tool_cache }}/console2svg/${VERSION}/${{ runner.arch }}"
+        rm -rf "$INSTALL_DIR"
         mkdir -p "$INSTALL_DIR"
+        archive_path="${INSTALL_DIR}/${FILE}"
 
         echo "Downloading ${URL} ..."
-        curl -fsSL -L -o "${INSTALL_DIR}/console2svg${EXT}" "${URL}"
-        [ -z "${EXT}" ] && chmod +x "${INSTALL_DIR}/console2svg"
+        curl -fsSL -L -o "$archive_path" "$URL"
 
-        echo "${INSTALL_DIR}" >> "$GITHUB_PATH"
+        if [ -n "${EXT}" ]; then
+          unzip -q "$archive_path" -d "$INSTALL_DIR"
+        else
+          tar -xzf "$archive_path" -C "$INSTALL_DIR"
+        fi
+        rm -f "$archive_path"
+
+        [ -z "${EXT}" ] && chmod +x "${INSTALL_DIR}/bin/console2svg"
+
+        echo "${INSTALL_DIR}/bin" >> "$GITHUB_PATH"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install console2svg from GitHub releases.
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/arika0093/console2svg/main/install.sh | bash
+#   CONSOLE2SVG_VERSION=0.8.0 bash install.sh
+#   CONSOLE2SVG_INSTALL_DIR=/opt/console2svg bash install.sh
+
+REPO="arika0093/console2svg"
+VERSION="${CONSOLE2SVG_VERSION:-latest}"
+
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+case "$OS" in
+  Linux)
+    case "$ARCH" in
+      x86_64)  RID="linux-x64" ;;
+      aarch64) RID="linux-arm64" ;;
+      *) echo "Unsupported Linux architecture: $ARCH" >&2; exit 1 ;;
+    esac
+    ;;
+  Darwin)
+    case "$ARCH" in
+      x86_64) RID="osx-x64" ;;
+      arm64)  RID="osx-arm64" ;;
+      *) echo "Unsupported macOS architecture: $ARCH" >&2; exit 1 ;;
+    esac
+    ;;
+  *)
+    echo "Unsupported OS: $OS" >&2
+    echo "For Windows, use npm or download the zip archive manually." >&2
+    exit 1
+    ;;
+esac
+
+ARCHIVE="console2svg-${RID}.tar.gz"
+if [ "$VERSION" = "latest" ]; then
+  URL="https://github.com/${REPO}/releases/latest/download/${ARCHIVE}"
+else
+  URL="https://github.com/${REPO}/releases/download/v${VERSION}/${ARCHIVE}"
+fi
+
+# Choose install destination.
+if [ -n "${CONSOLE2SVG_INSTALL_DIR:-}" ]; then
+  INSTALL_DIR="$CONSOLE2SVG_INSTALL_DIR"
+  BIN_DIR="${CONSOLE2SVG_BIN_DIR:-$(dirname "$INSTALL_DIR")/bin}"
+elif [ -w /usr/local/lib ] && [ -w /usr/local/bin ]; then
+  INSTALL_DIR="/usr/local/lib/console2svg"
+  BIN_DIR="/usr/local/bin"
+else
+  INSTALL_DIR="${HOME}/.console2svg"
+  BIN_DIR="${HOME}/.local/bin"
+fi
+
+echo "Installing console2svg (${RID}) ..."
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+curl -fsSL -L -o "${TMP_DIR}/${ARCHIVE}" "$URL"
+
+mkdir -p "$INSTALL_DIR"
+tar -xzf "${TMP_DIR}/${ARCHIVE}" -C "$INSTALL_DIR"
+
+chmod +x "$INSTALL_DIR/console2svg"
+
+mkdir -p "$BIN_DIR"
+ln -sf "$INSTALL_DIR/console2svg" "$BIN_DIR/console2svg"
+
+echo "console2svg installed to $BIN_DIR/console2svg"
+if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
+  echo "Add $BIN_DIR to your PATH to use it."
+fi

--- a/src/ConsoleToSvg/Cli/OptionParser.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.cs
@@ -47,8 +47,8 @@ public static class OptionParser
                 -o, --out <path>          Output file path (default: output.svg).
                                           Extension determines format:
                                             .svg          – SVG output (default, no external tools required).
-                                            .png/.jpg/…   – Raster image via ffmpeg (ffmpeg must be installed).
-                                            .mp4/.webm/…  – Video via ffmpeg using frame sequences (ffmpeg must be installed).
+                                            .png          – Raster image via resvg.
+                                            .mp4/.webm/…  – Video using frame sequences via ffmpeg.
                 --stdout                  Write SVG to stdout instead of a file.
                                           PTY output forwarding is suppressed so the pipe receives only SVG.
                 -m, --mode <image|video|repeat>  Output mode (default: image).

--- a/src/ConsoleToSvg/ConsoleToSvg.csproj
+++ b/src/ConsoleToSvg/ConsoleToSvg.csproj
@@ -23,6 +23,21 @@
     <!-- Disable dotnet tool packaging for NativeAOT builds -->
     <PackAsTool>false</PackAsTool>
   </PropertyGroup>
+  <ItemGroup Condition="'$(PublishAot)' == 'true'">
+    <!-- NativeAOT binaries need to locate bundled native libraries at runtime.
+         The archive layout is bin/<binary> + lib/<native libs>, so ../lib is
+         searched. The rpm/deb layout is /usr/local/bin/<binary> +
+         /usr/local/lib/console2svg/<native libs>, so ../lib/console2svg is
+         also searched. Windows uses the executable directory directly.
+         Single quotes around the rpath value prevent shell expansion of $ORIGIN
+         during the NativeAOT link step. -->
+    <LinkerArg Include="-Wl,-rpath,'$ORIGIN'" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <LinkerArg Include="-Wl,-rpath,'$ORIGIN/../lib'" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <LinkerArg Include="-Wl,-rpath,'$ORIGIN/../lib/console2svg'" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <LinkerArg Include="-Wl,-rpath,'@loader_path'" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <LinkerArg Include="-Wl,-rpath,'@loader_path/../lib'" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <LinkerArg Include="-Wl,-rpath,'@loader_path/../lib/console2svg'" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+  </ItemGroup>
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="System.Runtime.EnableWriteXorExecute" Value="false" />
   </ItemGroup>

--- a/src/ConsoleToSvg/ConsoleToSvg.csproj
+++ b/src/ConsoleToSvg/ConsoleToSvg.csproj
@@ -25,17 +25,16 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(PublishAot)' == 'true'">
     <!-- NativeAOT binaries need to locate bundled native libraries at runtime.
-         The archive layout is bin/<binary> + lib/<native libs>, so ../lib is
-         searched. The rpm/deb layout is /usr/local/bin/<binary> +
-         /usr/local/lib/console2svg/<native libs>, so ../lib/console2svg is
-         also searched. Windows uses the executable directory directly.
+         Release archives use a flat layout, so the binary searches its own
+         directory ($ORIGIN / @loader_path). rpm/deb packages use
+         /usr/local/bin/<binary> + /usr/local/lib/console2svg/<native libs>, so
+         ../lib/console2svg is also searched. Windows uses the executable
+         directory directly.
          Single quotes around the rpath value prevent shell expansion of $ORIGIN
          during the NativeAOT link step. -->
     <LinkerArg Include="-Wl,-rpath,'$ORIGIN'" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <LinkerArg Include="-Wl,-rpath,'$ORIGIN/../lib'" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
     <LinkerArg Include="-Wl,-rpath,'$ORIGIN/../lib/console2svg'" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
     <LinkerArg Include="-Wl,-rpath,'@loader_path'" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-    <LinkerArg Include="-Wl,-rpath,'@loader_path/../lib'" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
     <LinkerArg Include="-Wl,-rpath,'@loader_path/../lib/console2svg'" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
   </ItemGroup>
   <ItemGroup>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.8.0",
+  "version": "0.8.0-rc1.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.8.0",
+  "version": "0.8.0-rc1",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.8.0-rc1.{height}",
+  "version": "0.8.0",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },

--- a/wrapper/npm/cli/console2svg.js
+++ b/wrapper/npm/cli/console2svg.js
@@ -7,7 +7,7 @@ const { spawn } = require('child_process');
 
 const isWin = process.platform === 'win32';
 const ext = isWin ? '.exe' : '';
-const binPath = path.join(__dirname, '..', 'dist', 'bin', `console2svg${ext}`);
+const binPath = path.join(__dirname, '..', 'dist', `console2svg${ext}`);
 
 if (!fs.existsSync(binPath)) {
   console.error('console2svg: binary not found.');

--- a/wrapper/npm/cli/console2svg.js
+++ b/wrapper/npm/cli/console2svg.js
@@ -7,7 +7,7 @@ const { spawn } = require('child_process');
 
 const isWin = process.platform === 'win32';
 const ext = isWin ? '.exe' : '';
-const binPath = path.join(__dirname, '..', 'dist', `console2svg${ext}`);
+const binPath = path.join(__dirname, '..', 'dist', 'bin', `console2svg${ext}`);
 
 if (!fs.existsSync(binPath)) {
   console.error('console2svg: binary not found.');

--- a/wrapper/npm/cli/install.js
+++ b/wrapper/npm/cli/install.js
@@ -40,8 +40,7 @@ if (platform === 'win32') {
 
 const isWin = platform === 'win32';
 const distDir = path.join(__dirname, '..', 'dist');
-const binaryDir = path.join(distDir, 'bin');
-const binaryPath = path.join(binaryDir, `console2svg${isWin ? '.exe' : ''}`);
+const binaryPath = path.join(distDir, `console2svg${isWin ? '.exe' : ''}`);
 
 if (fs.existsSync(binaryPath)) {
   process.exit(0);

--- a/wrapper/npm/cli/install.js
+++ b/wrapper/npm/cli/install.js
@@ -40,9 +40,10 @@ if (platform === 'win32') {
 
 const isWin = platform === 'win32';
 const distDir = path.join(__dirname, '..', 'dist');
-const destPath = path.join(distDir, `console2svg${isWin ? '.exe' : ''}`);
+const binaryDir = path.join(distDir, 'bin');
+const binaryPath = path.join(binaryDir, `console2svg${isWin ? '.exe' : ''}`);
 
-if (fs.existsSync(destPath)) {
+if (fs.existsSync(binaryPath)) {
   process.exit(0);
 }
 
@@ -66,7 +67,8 @@ function download(downloadUrl, redirects, onFinish) {
   const agent = proxy ? new HttpsProxyAgent(proxy) : undefined;
   const urlObj = new URL(downloadUrl);
 
-  const tempPath = `${destPath}.tmp`;
+  const archiveName = isWin ? `console2svg-${rid}.zip` : `console2svg-${rid}.tar.gz`;
+  const tempPath = path.join(distDir, `${archiveName}.tmp`);
 
   const request = https.get(
     {
@@ -105,11 +107,11 @@ function download(downloadUrl, redirects, onFinish) {
       });
       file.on('error', (err) => {
         try {
-            fs.unlinkSync(tempPath);
-          } catch {
-            // ignore
-          }
-          fail('console2svg: write failed.', err);
+          fs.unlinkSync(tempPath);
+        } catch {
+          // ignore
+        }
+        fail('console2svg: write failed.', err);
       });
     }
   );
@@ -119,47 +121,55 @@ function download(downloadUrl, redirects, onFinish) {
   });
 }
 
-if (isWin) {
-  // On Windows: download the ffmpeg bundle zip (console2svg.exe + ffmpeg.exe + DLLs)
-  const zipFileName = `console2svg-${rid}-ffmpeg.zip`;
-  const zipUrl = `https://github.com/arika0093/console2svg/releases/download/v${version}/${zipFileName}`;
+const archiveFileName = isWin
+  ? `console2svg-${rid}.zip`
+  : `console2svg-${rid}.tar.gz`;
+const archiveUrl = `https://github.com/arika0093/console2svg/releases/download/v${version}/${archiveFileName}`;
 
-  download(zipUrl, 0, (tempZipPath) => {
-    // Escape single quotes in paths for PowerShell single-quoted string literals.
+download(archiveUrl, 0, (tempArchivePath) => {
+  if (isWin) {
     const psEscape = (p) => p.replace(/'/g, "''");
-    // Extract the zip into distDir using PowerShell
     const result = spawnSync(
       'powershell',
       [
         '-NoProfile',
         '-NonInteractive',
         '-Command',
-        `Expand-Archive -LiteralPath '${psEscape(tempZipPath)}' -DestinationPath '${psEscape(distDir)}' -Force`
+        `Expand-Archive -LiteralPath '${psEscape(tempArchivePath)}' -DestinationPath '${psEscape(distDir)}' -Force`
       ],
       { stdio: 'inherit' }
     );
 
-    try { fs.unlinkSync(tempZipPath); } catch { /* ignore */ }
+    try { fs.unlinkSync(tempArchivePath); } catch { /* ignore */ }
 
     if (result.status !== 0) {
       fail('console2svg: failed to extract zip bundle.');
     }
+  } else {
+    const result = spawnSync(
+      'tar',
+      ['-xzf', tempArchivePath, '-C', distDir],
+      { stdio: 'inherit' }
+    );
 
-    if (!fs.existsSync(destPath)) {
-      fail('console2svg: console2svg.exe not found after extraction.');
+    try { fs.unlinkSync(tempArchivePath); } catch { /* ignore */ }
+
+    if (result.status !== 0) {
+      fail('console2svg: failed to extract tar.gz bundle.');
     }
 
-    process.exit(0);
-  });
-} else {
-  // On Linux/macOS: download the single binary
-  const fileName = `console2svg-${rid}`;
-  const url = `https://github.com/arika0093/console2svg/releases/download/v${version}/${fileName}`;
+    if (!isWin) {
+      try {
+        fs.chmodSync(binaryPath, 0o755);
+      } catch (err) {
+        fail('console2svg: failed to make binary executable.', err);
+      }
+    }
+  }
 
-  download(url, 0, (tempPath) => {
-    fs.renameSync(tempPath, destPath);
-    fs.chmodSync(destPath, 0o755);
-    process.exit(0);
-  });
-}
+  if (!fs.existsSync(binaryPath)) {
+    fail(`console2svg: expected binary not found at ${binaryPath} after extraction.`);
+  }
 
+  process.exit(0);
+});

--- a/wrapper/npm/package.json
+++ b/wrapper/npm/package.json
@@ -31,7 +31,8 @@
     "win32"
   ],
   "cpu": [
-    "x64"
+    "x64",
+    "arm64"
   ],
   "preferGlobal": true
 }


### PR DESCRIPTION
Closes the issue where `console2svg.exe -o test.mp4 -- dotnet --version` failed because the ResvgSharp native runtime (`resvg_wrapper.dll` / `libresvg_wrapper.so` / `libresvg_wrapper.dylib`) was not included in the release artifacts.

### Breaking change
Standalone releases are now archive-based (flat layout):
- Windows: `console2svg-win-x64.zip` / `console2svg-win-arm64.zip`
- Linux: `console2svg-linux-x64.tar.gz` / `console2svg-linux-arm64.tar.gz`
- macOS: `console2svg-osx-x64.tar.gz` / `console2svg-osx-arm64.tar.gz`

Archives contain the executable and native libraries in the same directory. The old single-file downloads and the separate `-ffmpeg` zip are removed. ffmpeg is now bundled inside the Windows archive in a `ffmpeg/` subdirectory.

### What changed
- Bumped version to `0.8.0`.
- Added NativeAOT RPATH linker args so the binary can locate bundled native libraries in the flat archive layout (`$ORIGIN` / `@loader_path`) and in rpm/deb packages (`$ORIGIN/../lib/console2svg` / `@loader_path/../lib/console2svg`).
- Updated `release.yaml` to build flat archives, bundle ffmpeg on Windows, and include `libresvg_wrapper.so` in `.deb` / `.rpm` packages.
  - Added ffmpeg zip integrity check (`unzip -t`) and SHA-256 print because BtbN's `latest` release assets are rolling and cannot be pinned.
- Updated `action.yml` to download and extract flat archives, and to copy native libs next to the binary for `develop` builds.
- Updated the npm wrapper to download flat archives and run the binary from `dist/`. Also added `arm64` to supported CPU architectures.
- Added root `install.sh` for Linux/macOS and simplified README installation instructions to use `curl | bash`.

### Verification
- Verified NativeAOT publish for `linux-x64` produces `libresvg_wrapper.so` alongside the binary.
- Verified the binary runs in the flat archive layout (executable + `.so` in the same directory).
- Verified the binary runs in the rpm/deb layout (`/usr/local/bin` + `/usr/local/lib/console2svg`).
- Verified `--svg-converter resvg -o test.mp4` works, confirming ResvgSharp loads correctly.
- `dotnet test` passes (299/299).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Linux/macOS installation script with automatic platform and architecture detection.
  * Added ARM64 support for the npm package.
  * Release archives now include required native runtime libraries and bundled Windows FFmpeg.

* **Bug Fixes**
  * Improved npm and GitHub Action installation across supported platforms.
  * Fixed native library placement for Linux packages and runtime loading on Linux/macOS.
  * Updated PNG conversion help to identify resvg as the rasterization tool.

* **Documentation**
  * Simplified installation and release archive guidance, including Windows PowerShell instructions.
  * Documented FFmpeg requirements for dotnet tool installations.

* **Release**
  * Updated version to 0.8.0-rc1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->