### PR TITLE
Skip system fonts in video mode for ResvgSharp

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
       version: ${{ steps.version.outputs.semver }}
       package-version: ${{ steps.version.outputs.package_version }}
       package-iteration: ${{ steps.version.outputs.package_iteration }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -61,10 +62,16 @@ jobs:
             package_iteration="${package_iteration}.${metadata}"
           fi
 
+          prerelease='false'
+          if [[ "$semver" == *-* ]]; then
+            prerelease='true'
+          fi
+
           {
             echo "semver=$semver"
             echo "package_version=$package_version"
             echo "package_iteration=$package_iteration"
+            echo "prerelease=$prerelease"
           } >> "$GITHUB_OUTPUT"
 
       - name: Restore dependencies
@@ -299,6 +306,7 @@ jobs:
           tag_name: v${{ needs.build-nupkg.outputs.version }}
           name: ${{ needs.build-nupkg.outputs.version }}
           generate_release_notes: true
+          prerelease: ${{ needs.build-nupkg.outputs.prerelease == 'true' }}
           files: ./release-upload/*
 
   release-nuget:
@@ -323,6 +331,7 @@ jobs:
 
   release-npm:
     needs: [build-nupkg, release-github]
+    if: ${{ needs.build-nupkg.outputs.prerelease != 'true' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ If you want to set a fixed width and height, you can use the `-w` and `-h` optio
 console2svg -w 120 -h 20 -- git log --oneline
 ```
 
+If you want to match the current terminal width, specify `-w adjust`.
+
+```sh
+console2svg -w adjust -h 20 -- git log --oneline
+```
+
 ### Static SVG with crop
 
 You can crop the output by specifying the number of pixels or characters to crop from each side.

--- a/src/ConsoleToSvg/Svg/SvgConverter.cs
+++ b/src/ConsoleToSvg/Svg/SvgConverter.cs
@@ -287,6 +287,7 @@ internal static class SvgConverter
                     effectiveConverter,
                     width,
                     height,
+                    skipSystemFonts: false,
                     logger,
                     cancellationToken
                 )
@@ -393,6 +394,7 @@ internal static class SvgConverter
                                 effectiveConverter,
                                 width,
                                 height,
+                                skipSystemFonts: true,
                                 logger,
                                 ct
                             )
@@ -431,6 +433,7 @@ internal static class SvgConverter
         SvgConverterMode converter,
         double? width,
         double? height,
+        bool skipSystemFonts,
         ILogger logger,
         CancellationToken cancellationToken
     )
@@ -458,6 +461,7 @@ internal static class SvgConverter
                     pngPath,
                     width,
                     height,
+                    skipSystemFonts,
                     logger,
                     cancellationToken
                 )
@@ -546,6 +550,7 @@ internal static class SvgConverter
         string pngPath,
         double? width,
         double? height,
+        bool skipSystemFonts,
         ILogger logger,
         CancellationToken cancellationToken
     )
@@ -568,7 +573,11 @@ internal static class SvgConverter
                     {
                         // Render the entire SVG viewport.
                         ExportAreaPage = true,
+                        // System font scanning dominates conversion time on Windows,
+                        // especially for video mode where it is repeated per frame.
+                        SkipSystemFonts = skipSystemFonts,
                     };
+
                     if (width.HasValue)
                     {
                         options.Width = ToPxInt(width.Value);


### PR DESCRIPTION
## Summary

Skip system font scanning when rendering video frames via ResvgSharp.

## Problem

ResvgSharp's native wrapper rebuilds the font database on every `RenderToPng` call and scans system fonts each time. On Windows this dominates conversion time, causing 100-frame videos to take ~2 minutes.

## Change

- **Video mode**: `SkipSystemFonts = true` when converting SVG frames to PNG via ResvgSharp
- **Image mode**: unchanged (still uses system fonts so single-frame output matches local fonts)

This is the minimal change to address the Windows video-mode slowness without affecting image output or adding bundled fonts.

## Note

This change means video frames rendered through ResvgSharp will use resvg's fallback font instead of the system monospace font. Text layout is still preserved via `textLength`, but glyph shapes may differ from the system font.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved release handling so prerelease builds are clearly identified and are not published as stable npm releases.
  * Video conversion can render frames more efficiently while preserving system font support for single-image SVG conversion.

* **Documentation**
  * Added instructions and an example for automatically matching the current terminal width with `-w adjust`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->