### PR TITLE
feat: implement interactive PTY capture handling

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,6 +46,10 @@ jobs:
 
       - name: Build
         run: dotnet build --no-restore
+        # Cargo's inherited workflow env file can contain malformed metadata on
+        # macOS runners. This build does not need to export variables to later steps.
+        env:
+          GITHUB_ENV: ${{ runner.os == 'Windows' && 'NUL' || '/dev/null' }}
 
       - name: Run tests
         run: dotnet test --no-build --verbosity normal

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 src/ConsoleToSvg.Converter/native/resvg-wrapper/target/
 native-assets/
 exported/
-output.svg
+output*.svg
 *.recieved.*
 frames-dir/
 output.mp4

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ console2svg -v -c -d macos -- copilot --banner
 
 ---
 
-In interactive mode(`-i`), you can run your normal interactive shell in a PTY and capture its current screen on demand. Press <kbd>F10</kbd> to write a static SVG, or <kbd>F9</kbd> to start recording from the exact current terminal state, then press <kbd>F9</kbd> again to save the recording.
+In interactive mode(`-i`), you can run your normal interactive shell in a PTY and capture its current screen on demand. Press `F10` to write a static SVG, or `F9` to start recording from the exact current terminal state.
 
 ```bash
 console2svg -i -d windows-pc -o ./captures/output.svg
@@ -203,12 +203,12 @@ console2svg -i -o ./captures/output.svg
 # -> writes ./captures/output_yyyyMMdd_HHmmss.svg (image)
 ```
 
-Press `F9` to start recording from the exact current terminal state, then press `F9` again to save the recording.
+Press `F9` to start recording from the exact current terminal state, `F12` to pause or resume it, then `F9` again to save the recording. Output and elapsed time while paused are excluded from the recording.
 The output format controls whether the capture is written as animated SVG or converted to the requested video format.
 
 ```sh
 console2svg -i -o ./captures/session.svg
-# -> writes ./captures/session_yyyyMMdd_HHmmss.svg (video)
+# -> writes ./captures/session_yyyyMMdd_HHmmss.svg (animation)
 ```
 
 ### Static SVG with crop

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ console2svg -w adjust -h 20 -- git log --oneline
 
 Run your normal interactive shell in a PTY and capture its current screen on demand.
 On Unix, `console2svg` uses `$SHELL`; on Windows, it uses the system command shell.
-The shell's output is forwarded live to your terminal. Press <kbd>F12</kbd> to write a
+The shell's output is forwarded live to your terminal. Press <kbd>F10</kbd> to write a
 static SVG; the capture notification is printed by the host and is not sent to the shell.
 
 ```sh
@@ -184,8 +184,9 @@ console2svg --interactive -o ./captures/output.svg
 # writes ./captures/output_yyyyMMdd_HHmmss.svg
 ```
 
-With `-v` (or `--mode video`), the first F12 press starts recording from the exact
-current terminal state and the second press writes an animated SVG.
+Press <kbd>F9</kbd> to start recording from the exact current terminal state, then press
+<kbd>F9</kbd> again to save the recording. The output format controls whether the capture
+is written as animated SVG or converted to the requested video format.
 
 ```sh
 console2svg --interactive -v -o ./captures/session.svg

--- a/README.md
+++ b/README.md
@@ -172,6 +172,25 @@ If you want to match the current terminal width, specify `-w adjust`.
 console2svg -w adjust -h 20 -- git log --oneline
 ```
 
+### Interactive capture
+
+Run your normal interactive shell in a PTY and capture its current screen on demand.
+On Unix, `console2svg` uses `$SHELL`; on Windows, it uses the system command shell.
+The shell's output is forwarded live to your terminal. Press <kbd>F12</kbd> to write a
+static SVG; the capture notification is printed by the host and is not sent to the shell.
+
+```sh
+console2svg --interactive -o ./captures/output.svg
+# writes ./captures/output_yyyyMMdd_HHmmss.svg
+```
+
+With `-v` (or `--mode video`), the first F12 press starts recording from the exact
+current terminal state and the second press writes an animated SVG.
+
+```sh
+console2svg --interactive -v -o ./captures/session.svg
+```
+
 ### Static SVG with crop
 
 You can crop the output by specifying the number of pixels or characters to crop from each side.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
-# console2svg
-Easily convert terminal output into SVG images. truecolor, animation, cropping and many appearance options are supported.
+<div align="center">
 
 ![console2svg hero image with oh-my-logo](./assets/cmd-hero.svg)
 
-> Of course, this hero image is [generated](https://github.com/arika0093/console2svg/blob/main/scripts/image-gen.sh#L2-L3) using console2svg itself.
+[![NuGet Version](https://img.shields.io/nuget/v/ConsoleToSvg?style=flat-square&logo=NuGet&color=0080CC)](https://www.nuget.org/packages/ConsoleToSvg/) [![npm version](https://img.shields.io/npm/v/console2svg?style=flat-square&logo=npm&color=0080CC)](https://www.npmjs.com/package/console2svg) [![GitHub Release](https://img.shields.io/github/v/release/arika0093/console2svg?style=flat-square&logo=github&label=GitHub%20Release&color=%230080CC)](https://github.com/arika0093/console2svg/releases/latest)
 
+Easily convert terminal output into SVG images. <br/>
+Truecolor, animation, cropping and many appearance options are supported.
+
+</div>
+
+# console2svg
 
 * [Why console2svg?](#why-console2svg)
 * [Overview](#overview)
@@ -21,11 +26,14 @@ There are similar tools, but console2svg stands out for:
 
 * [**No dependencies**](#install): no additional software or libraries required. Everything you need is included.
 * [**Video mode**](#animated-svg): save command execution animations as SVG. great for documentation and blog posts.
+* [**Interactive capture**](#interactive-capture): capture the current terminal screen on demand, or record a session and save it as an animated SVG.
 * [**Crop**](#static-svg-with-crop): trim specific parts of the output. Crop based on text patterns is also supported, making it easy to trim specific lines or sections.
 * [**Background and window**](#window-chrome): add background and window frames to produce presentation-ready SVGs for documentation, blogs, social media, etc.
 * [**CI friendly**](#github-actions): with features like replay and timeout, it can generate both static and animated SVGs in CI environments, minimizing discrepancies between code and images.
 * [**Windows support**](#supported-platforms): works on Windows, macOS and Linux.
 * [**Support many format**](#convert-to-other-formats): By incorporating `ffmpeg` and `resvg`, it can output not only SVG but also various formats such as PNG, MP4, GIF, etc.
+
+> Of course, this hero image is [generated](https://github.com/arika0093/console2svg/blob/main/scripts/image-gen.sh#L2-L3) using console2svg itself.
 
 ## Overview
 
@@ -57,8 +65,19 @@ console2svg -v -c -d macos -- copilot --banner
 
 ![console2svg -v -c -d macos -- copilot --banner](./assets/cmd-loop.svg)
 
+---
+
+In interactive mode(`-i`), you can run your normal interactive shell in a PTY and capture its current screen on demand. Press <kbd>F10</kbd> to write a static SVG, or <kbd>F9</kbd> to start recording from the exact current terminal state, then press <kbd>F9</kbd> again to save the recording.
+
+```bash
+console2svg -i -d windows-pc -o ./captures/output.svg
+# -> saves ./captures/output_yyyyMMdd_HHmmss.svg
+```
+
+![console2svg -i -d windows-pc -o ./captures/output.svg](./assets/cmd-interactive.svg)
+
+
 ## Install
-[![NuGet Version](https://img.shields.io/nuget/v/ConsoleToSvg?style=flat-square&logo=NuGet&color=0080CC)](https://www.nuget.org/packages/ConsoleToSvg/) [![npm version](https://img.shields.io/npm/v/console2svg?style=flat-square&logo=npm&color=0080CC)](https://www.npmjs.com/package/console2svg) [![GitHub Release](https://img.shields.io/github/v/release/arika0093/console2svg?style=flat-square&logo=github&label=GitHub%20Release&color=%230080CC)](https://github.com/arika0093/console2svg/releases/latest)
 
 The easiest way on Linux/macOS is the install script. Windows users can use npm or download the zip.
 
@@ -176,20 +195,20 @@ console2svg -w adjust -h 20 -- git log --oneline
 
 Run your normal interactive shell in a PTY and capture its current screen on demand.
 On Unix, `console2svg` uses `$SHELL`; on Windows, it uses the system command shell.
-The shell's output is forwarded live to your terminal. Press <kbd>F10</kbd> to write a
+The shell's output is forwarded live to your terminal. Press `F10` to write a
 static SVG; the capture notification is printed by the host and is not sent to the shell.
 
 ```sh
-console2svg --interactive -o ./captures/output.svg
-# writes ./captures/output_yyyyMMdd_HHmmss.svg
+console2svg -i -o ./captures/output.svg
+# -> writes ./captures/output_yyyyMMdd_HHmmss.svg (image)
 ```
 
-Press <kbd>F9</kbd> to start recording from the exact current terminal state, then press
-<kbd>F9</kbd> again to save the recording. The output format controls whether the capture
-is written as animated SVG or converted to the requested video format.
+Press `F9` to start recording from the exact current terminal state, then press `F9` again to save the recording.
+The output format controls whether the capture is written as animated SVG or converted to the requested video format.
 
 ```sh
-console2svg --interactive -v -o ./captures/session.svg
+console2svg -i -o ./captures/session.svg
+# -> writes ./captures/session_yyyyMMdd_HHmmss.svg (video)
 ```
 
 ### Static SVG with crop
@@ -457,6 +476,7 @@ tmux capture-pane -pe -S - -t :0 | console2svg -o full-capture-$(date +%s).svg
 * `-w`: width of the output SVG (default: terminal width[pipe], 100ch[pty])
 * `-h`: height of the output SVG (default: terminal height[pipe], auto[pty])
 * `-v`: output to video mode SVG (animated, looped by default)
+* `-i`: interactive mode (run a shell in a PTY and capture the current screen on demand)
 * `-d`: window chrome style (none, macos, windows, macos-pc, windows-pc, transparent, ...)
 * `--background`: background color or image for the output SVG
 * `--forecolor`: override default console foreground color

--- a/assets/cmd-interactive.svg
+++ b/assets/cmd-interactive.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1307.2" height="386" viewBox="0 0 1307.2 386" role="img" aria-label="console2svg output">
+<style>
+.crt {
+  font-family: "JetBrains Mono","Cascadia Mono","Segoe UI Mono","Noto Sans Mono","SFMono-Regular",Menlo,Consolas,"DejaVu Sans Mono","Liberation Mono",monospace;
+  font-size: 14px;
+}
+text {
+  dominant-baseline: alphabetic;
+}
+.bg {
+  shape-rendering: crispEdges;
+}
+</style>
+<defs>
+<linearGradient id="desktop-bg" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#1a2535"/><stop offset="100%" stop-color="#253345"/></linearGradient>
+</defs>
+<rect width="1307.2" height="386" fill="url(#desktop-bg)"/>
+<rect x="26" y="26" width="1261.2" height="340" fill="black" fill-opacity="0.25"/>
+<rect x="20.5" y="20.5" width="1260.2" height="339" fill="#333" stroke="#333"/>
+<rect x="21" y="21" width="1259.2" height="34" fill="#333"/>
+<path d="M 28,55 L 28,31 Q 28,26 33,26 L 183,26 Q 188,26 188,31 L 188,55 Z" fill="#0c0c0c"/>
+<polyline points="36,35.5 40,39.5 36,43.5" fill="none" stroke="#cccccc" stroke-width="1.2" stroke-linejoin="round"/>
+<line x1="43" y1="44" x2="49" y2="44" stroke="#cccccc" stroke-width="1.2"/>
+<line x1="172.5" y1="36" x2="179.5" y2="43" stroke="#888888" stroke-width="1.1"/>
+<line x1="179.5" y1="36" x2="172.5" y2="43" stroke="#888888" stroke-width="1.1"/>
+<line x1="1161.2" y1="39.5" x2="1171.2" y2="39.5" stroke="#cccccc" stroke-width="1.2"/>
+<rect x="1207.2" y="34.5" width="10" height="10" fill="none" stroke="#cccccc" stroke-width="1.2"/>
+<line x1="1253.2" y1="34.5" x2="1263.2" y2="44.5" stroke="#cccccc" stroke-width="1.3"/>
+<line x1="1263.2" y1="34.5" x2="1253.2" y2="44.5" stroke="#cccccc" stroke-width="1.3"/>
+<rect x="21" y="55" width="1259.2" height="304" fill="#0c0c0c"/>
+<g transform="translate(29 63)">
+<rect width="1243.2" height="288" fill="#0c0c0c"/>
+<rect class="bg" x="940.8" y="0" width="294" height="18" fill="#87D787"/>
+<text class="crt" x="0" y="14" fill="#0dbc79" textLength="75.6" lengthAdjust="spacing">codespace</text>
+<text class="crt" x="84" y="14" fill="#F63B3B" textLength="8.4" lengthAdjust="spacing" style="font-weight:bold;">➜</text>
+<text class="crt" x="100.8" y="14" fill="#2B89F0" textLength="92.4" lengthAdjust="spacing" style="font-weight:bold;">~/workspace</text>
+<text class="crt" x="201.6" y="14" fill="#11a8cd" textLength="8.4" lengthAdjust="spacing">(</text>
+<text class="crt" x="210" y="14" fill="#F63B3B" textLength="226.8" lengthAdjust="spacing" style="font-weight:bold;">feature/interactive-capture</text>
+<text class="crt" x="436.8" y="14" fill="#11a8cd" textLength="8.4" lengthAdjust="spacing">)</text>
+<text class="crt" x="453.6" y="14" fill="#d4d4d4" textLength="8.4" lengthAdjust="spacing">$</text>
+<text class="crt" x="470.4" y="14" fill="#d4d4d4" textLength="25.2" lengthAdjust="spacing">cat</text>
+<text class="crt" x="504" y="14" fill="#d4d4d4" textLength="126" lengthAdjust="spacing">/etc/os-release</text>
+<text class="crt" x="957.6" y="14" fill="#1e1e1e" textLength="25.2" lengthAdjust="spacing">F9:</text>
+<text class="crt" x="991.2" y="14" fill="#1e1e1e" textLength="50.4" lengthAdjust="spacing">Record</text>
+<text class="crt" x="1050" y="14" fill="#1e1e1e" textLength="42" lengthAdjust="spacing">start</text>
+<text class="crt" x="1117.2" y="14" fill="#1e1e1e" textLength="33.6" lengthAdjust="spacing">F10:</text>
+<text class="crt" x="1159.2" y="14" fill="#1e1e1e" textLength="58.8" lengthAdjust="spacing">Capture</text>
+<text class="crt" x="0" y="32" fill="#d4d4d4" textLength="159.6" lengthAdjust="spacing">PRETTY_NAME=&quot;Ubuntu</text>
+<text class="crt" x="168" y="32" fill="#d4d4d4" textLength="58.8" lengthAdjust="spacing">24.04.4</text>
+<text class="crt" x="235.2" y="32" fill="#d4d4d4" textLength="33.6" lengthAdjust="spacing">LTS&quot;</text>
+<text class="crt" x="0" y="50" fill="#d4d4d4" textLength="109.2" lengthAdjust="spacing">NAME=&quot;Ubuntu&quot;</text>
+<text class="crt" x="0" y="68" fill="#d4d4d4" textLength="151.2" lengthAdjust="spacing">VERSION_ID=&quot;24.04&quot;</text>
+<text class="crt" x="0" y="86" fill="#d4d4d4" textLength="134.4" lengthAdjust="spacing">VERSION=&quot;24.04.4</text>
+<text class="crt" x="142.8" y="86" fill="#d4d4d4" textLength="25.2" lengthAdjust="spacing">LTS</text>
+<text class="crt" x="176.4" y="86" fill="#d4d4d4" textLength="50.4" lengthAdjust="spacing">(Noble</text>
+<text class="crt" x="235.2" y="86" fill="#d4d4d4" textLength="67.2" lengthAdjust="spacing">Numbat)&quot;</text>
+<text class="crt" x="0" y="104" fill="#d4d4d4" textLength="184.8" lengthAdjust="spacing">VERSION_CODENAME=noble</text>
+<text class="crt" x="0" y="122" fill="#d4d4d4" textLength="75.6" lengthAdjust="spacing">ID=ubuntu</text>
+<text class="crt" x="0" y="140" fill="#d4d4d4" textLength="117.6" lengthAdjust="spacing">ID_LIKE=debian</text>
+<text class="crt" x="0" y="158" fill="#d4d4d4" textLength="285.6" lengthAdjust="spacing">HOME_URL=&quot;https://www.ubuntu.com/&quot;</text>
+<text class="crt" x="0" y="176" fill="#d4d4d4" textLength="319.2" lengthAdjust="spacing">SUPPORT_URL=&quot;https://help.ubuntu.com/&quot;</text>
+<text class="crt" x="0" y="194" fill="#d4d4d4" textLength="428.4" lengthAdjust="spacing">BUG_REPORT_URL=&quot;https://bugs.launchpad.net/ubuntu/&quot;</text>
+<text class="crt" x="0" y="212" fill="#d4d4d4" textLength="697.2" lengthAdjust="spacing">PRIVACY_POLICY_URL=&quot;https://www.ubuntu.com/legal/terms-and-policies/privacy-policy&quot;</text>
+<text class="crt" x="0" y="230" fill="#d4d4d4" textLength="176.4" lengthAdjust="spacing">UBUNTU_CODENAME=noble</text>
+<text class="crt" x="0" y="248" fill="#d4d4d4" textLength="134.4" lengthAdjust="spacing">LOGO=ubuntu-logo</text>
+<text class="crt" x="0" y="266" fill="#0dbc79" textLength="75.6" lengthAdjust="spacing">codespace</text>
+<text class="crt" x="84" y="266" fill="#d4d4d4" textLength="8.4" lengthAdjust="spacing">➜</text>
+<text class="crt" x="100.8" y="266" fill="#2B89F0" textLength="92.4" lengthAdjust="spacing" style="font-weight:bold;">~/workspace</text>
+<text class="crt" x="201.6" y="266" fill="#11a8cd" textLength="8.4" lengthAdjust="spacing">(</text>
+<text class="crt" x="210" y="266" fill="#F63B3B" textLength="226.8" lengthAdjust="spacing" style="font-weight:bold;">feature/interactive-capture</text>
+<text class="crt" x="436.8" y="266" fill="#11a8cd" textLength="8.4" lengthAdjust="spacing">)</text>
+<text class="crt" x="453.6" y="266" fill="#d4d4d4" textLength="8.4" lengthAdjust="spacing">$</text>
+</g>
+</svg>

--- a/src/ConsoleToSvg.Converter/ConsoleToSvg.Converter.Native.targets
+++ b/src/ConsoleToSvg.Converter/ConsoleToSvg.Converter.Native.targets
@@ -2,6 +2,10 @@
   <PropertyGroup>
     <ResvgNativeRuntimeIdentifier Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</ResvgNativeRuntimeIdentifier>
     <ResvgNativeRuntimeIdentifier Condition="'$(ResvgNativeRuntimeIdentifier)' == ''">$(NETCoreSdkRuntimeIdentifier)</ResvgNativeRuntimeIdentifier>
+    <!-- ResvgBuild was used by the CLI development command before this target
+         adopted the more descriptive BuildResvgNative property. Keep it as an
+         alias so `-p ResvgBuild=false` still disables the local Cargo build. -->
+    <BuildResvgNative Condition="'$(ResvgBuild)' != ''">$(ResvgBuild)</BuildResvgNative>
     <BuildResvgNative Condition="'$(BuildResvgNative)' == '' and ('$(RuntimeIdentifier)' != '' Or '$(TargetFramework)' == 'net10.0')">true</BuildResvgNative>
     <ResvgNativeRustTarget Condition="'$(ResvgNativeRuntimeIdentifier)' == 'linux-x64'">x86_64-unknown-linux-gnu</ResvgNativeRustTarget>
     <ResvgNativeRustTarget Condition="'$(ResvgNativeRuntimeIdentifier)' == 'linux-arm64'">aarch64-unknown-linux-gnu</ResvgNativeRustTarget>

--- a/src/ConsoleToSvg.Converter/SvgConverter.cs
+++ b/src/ConsoleToSvg.Converter/SvgConverter.cs
@@ -644,13 +644,7 @@ public static class SvgConverter
     {
         logger.ZLogDebug($"Running ffmpeg: {ffmpegPath} {string.Join(' ', args)}");
 
-        using var process = new Process();
-        process.StartInfo.FileName = ffmpegPath;
-        process.StartInfo.UseShellExecute = false;
-        foreach (var arg in args)
-        {
-            process.StartInfo.ArgumentList.Add(arg);
-        }
+        using var process = new Process { StartInfo = CreateFfmpegStartInfo(ffmpegPath, args) };
 
         try
         {
@@ -666,6 +660,12 @@ public static class SvgConverter
             );
         }
 
+        // ffmpeg's progress and diagnostics must not be written into the interactive
+        // terminal. Start draining both streams immediately to avoid blocking when a
+        // conversion produces enough output to fill an OS pipe buffer.
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var standardErrorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
         using var killOnCancel = cancellationToken.Register(() =>
         {
             try { process.Kill(entireProcessTree: true); }
@@ -673,6 +673,8 @@ public static class SvgConverter
         });
 
         await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        await standardOutputTask.ConfigureAwait(false);
+        var standardError = await standardErrorTask.ConfigureAwait(false);
 
         if (process.ExitCode != 0)
         {
@@ -680,10 +682,47 @@ public static class SvgConverter
                 $"ffmpeg exited with code {process.ExitCode}. "
                 + "Ensure ffmpeg supports the requested output format "
                 + "(SVG input requires the librsvg input device)."
+                + FormatFfmpegError(standardError)
             );
         }
 
         logger.ZLogDebug($"ffmpeg completed successfully.");
+    }
+
+    private static ProcessStartInfo CreateFfmpegStartInfo(string ffmpegPath, string[] args)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = ffmpegPath,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+
+        foreach (var arg in args)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        return startInfo;
+    }
+
+    private static string FormatFfmpegError(string standardError)
+    {
+        if (string.IsNullOrWhiteSpace(standardError))
+        {
+            return string.Empty;
+        }
+
+        const int maxLength = 2_000;
+        var details = standardError.Trim();
+        if (details.Length > maxLength)
+        {
+            details = details[^maxLength..];
+        }
+
+        return $"\nffmpeg stderr:\n{details}";
     }
 
     /// <summary>

--- a/src/ConsoleToSvg.Core/Svg/AnimatedSvgRenderer.cs
+++ b/src/ConsoleToSvg.Core/Svg/AnimatedSvgRenderer.cs
@@ -19,13 +19,28 @@ public static class AnimatedSvgRenderer
         var emulator = new TerminalEmulator(session.Header.width, session.Header.height, theme);
         var frames = emulator.ReplayFrames(session);
         frames = TrimTrailingAltScreenRestoreFrame(frames, session);
-        frames = NormalizeTiming(frames, options.VideoFps, options.VideoTiming);
 
         if (frames.Count == 0)
         {
             return SvgRenderer.Render(session, options);
         }
 
+        return RenderFrames(frames, options);
+    }
+
+    /// <summary>Renders terminal frames captured from an already-running interactive terminal.</summary>
+    public static string RenderFrames(
+        System.Collections.Generic.IReadOnlyList<TerminalFrame> frames,
+        SvgRenderOptions options
+    )
+    {
+        if (frames.Count == 0)
+        {
+            throw new ArgumentException("At least one terminal frame is required.", nameof(frames));
+        }
+
+        var theme = SvgRenderShared.ResolveTheme(options);
+        frames = NormalizeTiming(frames, options.VideoFps, options.VideoTiming);
         var reducedFrames = ReduceFrames(frames, options.VideoFps);
         reducedFrames = SpreadCollapsedFrameTimes(reducedFrames, options.VideoFps);
 
@@ -73,7 +88,7 @@ public static class AnimatedSvgRenderer
 
             if (filtered.Count == 0)
             {
-                return SvgRenderer.Render(session, options);
+                return SvgRenderer.Render(reducedFrames[0].Buffer, options);
             }
 
             reducedFrames = filtered;

--- a/src/ConsoleToSvg.Core/Svg/AnimatedSvgRenderer.cs
+++ b/src/ConsoleToSvg.Core/Svg/AnimatedSvgRenderer.cs
@@ -72,14 +72,19 @@ public static class AnimatedSvgRenderer
             // correct terminal state at the start of the time window.
             if (lastBeforeRange is not null)
             {
-                filtered.Insert(0, lastBeforeRange);
+                filtered.Insert(
+                    0,
+                    options.TimeStart.HasValue
+                        ? new TerminalFrame(rangeStart, lastBeforeRange.Buffer)
+                        : lastBeforeRange
+                );
             }
 
             // Rebase timestamps so the clip starts at t=0 instead of the
             // original absolute time (e.g., --time 5-6 → clip from 0 to 1s).
             if (filtered.Count > 0)
             {
-                var baseTime = filtered[0].Time;
+                var baseTime = options.TimeStart ?? filtered[0].Time;
                 for (var i = 0; i < filtered.Count; i++)
                 {
                     filtered[i] = new TerminalFrame(filtered[i].Time - baseTime, filtered[i].Buffer);

--- a/src/ConsoleToSvg.Core/Svg/SvgRenderer.cs
+++ b/src/ConsoleToSvg.Core/Svg/SvgRenderer.cs
@@ -30,10 +30,20 @@ public static class SvgRenderer
             emulator.Replay(session, targetFrame);
         }
 
+        return Render(emulator.Buffer, options, includeScrollback: effectiveFrame == null);
+    }
+
+    /// <summary>Renders an already-emulated terminal screen.</summary>
+    public static string Render(
+        ScreenBuffer buffer,
+        SvgRenderOptions options,
+        bool includeScrollback = false
+    )
+    {
+        var theme = SvgRenderShared.ResolveTheme(options);
         var commandHeaderRows = string.IsNullOrEmpty(options.CommandHeader) ? 0 : 1;
-        var includeScrollback = effectiveFrame == null;
         var context = SvgRenderShared.CreateContext(
-            emulator.Buffer,
+            buffer,
             options,
             includeScrollback,
             commandHeaderRows
@@ -52,7 +62,7 @@ public static class SvgRenderer
         );
         SvgDocumentBuilder.AppendFrameGroup(
             sb.Inner,
-            emulator.Buffer,
+            buffer,
             context,
             theme,
             id: null,

--- a/src/ConsoleToSvg.Record/InteractiveInputRouter.cs
+++ b/src/ConsoleToSvg.Record/InteractiveInputRouter.cs
@@ -36,6 +36,10 @@ public sealed class InteractiveInputRouter
     {
         if (value == 0x04)
         {
+            // Let Unix shells receive EOT so Bash can close normally. Windows
+            // cmd.exe does not treat it as EOF, so the caller also receives the
+            // explicit Exit action and can close the recording session there.
+            forwarded.Add(value);
             return InteractiveInputAction.Exit;
         }
 

--- a/src/ConsoleToSvg.Record/InteractiveInputRouter.cs
+++ b/src/ConsoleToSvg.Record/InteractiveInputRouter.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+
+namespace ConsoleToSvg.Recording;
+
+/// <summary>Classifies interactive capture keys while preserving all other VT input.</summary>
+public enum InteractiveInputAction
+{
+    None,
+    Screenshot,
+    ToggleRecording,
+    Exit,
+}
+
+public sealed class InteractiveInputRouter
+{
+    private readonly byte[] _screenshotKey;
+    private readonly byte[] _recordingKey;
+    private readonly List<byte> _pending;
+    private bool _discardingSgrMouseReport;
+
+    public InteractiveInputRouter(ReadOnlySpan<byte> screenshotKey, ReadOnlySpan<byte> recordingKey)
+    {
+        _screenshotKey = screenshotKey.ToArray();
+        _recordingKey = recordingKey.ToArray();
+        _pending = new List<byte>(Math.Max(_screenshotKey.Length, _recordingKey.Length));
+    }
+
+    public bool HasStandaloneEscape => _pending.Count == 1 && _pending[0] == 0x1b;
+
+    /// <summary>
+    /// Routes one byte. Non-capture sequences are appended to <paramref name="forwarded"/>
+    /// unchanged and as a single sequence.
+    /// </summary>
+    public InteractiveInputAction Process(byte value, List<byte> forwarded)
+    {
+        if (value == 0x04)
+        {
+            return InteractiveInputAction.Exit;
+        }
+
+        if (_discardingSgrMouseReport)
+        {
+            if (value is (byte)'M' or (byte)'m')
+            {
+                _discardingSgrMouseReport = false;
+            }
+
+            return InteractiveInputAction.None;
+        }
+
+        _pending.Add(value);
+        if (IsPrefix(_pending, _screenshotKey) || IsPrefix(_pending, _recordingKey))
+        {
+            if (_pending.Count == _screenshotKey.Length && IsPrefix(_pending, _screenshotKey))
+            {
+                _pending.Clear();
+                return InteractiveInputAction.Screenshot;
+            }
+
+            if (_pending.Count == _recordingKey.Length && IsPrefix(_pending, _recordingKey))
+            {
+                _pending.Clear();
+                return InteractiveInputAction.ToggleRecording;
+            }
+
+            return InteractiveInputAction.None;
+        }
+
+        if (IsSgrMouseReportPrefix(_pending))
+        {
+            _pending.Clear();
+            _discardingSgrMouseReport = true;
+            return InteractiveInputAction.None;
+        }
+
+        ForwardPending(forwarded);
+        return InteractiveInputAction.None;
+    }
+
+    public void ForwardPending(List<byte> forwarded)
+    {
+        forwarded.AddRange(_pending);
+        _pending.Clear();
+    }
+
+    private static bool IsPrefix(List<byte> value, ReadOnlySpan<byte> expected)
+    {
+        if (value.Count > expected.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < value.Count; i++)
+        {
+            if (value[i] != expected[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsSgrMouseReportPrefix(List<byte> value) =>
+        value.Count == 3 && value[0] == 0x1b && value[1] == (byte)'[' && value[2] == (byte)'<';
+}

--- a/src/ConsoleToSvg.Record/InteractiveInputRouter.cs
+++ b/src/ConsoleToSvg.Record/InteractiveInputRouter.cs
@@ -9,6 +9,7 @@ public enum InteractiveInputAction
     None,
     Screenshot,
     ToggleRecording,
+    TogglePause,
     Exit,
 }
 
@@ -16,14 +17,22 @@ public sealed class InteractiveInputRouter
 {
     private readonly byte[] _screenshotKey;
     private readonly byte[] _recordingKey;
+    private readonly byte[] _pauseKey;
     private readonly List<byte> _pending;
     private bool _discardingSgrMouseReport;
 
-    public InteractiveInputRouter(ReadOnlySpan<byte> screenshotKey, ReadOnlySpan<byte> recordingKey)
+    public InteractiveInputRouter(
+        ReadOnlySpan<byte> screenshotKey,
+        ReadOnlySpan<byte> recordingKey,
+        ReadOnlySpan<byte> pauseKey
+    )
     {
         _screenshotKey = screenshotKey.ToArray();
         _recordingKey = recordingKey.ToArray();
-        _pending = new List<byte>(Math.Max(_screenshotKey.Length, _recordingKey.Length));
+        _pauseKey = pauseKey.ToArray();
+        _pending = new List<byte>(
+            Math.Max(_screenshotKey.Length, Math.Max(_recordingKey.Length, _pauseKey.Length))
+        );
     }
 
     public bool HasStandaloneEscape => _pending.Count == 1 && _pending[0] == 0x1b;
@@ -54,7 +63,11 @@ public sealed class InteractiveInputRouter
         }
 
         _pending.Add(value);
-        if (IsPrefix(_pending, _screenshotKey) || IsPrefix(_pending, _recordingKey))
+        if (
+            IsPrefix(_pending, _screenshotKey)
+            || IsPrefix(_pending, _recordingKey)
+            || IsPrefix(_pending, _pauseKey)
+        )
         {
             if (_pending.Count == _screenshotKey.Length && IsPrefix(_pending, _screenshotKey))
             {
@@ -66,6 +79,12 @@ public sealed class InteractiveInputRouter
             {
                 _pending.Clear();
                 return InteractiveInputAction.ToggleRecording;
+            }
+
+            if (_pending.Count == _pauseKey.Length && IsPrefix(_pending, _pauseKey))
+            {
+                _pending.Clear();
+                return InteractiveInputAction.TogglePause;
             }
 
             return InteractiveInputAction.None;

--- a/src/ConsoleToSvg.Record/InteractiveRecorder.cs
+++ b/src/ConsoleToSvg.Record/InteractiveRecorder.cs
@@ -43,6 +43,7 @@ public static class InteractiveRecorder
         Theme theme,
         ReadOnlyMemory<byte> screenshotKey,
         ReadOnlyMemory<byte> recordingKey,
+        ReadOnlyMemory<byte> pauseKey,
         bool noDeleteEnvs,
         string[]? command,
         bool exitOnCtrlD,
@@ -51,9 +52,9 @@ public static class InteractiveRecorder
         ILogger? logger = null
     )
     {
-        if (screenshotKey.IsEmpty || recordingKey.IsEmpty)
+        if (screenshotKey.IsEmpty || recordingKey.IsEmpty || pauseKey.IsEmpty)
         {
-            throw new ArgumentException("Screenshot and recording keys are required.");
+            throw new ArgumentException("Screenshot, recording, and pause keys are required.");
         }
 
         logger ??= Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
@@ -64,9 +65,12 @@ public static class InteractiveRecorder
         var notificationColumn = 1;
         var notificationLength = 0;
         var recordingIndicatorActive = 0;
+        var recordingPaused = 0;
         var startupIndicatorActive = 0;
         List<TerminalFrame>? videoFrames = null;
         var videoStarted = 0d;
+        var videoPausedAt = 0d;
+        var videoPausedDuration = 0d;
         var stopwatch = Stopwatch.StartNew();
         long lastOutputTimestamp = Stopwatch.GetTimestamp();
 
@@ -233,9 +237,14 @@ public static class InteractiveRecorder
                 return;
             }
 
-            var label = isRecording
-                ? "  ● REC  "
-                : "  F9: Record start   F10: Capture  ";
+            var label = "  F9: Record start   F10: Capture  ";
+            if (isRecording)
+            {
+                label =
+                    Volatile.Read(ref recordingPaused) != 0
+                        ? "  ● REC (F9:End, F12:Resume)  "
+                        : "  ● REC (F9:End, F12:Pause)  ";
+            }
             var width = Math.Max(20, Console.WindowWidth);
             var column = Math.Max(1, width - label.Length);
             var clearPrevious = notificationLength == 0
@@ -406,6 +415,8 @@ public static class InteractiveRecorder
                 if (videoFrames is null)
                 {
                     videoStarted = stopwatch.Elapsed.TotalSeconds;
+                    videoPausedDuration = 0d;
+                    videoPausedAt = 0d;
                     videoFrames = [new TerminalFrame(0d, emulator.Buffer.Clone())];
                     isStarting = true;
                 }
@@ -423,14 +434,69 @@ public static class InteractiveRecorder
             {
                 capture = CompleteRecording(
                     videoFrames,
-                    stopwatch.Elapsed.TotalSeconds - videoStarted,
+                    GetRecordingElapsedSeconds(),
                     emulator.Buffer
                 );
                 videoFrames = null;
+                videoPausedDuration = 0d;
+                videoPausedAt = 0d;
             }
             Interlocked.Exchange(ref recordingIndicatorActive, 0);
+            Interlocked.Exchange(ref recordingPaused, 0);
 
             return capture;
+        }
+
+        async Task TogglePauseAsync()
+        {
+            var changed = false;
+            lock (captureGate)
+            {
+                if (videoFrames is null)
+                {
+                    return;
+                }
+
+                if (Volatile.Read(ref recordingPaused) == 0)
+                {
+                    videoPausedAt = stopwatch.Elapsed.TotalSeconds;
+                    Interlocked.Exchange(ref recordingPaused, 1);
+                }
+                else
+                {
+                    videoPausedDuration += stopwatch.Elapsed.TotalSeconds - videoPausedAt;
+                    videoPausedAt = 0d;
+                    Interlocked.Exchange(ref recordingPaused, 0);
+                }
+
+                changed = true;
+            }
+
+            if (changed)
+            {
+                Interlocked.Exchange(ref recordingIndicatorActive, 1);
+                Interlocked.Increment(ref notificationVersion);
+                await hostOutputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
+                try
+                {
+                    await RenderPersistentIndicatorAsync().ConfigureAwait(false);
+                }
+                finally
+                {
+                    hostOutputGate.Release();
+                }
+            }
+        }
+
+        double GetRecordingElapsedSeconds()
+        {
+            var elapsed = stopwatch.Elapsed.TotalSeconds - videoStarted - videoPausedDuration;
+            if (Volatile.Read(ref recordingPaused) != 0)
+            {
+                elapsed -= stopwatch.Elapsed.TotalSeconds - videoPausedAt;
+            }
+
+            return Math.Max(0d, elapsed);
         }
 
         var outputTask = Task.Run(
@@ -463,11 +529,14 @@ public static class InteractiveRecorder
                                 var text = new string(chars, 0, charCount);
                                 emulator.Process(text);
                                 Volatile.Write(ref lastOutputTimestamp, Stopwatch.GetTimestamp());
-                                if (videoFrames is not null)
+                                if (
+                                    videoFrames is not null
+                                    && Volatile.Read(ref recordingPaused) == 0
+                                )
                                 {
                                     videoFrames.Add(
                                         new TerminalFrame(
-                                            stopwatch.Elapsed.TotalSeconds - videoStarted,
+                                            GetRecordingElapsedSeconds(),
                                             emulator.Buffer.Clone()
                                         )
                                     );
@@ -569,7 +638,11 @@ public static class InteractiveRecorder
             async () =>
             {
                 var bytes = new byte[256];
-                var router = new InteractiveInputRouter(screenshotKey.Span, recordingKey.Span);
+                var router = new InteractiveInputRouter(
+                    screenshotKey.Span,
+                    recordingKey.Span,
+                    pauseKey.Span
+                );
                 var inputGate = new SemaphoreSlim(1, 1);
                 long escapePendingVersion = 0;
                 logger.ZLogDebug($"Interactive input forwarding started.");
@@ -701,6 +774,16 @@ public static class InteractiveRecorder
                                             logger.ZLogError(ex, $"Interactive recording capture failed.");
                                         }
                                         break;
+                                    case InteractiveInputAction.TogglePause:
+                                        try
+                                        {
+                                            await TogglePauseAsync().ConfigureAwait(false);
+                                        }
+                                        catch (Exception ex)
+                                        {
+                                            logger.ZLogError(ex, $"Interactive recording pause failed.");
+                                        }
+                                        break;
                                 }
                             }
 
@@ -807,16 +890,19 @@ public static class InteractiveRecorder
                 {
                     capture = CompleteRecording(
                         videoFrames,
-                        stopwatch.Elapsed.TotalSeconds - videoStarted,
+                        GetRecordingElapsedSeconds(),
                         emulator.Buffer
                     );
                     videoFrames = null;
+                    videoPausedDuration = 0d;
+                    videoPausedAt = 0d;
                 }
             }
 
             if (capture is not null)
             {
                 Interlocked.Exchange(ref recordingIndicatorActive, 0);
+                Interlocked.Exchange(ref recordingPaused, 0);
                 Interlocked.Increment(ref notificationVersion);
                 QueueSaveCapture(capture);
             }

--- a/src/ConsoleToSvg.Record/InteractiveRecorder.cs
+++ b/src/ConsoleToSvg.Record/InteractiveRecorder.cs
@@ -330,7 +330,10 @@ public static class InteractiveRecorder
                         {
                             try
                             {
-                                await Task.Delay(30, lifetime.Token).ConfigureAwait(false);
+                                // Some WSL terminal stacks deliver a function-key
+                                // sequence in separate reads. Keep ESC long enough
+                                // for the remaining CSI bytes to arrive.
+                                await Task.Delay(100, lifetime.Token).ConfigureAwait(false);
                                 await inputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
                                 try
                                 {
@@ -398,8 +401,15 @@ public static class InteractiveRecorder
                                 switch (action)
                                 {
                                     case InteractiveInputAction.Exit:
-                                        await lifetime.CancelAsync().ConfigureAwait(false);
-                                        return;
+                                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                                        {
+                                            await lifetime.CancelAsync().ConfigureAwait(false);
+                                            return;
+                                        }
+
+                                        // Bash receives the EOT byte above and exits;
+                                        // wait for the PTY's normal process-exit path.
+                                        break;
                                     case InteractiveInputAction.Screenshot:
                                         try
                                         {
@@ -650,7 +660,9 @@ public static class InteractiveRecorder
         var unixShell = Environment.GetEnvironmentVariable("SHELL");
         if (string.IsNullOrWhiteSpace(unixShell))
         {
-            unixShell = "/bin/sh";
+            // WSL does not always propagate SHELL to a launched .NET process.
+            // Prefer Bash so Ctrl+L/Ctrl+D retain the familiar interactive bindings.
+            unixShell = File.Exists("/bin/bash") ? "/bin/bash" : "/bin/sh";
         }
 
         if (command is { Length: > 0 })

--- a/src/ConsoleToSvg.Record/InteractiveRecorder.cs
+++ b/src/ConsoleToSvg.Record/InteractiveRecorder.cs
@@ -40,27 +40,29 @@ public static class InteractiveRecorder
         int width,
         int height,
         Theme theme,
-        ReadOnlyMemory<byte> captureKey,
-        bool video,
+        ReadOnlyMemory<byte> screenshotKey,
+        ReadOnlyMemory<byte> recordingKey,
         bool noDeleteEnvs,
-        Func<InteractiveCapture, Task> onCapture,
+        string[]? command,
+        Func<InteractiveCapture, Task<string?>> onCapture,
         CancellationToken cancellationToken,
         ILogger? logger = null
     )
     {
-        if (captureKey.IsEmpty)
+        if (screenshotKey.IsEmpty || recordingKey.IsEmpty)
         {
-            throw new ArgumentException("A capture key is required.", nameof(captureKey));
+            throw new ArgumentException("Screenshot and recording keys are required.");
         }
 
         logger ??= Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
         var emulator = new TerminalEmulator(width, height, theme);
         var captureGate = new object();
+        using var hostOutputGate = new SemaphoreSlim(1, 1);
         List<TerminalFrame>? videoFrames = null;
         var videoStarted = 0d;
         var stopwatch = Stopwatch.StartNew();
 
-        var options = BuildOptions(width, height, noDeleteEnvs);
+        var options = BuildOptions(width, height, noDeleteEnvs, command);
         using var connection = await NativePty
             .SpawnAsync(options, cancellationToken)
             .ConfigureAwait(false);
@@ -72,21 +74,71 @@ public static class InteractiveRecorder
                 ? Console.Out
                 : null;
         var input = Console.OpenStandardInput();
+        PtyRecorder.TryDisableTerminalMouseTracking(forwardToConsole: true, logger);
 
-        async Task CaptureAsync()
+        async Task NotifyAsync(string message)
+        {
+            if (Console.IsOutputRedirected)
+            {
+                return;
+            }
+
+            await hostOutputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
+            try
+            {
+                // This is deliberately written to the host terminal, never the PTY.
+                // Saving/restoring the cursor prevents it from becoming shell input.
+                var width = Math.Max(20, Console.WindowWidth);
+                var label = $"  {message}  ";
+                if (label.Length > width - 2)
+                {
+                    label = label[..Math.Max(1, width - 2)];
+                }
+
+                var column = Math.Max(1, width - label.Length);
+                var overlay = $"\u001b7\u001b[1;{column}H\u001b[30;48;5;114m{label}\u001b[0m\u001b8";
+                await output.WriteAsync(Encoding.UTF8.GetBytes(overlay), lifetime.Token).ConfigureAwait(false);
+                await output.FlushAsync(lifetime.Token).ConfigureAwait(false);
+                await Task.Delay(TimeSpan.FromMilliseconds(1500), lifetime.Token).ConfigureAwait(false);
+                var clear = $"\u001b7\u001b[1;{column}H{new string(' ', label.Length)}\u001b8";
+                await output.WriteAsync(Encoding.UTF8.GetBytes(clear), lifetime.Token).ConfigureAwait(false);
+                await output.FlushAsync(lifetime.Token).ConfigureAwait(false);
+            }
+            finally
+            {
+                hostOutputGate.Release();
+            }
+        }
+
+        async Task SaveCaptureAsync(InteractiveCapture capture)
+        {
+            var message = await onCapture(capture).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(message))
+            {
+                await NotifyAsync(message).ConfigureAwait(false);
+            }
+        }
+
+        async Task CaptureScreenshotAsync()
         {
             InteractiveCapture capture;
             lock (captureGate)
             {
-                if (!video)
-                {
-                    capture = new InteractiveCapture(emulator.Buffer.Clone());
-                }
-                else if (videoFrames is null)
+                capture = new InteractiveCapture(emulator.Buffer.Clone());
+            }
+
+            await SaveCaptureAsync(capture).ConfigureAwait(false);
+        }
+
+        async Task ToggleRecordingAsync()
+        {
+            InteractiveCapture? capture = null;
+            lock (captureGate)
+            {
+                if (videoFrames is null)
                 {
                     videoStarted = stopwatch.Elapsed.TotalSeconds;
                     videoFrames = [new TerminalFrame(0d, emulator.Buffer.Clone())];
-                    return;
                 }
                 else
                 {
@@ -95,7 +147,13 @@ public static class InteractiveRecorder
                 }
             }
 
-            await onCapture(capture).ConfigureAwait(false);
+            if (capture is null)
+            {
+                await NotifyAsync("Recording started").ConfigureAwait(false);
+                return;
+            }
+
+            await SaveCaptureAsync(capture).ConfigureAwait(false);
         }
 
         var outputTask = Task.Run(
@@ -107,6 +165,7 @@ public static class InteractiveRecorder
                     ? Console.OutputEncoding
                     : Encoding.UTF8;
                 var decoder = outputEncoding.GetDecoder();
+                var hostSequenceFilter = new HostTerminalSequenceFilter();
                 try
                 {
                     while (!lifetime.IsCancellationRequested)
@@ -142,10 +201,22 @@ public static class InteractiveRecorder
                         {
                             if (charCount > 0)
                             {
-                                await outputWriter
-                                    .WriteAsync(chars.AsMemory(0, charCount), lifetime.Token)
-                                    .ConfigureAwait(false);
-                                await outputWriter.FlushAsync(lifetime.Token).ConfigureAwait(false);
+                                var text = hostSequenceFilter.Filter(new string(chars, 0, charCount));
+                                if (text.Length > 0)
+                                {
+                                    await hostOutputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
+                                    try
+                                    {
+                                        await outputWriter
+                                            .WriteAsync(text.AsMemory(), lifetime.Token)
+                                            .ConfigureAwait(false);
+                                        await outputWriter.FlushAsync(lifetime.Token).ConfigureAwait(false);
+                                    }
+                                    finally
+                                    {
+                                        hostOutputGate.Release();
+                                    }
+                                }
                             }
                         }
                         else
@@ -173,7 +244,51 @@ public static class InteractiveRecorder
             async () =>
             {
                 var bytes = new byte[256];
-                var pending = new List<byte>(captureKey.Length);
+                var pending = new List<byte>(Math.Max(screenshotKey.Length, recordingKey.Length));
+                var discardingSgrMouseReport = false;
+                var inputGate = new SemaphoreSlim(1, 1);
+                long escapePendingVersion = 0;
+
+                void ScheduleStandaloneEscape(long version)
+                {
+                    _ = Task.Run(
+                        async () =>
+                        {
+                            try
+                            {
+                                await Task.Delay(30, lifetime.Token).ConfigureAwait(false);
+                                await inputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
+                                try
+                                {
+                                    if (
+                                        Volatile.Read(ref escapePendingVersion) == version
+                                        && pending.Count == 1
+                                        && pending[0] == 0x1b
+                                    )
+                                    {
+                                        await connection.WriterStream
+                                            .WriteAsync(pending.ToArray(), lifetime.Token)
+                                            .ConfigureAwait(false);
+                                        pending.Clear();
+                                        await connection.WriterStream
+                                            .FlushAsync(lifetime.Token)
+                                            .ConfigureAwait(false);
+                                    }
+                                }
+                                finally
+                                {
+                                    inputGate.Release();
+                                }
+                            }
+                            catch (OperationCanceledException)
+                            {
+                                // The session ended before a standalone Escape was due.
+                            }
+                        },
+                        CancellationToken.None
+                    );
+                }
+
                 try
                 {
                     while (!lifetime.IsCancellationRequested)
@@ -186,50 +301,90 @@ public static class InteractiveRecorder
                             break;
                         }
 
-                        for (var i = 0; i < count; i++)
+                        await inputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
+                        try
                         {
-                            pending.Add(bytes[i]);
-                            while (pending.Count > 0)
+                            // A new byte invalidates any pending standalone-Escape timer.
+                            Interlocked.Increment(ref escapePendingVersion);
+                            for (var i = 0; i < count; i++)
                             {
-                                if (IsPrefix(pending, captureKey.Span))
+                                if (discardingSgrMouseReport)
                                 {
-                                    if (pending.Count == captureKey.Length)
+                                    if (bytes[i] is (byte)'M' or (byte)'m')
                                     {
-                                        pending.Clear();
-                                        try
-                                        {
-                                            await CaptureAsync().ConfigureAwait(false);
-                                        }
-                                        catch (Exception ex)
-                                        {
-                                            logger.ZLogError(ex, $"Interactive capture failed.");
-                                            await Console.Error.WriteLineAsync(
-                                                $"Interactive capture failed: {ex.Message}".AsMemory(),
-                                                CancellationToken.None
-                                            );
-                                        }
+                                        discardingSgrMouseReport = false;
                                     }
-                                    break;
+
+                                    continue;
                                 }
 
-                                await connection.WriterStream
-                                    .WriteAsync(new byte[] { pending[0] }, lifetime.Token)
-                                    .ConfigureAwait(false);
-                                pending.RemoveAt(0);
+                                pending.Add(bytes[i]);
+                                while (pending.Count > 0)
+                                {
+                                    if (IsPrefix(pending, screenshotKey.Span) || IsPrefix(pending, recordingKey.Span))
+                                    {
+                                        if (pending.Count == screenshotKey.Length && IsPrefix(pending, screenshotKey.Span))
+                                        {
+                                            pending.Clear();
+                                            try
+                                            {
+                                                await CaptureScreenshotAsync().ConfigureAwait(false);
+                                            }
+                                            catch (Exception ex)
+                                            {
+                                                logger.ZLogError(ex, $"Interactive capture failed.");
+                                            }
+                                        }
+                                        else if (pending.Count == recordingKey.Length && IsPrefix(pending, recordingKey.Span))
+                                        {
+                                            pending.Clear();
+                                            try
+                                            {
+                                                await ToggleRecordingAsync().ConfigureAwait(false);
+                                            }
+                                            catch (Exception ex)
+                                            {
+                                                logger.ZLogError(ex, $"Interactive recording capture failed.");
+                                            }
+                                        }
+                                        break;
+                                    }
+
+                                    // ENABLE_VIRTUAL_TERMINAL_INPUT can surface host mouse
+                                    // reports as CSI <... M/m. They are neither shell input
+                                    // nor capture keys; forwarding them produces visible
+                                    // fragments such as "[<35;..." in line editors.
+                                    if (IsSgrMouseReportPrefix(pending))
+                                    {
+                                        pending.Clear();
+                                        discardingSgrMouseReport = true;
+                                        break;
+                                    }
+
+                                    // Any non-capture sequence is opaque input. Forward
+                                    // it as received rather than special-casing cursor
+                                    // keys, paste markers, modifiers, or future VT keys.
+                                    await connection.WriterStream
+                                        .WriteAsync(pending.ToArray(), lifetime.Token)
+                                        .ConfigureAwait(false);
+                                    pending.Clear();
+                                }
                             }
-                        }
 
-                        // F12 begins with ESC. Do not indefinitely swallow a standalone
-                        // Escape key when an application receives it in a separate read.
-                        if (pending.Count == 1 && pending[0] == 0x1b)
+                            // Function keys and other VT input can arrive across reads.
+                            // Give a lone Escape a short grace period before forwarding it.
+                            if (pending.Count == 1 && pending[0] == 0x1b)
+                            {
+                                var version = Interlocked.Increment(ref escapePendingVersion);
+                                ScheduleStandaloneEscape(version);
+                            }
+
+                            await connection.WriterStream.FlushAsync(lifetime.Token).ConfigureAwait(false);
+                        }
+                        finally
                         {
-                            await connection.WriterStream
-                                .WriteAsync(new byte[] { pending[0] }, lifetime.Token)
-                                .ConfigureAwait(false);
-                            pending.Clear();
+                            inputGate.Release();
                         }
-
-                        await connection.WriterStream.FlushAsync(lifetime.Token).ConfigureAwait(false);
                     }
                 }
                 catch (OperationCanceledException)
@@ -268,6 +423,10 @@ public static class InteractiveRecorder
             connection.Dispose();
             await IgnoreFailureAsync(outputTask).ConfigureAwait(false);
             await IgnoreFailureAsync(inputTask).ConfigureAwait(false);
+            // A child application can leave the outer terminal in mouse-reporting
+            // mode. Reset it before restoring the host input mode so selection is
+            // available after an interactive session ends.
+            PtyRecorder.TryDisableTerminalMouseTracking(forwardToConsole: true, logger);
         }
     }
 
@@ -289,6 +448,65 @@ public static class InteractiveRecorder
         return true;
     }
 
+    private static bool IsSgrMouseReportPrefix(List<byte> value) =>
+        value.Count == 3 && value[0] == 0x1b && value[1] == (byte)'[' && value[2] == (byte)'<';
+
+    private sealed class HostTerminalSequenceFilter
+    {
+        private static readonly HashSet<string> SuppressedPrivateModes =
+            ["9", "1000", "1002", "1003", "1004", "1005", "1006", "1015", "1016", "9001"];
+        private readonly StringBuilder _pending = new();
+
+        public string Filter(string text)
+        {
+            _pending.Append(text);
+            var output = new StringBuilder(_pending.Length);
+            var index = 0;
+            while (index < _pending.Length)
+            {
+                if (_pending[index] != '\u001b')
+                {
+                    output.Append(_pending[index++]);
+                    continue;
+                }
+
+                if (index + 2 >= _pending.Length)
+                {
+                    break;
+                }
+
+                if (_pending[index + 1] != '[' || _pending[index + 2] != '?')
+                {
+                    output.Append(_pending[index++]);
+                    continue;
+                }
+
+                var end = index + 3;
+                while (end < _pending.Length && char.IsDigit(_pending[end]))
+                {
+                    end++;
+                }
+
+                if (end >= _pending.Length)
+                {
+                    break;
+                }
+
+                var mode = _pending.ToString(index + 3, end - index - 3);
+                if ((_pending[end] is 'h' or 'l') && SuppressedPrivateModes.Contains(mode))
+                {
+                    index = end + 1;
+                    continue;
+                }
+
+                output.Append(_pending[index++]);
+            }
+
+            _pending.Remove(0, index);
+            return output.ToString();
+        }
+    }
+
     private static async Task IgnoreFailureAsync(Task task)
     {
         try
@@ -301,7 +519,12 @@ public static class InteractiveRecorder
         }
     }
 
-    private static NativePtyOptions BuildOptions(int width, int height, bool noDeleteEnvs)
+    private static NativePtyOptions BuildOptions(
+        int width,
+        int height,
+        bool noDeleteEnvs,
+        string[]? command
+    )
     {
         var environment = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (System.Collections.DictionaryEntry entry in Environment.GetEnvironmentVariables())
@@ -322,6 +545,21 @@ public static class InteractiveRecorder
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
+            if (command is { Length: > 0 })
+            {
+                return new NativePtyOptions
+                {
+                    Name = "console2svg",
+                    Cols = width,
+                    Rows = height,
+                    Cwd = Environment.CurrentDirectory,
+                    App = command[0],
+                    Args = command[1..],
+                    Environment = environment,
+                    DisableInputEcho = false,
+                };
+            }
+
             var shell = Environment.GetEnvironmentVariable("COMSPEC");
             if (string.IsNullOrWhiteSpace(shell))
             {
@@ -338,7 +576,10 @@ public static class InteractiveRecorder
                 Rows = height,
                 Cwd = Environment.CurrentDirectory,
                 App = shell,
-                Args = ["/d", "/k"],
+                // Do not use cmd.exe's /d switch here: it disables the user's
+                // AutoRun configuration, including prompt integrations such as
+                // Starship. An interactive capture should behave like their shell.
+                Args = ["/k"],
                 Environment = environment,
                 DisableInputEcho = false,
             };
@@ -348,6 +589,21 @@ public static class InteractiveRecorder
         if (string.IsNullOrWhiteSpace(unixShell))
         {
             unixShell = "/bin/sh";
+        }
+
+        if (command is { Length: > 0 })
+        {
+            return new NativePtyOptions
+            {
+                Name = "console2svg",
+                Cols = width,
+                Rows = height,
+                Cwd = Environment.CurrentDirectory,
+                App = command[0],
+                Args = command[1..],
+                Environment = environment,
+                DisableInputEcho = false,
+            };
         }
 
         return new NativePtyOptions

--- a/src/ConsoleToSvg.Record/InteractiveRecorder.cs
+++ b/src/ConsoleToSvg.Record/InteractiveRecorder.cs
@@ -109,12 +109,7 @@ public static class InteractiveRecorder
         var rawInput = PtyRecorder.ConsoleInputMode.TryEnableRaw(logger);
         await ClearHostTerminalAsync().ConfigureAwait(false);
 
-        async Task NotifyAsync(
-            string message,
-            bool isRecording,
-            long version,
-            TimeSpan displayDuration
-        )
+        async Task NotifyAsync(string message, bool isRecording, long version)
         {
             if (Console.IsOutputRedirected)
             {
@@ -160,7 +155,10 @@ public static class InteractiveRecorder
                 hostOutputGate.Release();
             }
 
-            await Task.Delay(displayDuration, lifetime.Token).ConfigureAwait(false);
+        }
+
+        async Task ClearNotificationAsync(long version)
+        {
             if (Volatile.Read(ref notificationVersion) != version)
             {
                 return;
@@ -188,24 +186,32 @@ public static class InteractiveRecorder
             }
         }
 
-        (long Version, Task Completion) ShowNotification(
-            string message,
-            bool isRecording = false,
-            TimeSpan? displayDuration = null
-        )
+        async Task ShowTimedNotificationAsync(string message, bool isRecording, long version)
+        {
+            await NotifyAsync(message, isRecording, version).ConfigureAwait(false);
+            await Task.Delay(TimeSpan.FromMilliseconds(1500), lifetime.Token).ConfigureAwait(false);
+            await ClearNotificationAsync(version).ConfigureAwait(false);
+        }
+
+        (long Version, Task Completion) ShowNotification(string message, bool isRecording = false)
         {
             var version = Interlocked.Increment(ref notificationVersion);
-            var notification = NotifyAsync(
-                    message,
-                    isRecording,
-                    version,
-                    displayDuration ?? TimeSpan.FromMilliseconds(1500)
-                );
+            var notification = ShowTimedNotificationAsync(message, isRecording, version);
             _ = notification.ContinueWith(
                 task => logger.ZLogDebug(task.Exception, $"Interactive notification failed."),
                 TaskContinuationOptions.OnlyOnFaulted
             );
             return (version, notification);
+        }
+
+        void ShowPersistentNotification(string message)
+        {
+            var version = Interlocked.Increment(ref notificationVersion);
+            var notification = NotifyAsync(message, isRecording: false, version: version);
+            _ = notification.ContinueWith(
+                task => logger.ZLogDebug(task.Exception, $"Interactive notification failed."),
+                TaskContinuationOptions.OnlyOnFaulted
+            );
         }
 
         async Task RenderPersistentIndicatorAsync()
@@ -309,60 +315,68 @@ public static class InteractiveRecorder
 
         async Task SaveCaptureAsync(InteractiveCapture capture)
         {
-            ShowNotification("Saving...");
-            var message = await onCapture(capture).ConfigureAwait(false);
-            if (!string.IsNullOrWhiteSpace(message))
+            ShowPersistentNotification("Saving...");
+            try
             {
-                var savedNotification = ShowNotification(message);
-                _ = Task.Run(
-                    async () =>
-                    {
-                        try
+                var message = await onCapture(capture).ConfigureAwait(false);
+                if (!string.IsNullOrWhiteSpace(message))
+                {
+                    var savedNotification = ShowNotification(message);
+                    _ = Task.Run(
+                        async () =>
                         {
-                            await savedNotification.Completion.ConfigureAwait(false);
-                            if (
-                                Volatile.Read(ref notificationVersion) != savedNotification.Version
-                                || Volatile.Read(ref recordingIndicatorActive) != 0
-                            )
+                            try
                             {
-                                return;
-                            }
-
-                            lock (captureGate)
-                            {
-                                if (videoFrames is not null)
+                                await savedNotification.Completion.ConfigureAwait(false);
+                                if (
+                                    Volatile.Read(ref notificationVersion) != savedNotification.Version
+                                    || Volatile.Read(ref recordingIndicatorActive) != 0
+                                )
                                 {
                                     return;
                                 }
-                            }
 
-                            Interlocked.Exchange(ref startupIndicatorActive, 1);
-                            await hostOutputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
-                            try
-                            {
-                                if (
-                                    Volatile.Read(ref notificationVersion)
-                                    == savedNotification.Version
-                                )
+                                lock (captureGate)
                                 {
-                                    await RenderPersistentIndicatorAsync().ConfigureAwait(false);
+                                    if (videoFrames is not null)
+                                    {
+                                        return;
+                                    }
+                                }
+
+                                Interlocked.Exchange(ref startupIndicatorActive, 1);
+                                await hostOutputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
+                                try
+                                {
+                                    if (
+                                        Volatile.Read(ref notificationVersion)
+                                        == savedNotification.Version
+                                    )
+                                    {
+                                        await RenderPersistentIndicatorAsync().ConfigureAwait(false);
+                                    }
+                                }
+                                finally
+                                {
+                                    hostOutputGate.Release();
                                 }
                             }
-                            finally
+                            catch (OperationCanceledException)
                             {
-                                hostOutputGate.Release();
+                                // The session ended before restoring the startup indicator.
                             }
-                        }
-                        catch (OperationCanceledException)
-                        {
-                            // The session ended before restoring the startup indicator.
-                        }
-                    },
-                    CancellationToken.None
-                ).ContinueWith(
-                    task => logger.ZLogDebug(task.Exception, $"Interactive notification failed."),
-                    TaskContinuationOptions.OnlyOnFaulted
-                );
+                        },
+                        CancellationToken.None
+                    ).ContinueWith(
+                        task => logger.ZLogDebug(task.Exception, $"Interactive notification failed."),
+                        TaskContinuationOptions.OnlyOnFaulted
+                    );
+                }
+            }
+            catch
+            {
+                ShowNotification("Save failed");
+                throw;
             }
         }
 

--- a/src/ConsoleToSvg.Record/InteractiveRecorder.cs
+++ b/src/ConsoleToSvg.Record/InteractiveRecorder.cs
@@ -111,7 +111,7 @@ public static class InteractiveRecorder
             }
         }
 
-        using var connection = await NativePty
+        var connection = await NativePty
             .SpawnAsync(options, cancellationToken)
             .ConfigureAwait(false);
         var rawInput = PtyRecorder.ConsoleInputMode.TryEnableRaw(logger);
@@ -446,10 +446,13 @@ public static class InteractiveRecorder
             InteractiveCapture capture;
             lock (captureGate)
             {
+                var finalScreen = Volatile.Read(ref recordingPaused) != 0
+                    ? videoFrames[^1].Buffer
+                    : emulator.Buffer;
                 capture = CompleteRecording(
                     videoFrames,
                     GetRecordingElapsedSeconds(),
-                    emulator.Buffer
+                    finalScreen
                 );
                 videoFrames = null;
                 videoPausedDuration = 0d;
@@ -900,10 +903,13 @@ public static class InteractiveRecorder
             {
                 if (videoFrames is not null)
                 {
+                    var finalScreen = Volatile.Read(ref recordingPaused) != 0
+                        ? videoFrames[^1].Buffer
+                        : emulator.Buffer;
                     capture = CompleteRecording(
                         videoFrames,
                         GetRecordingElapsedSeconds(),
-                        emulator.Buffer
+                        finalScreen
                     );
                     videoFrames = null;
                     videoPausedDuration = 0d;

--- a/src/ConsoleToSvg.Record/InteractiveRecorder.cs
+++ b/src/ConsoleToSvg.Record/InteractiveRecorder.cs
@@ -23,6 +23,11 @@ public sealed class InteractiveCapture
 
     public InteractiveCapture(IReadOnlyList<TerminalFrame> frames)
     {
+        if (frames.Count == 0)
+        {
+            throw new ArgumentException("At least one frame is required.", nameof(frames));
+        }
+
         Frames = frames;
         Screen = frames[0].Buffer;
     }
@@ -47,6 +52,7 @@ public static class InteractiveRecorder
         bool noDeleteEnvs,
         string[]? command,
         bool exitOnCtrlD,
+        bool recordingEnabled,
         Func<InteractiveCapture, Task<string?>> onCapture,
         CancellationToken cancellationToken,
         ILogger? logger = null
@@ -77,10 +83,6 @@ public static class InteractiveRecorder
         var options = BuildOptions(width, height, noDeleteEnvs, command);
         using var lifetime = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         var output = Console.OpenStandardOutput();
-        var outputWriter =
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected
-                ? Console.Out
-                : null;
         var input = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? Console.OpenStandardInput()
             : null;
@@ -117,6 +119,12 @@ public static class InteractiveRecorder
             forwardToConsole: true,
             logger
         );
+        // Console.Out is recreated when the console encoding changes. Acquire it
+        // after entering the UTF-8 scope so its writer matches the console.
+        var outputWriter =
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected
+                ? Console.Out
+                : null;
         await ClearHostTerminalAsync().ConfigureAwait(false);
 
         async Task NotifyAsync(string message, bool isRecording, long version)
@@ -131,14 +139,14 @@ public static class InteractiveRecorder
                 return;
             }
 
-            var width = Math.Max(20, Console.WindowWidth);
+            var consoleWidth = Math.Max(20, Console.WindowWidth);
             var label = $"  {message}  ";
-            if (label.Length > width - 2)
+            if (label.Length > consoleWidth - 2)
             {
-                label = label[..Math.Max(1, width - 2)];
+                label = label[..Math.Max(1, consoleWidth - 2)];
             }
 
-            var column = Math.Max(1, width - label.Length);
+            var column = Math.Max(1, consoleWidth - label.Length);
             await hostOutputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
             try
             {
@@ -409,6 +417,12 @@ public static class InteractiveRecorder
 
         async Task<InteractiveCapture?> ToggleRecordingAsync()
         {
+            if (!recordingEnabled)
+            {
+                ShowNotification("Recording requires SVG or a video output format");
+                return null;
+            }
+
             var isStarting = false;
             lock (captureGate)
             {
@@ -504,10 +518,7 @@ public static class InteractiveRecorder
             {
                 var bytes = new byte[4096];
                 var chars = new char[8192];
-                var outputEncoding = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                    ? Console.OutputEncoding
-                    : Encoding.UTF8;
-                var decoder = outputEncoding.GetDecoder();
+                var decoder = Encoding.UTF8.GetDecoder();
                 var hostSequenceFilter = new HostTerminalSequenceFilter();
                 try
                 {
@@ -569,9 +580,9 @@ public static class InteractiveRecorder
                         }
                         else
                         {
-                            var text = hostSequenceFilter.Filter(
-                                Encoding.UTF8.GetString(bytes, 0, count)
-                            );
+                            var text = charCount > 0
+                                ? hostSequenceFilter.Filter(new string(chars, 0, charCount))
+                                : string.Empty;
                             if (text.Length == 0)
                             {
                                 continue;
@@ -880,7 +891,8 @@ public static class InteractiveRecorder
             {
                 // Drain the PTY before completing the recording so its final output
                 // becomes part of the saved capture.
-                await IgnoreFailureAsync(outputTask).ConfigureAwait(false);
+                await Task.WhenAny(outputTask, Task.Delay(500, CancellationToken.None))
+                    .ConfigureAwait(false);
             }
 
             InteractiveCapture? capture = null;
@@ -952,13 +964,24 @@ public static class InteractiveRecorder
     {
         var descriptors = new[] { new PollFd { FileDescriptor = 0, Events = PollIn } };
         var pollResult = poll(descriptors, (nuint)descriptors.Length, timeoutMilliseconds);
-        if (pollResult <= 0)
+        if (pollResult == 0)
         {
             return -1;
         }
+        if (pollResult < 0)
+        {
+            var error = Marshal.GetLastWin32Error();
+            return error is 4 or 11 ? -1 : throw new IOException($"poll failed: errno {error}");
+        }
 
         var count = read(0, buffer, (nuint)buffer.Length);
-        return count < 0 ? 0 : checked((int)count);
+        if (count >= 0)
+        {
+            return checked((int)count);
+        }
+
+        var readError = Marshal.GetLastWin32Error();
+        return readError is 4 or 11 ? -1 : throw new IOException($"read failed: errno {readError}");
     }
 
     private const short PollIn = 0x0001;

--- a/src/ConsoleToSvg.Record/InteractiveRecorder.cs
+++ b/src/ConsoleToSvg.Record/InteractiveRecorder.cs
@@ -74,7 +74,9 @@ public static class InteractiveRecorder
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected
                 ? Console.Out
                 : null;
-        var input = Console.OpenStandardInput();
+        var input = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? Console.OpenStandardInput()
+            : null;
         PtyRecorder.TryDisableTerminalMouseTracking(forwardToConsole: true, logger);
 
         async Task ClearHostTerminalAsync()
@@ -322,6 +324,7 @@ public static class InteractiveRecorder
                 var router = new InteractiveInputRouter(screenshotKey.Span, recordingKey.Span);
                 var inputGate = new SemaphoreSlim(1, 1);
                 long escapePendingVersion = 0;
+                logger.ZLogDebug($"Interactive input forwarding started.");
 
                 void ScheduleStandaloneEscape(long version)
                 {
@@ -370,9 +373,19 @@ public static class InteractiveRecorder
                 {
                     while (!lifetime.IsCancellationRequested)
                     {
-                        var count = await input
-                            .ReadAsync(bytes, 0, bytes.Length, lifetime.Token)
-                            .ConfigureAwait(false);
+                        var count = input is not null
+                            ? await input
+                                .ReadAsync(bytes, 0, bytes.Length, lifetime.Token)
+                                .ConfigureAwait(false)
+                            : await Task.Run(
+                                () => ReadUnixTerminalInput(bytes, timeoutMilliseconds: 100),
+                                CancellationToken.None
+                            ).ConfigureAwait(false);
+                        if (count < 0)
+                        {
+                            // Poll timeout; check cancellation and continue.
+                            continue;
+                        }
                         if (count <= 0)
                         {
                             // An EOF from the outer terminal is another form of
@@ -522,6 +535,35 @@ public static class InteractiveRecorder
         frames.Add(new TerminalFrame(elapsedSeconds, finalScreen.Clone()));
         return new InteractiveCapture(frames.ToArray());
     }
+
+    private static int ReadUnixTerminalInput(byte[] buffer, int timeoutMilliseconds)
+    {
+        var descriptors = new[] { new PollFd { FileDescriptor = 0, Events = PollIn } };
+        var pollResult = poll(descriptors, (nuint)descriptors.Length, timeoutMilliseconds);
+        if (pollResult <= 0)
+        {
+            return -1;
+        }
+
+        var count = read(0, buffer, (nuint)buffer.Length);
+        return count < 0 ? 0 : checked((int)count);
+    }
+
+    private const short PollIn = 0x0001;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PollFd
+    {
+        public int FileDescriptor;
+        public short Events;
+        public short Revents;
+    }
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int poll(PollFd[] fds, nuint nfds, int timeout);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern nint read(int fd, byte[] buffer, nuint count);
 
     public sealed class HostTerminalSequenceFilter
     {

--- a/src/ConsoleToSvg.Record/InteractiveRecorder.cs
+++ b/src/ConsoleToSvg.Record/InteractiveRecorder.cs
@@ -58,17 +58,18 @@ public static class InteractiveRecorder
         var emulator = new TerminalEmulator(width, height, theme);
         var captureGate = new object();
         using var hostOutputGate = new SemaphoreSlim(1, 1);
+        long notificationVersion = 0;
+        var notificationColumn = 1;
+        var notificationLength = 0;
+        var recordingIndicatorActive = 0;
+        var startupIndicatorActive = 0;
         List<TerminalFrame>? videoFrames = null;
         var videoStarted = 0d;
         var stopwatch = Stopwatch.StartNew();
         long lastOutputTimestamp = Stopwatch.GetTimestamp();
 
         var options = BuildOptions(width, height, noDeleteEnvs, command);
-        using var connection = await NativePty
-            .SpawnAsync(options, cancellationToken)
-            .ConfigureAwait(false);
         using var lifetime = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        using var rawInput = PtyRecorder.ConsoleInputMode.TryEnableRaw(logger);
         var output = Console.OpenStandardOutput();
         var outputWriter =
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected
@@ -102,9 +103,25 @@ public static class InteractiveRecorder
             }
         }
 
-        async Task NotifyAsync(string message)
+        using var connection = await NativePty
+            .SpawnAsync(options, cancellationToken)
+            .ConfigureAwait(false);
+        var rawInput = PtyRecorder.ConsoleInputMode.TryEnableRaw(logger);
+        await ClearHostTerminalAsync().ConfigureAwait(false);
+
+        async Task NotifyAsync(
+            string message,
+            bool isRecording,
+            long version,
+            TimeSpan displayDuration
+        )
         {
             if (Console.IsOutputRedirected)
+            {
+                return;
+            }
+
+            if (Volatile.Read(ref notificationVersion) != version)
             {
                 return;
             }
@@ -120,26 +137,50 @@ public static class InteractiveRecorder
             await hostOutputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
             try
             {
-                // This is deliberately written to the host terminal, never the PTY.
-                // Saving/restoring the cursor prevents it from becoming shell input.
-                var overlay = $"\u001b7\u001b[1;{column}H\u001b[30;48;5;114m{label}\u001b[0m\u001b8";
-                await output.WriteAsync(Encoding.UTF8.GetBytes(overlay), lifetime.Token).ConfigureAwait(false);
+                if (Volatile.Read(ref notificationVersion) != version)
+                {
+                    return;
+                }
+
+                var style = isRecording ? "\u001b[1;31;48;5;236m" : "\u001b[30;48;5;114m";
+                var clearPrevious = notificationLength == 0
+                    ? string.Empty
+                    : $"\u001b[1;{notificationColumn}H{new string(' ', notificationLength)}";
+                var overlay =
+                    $"\u001b7{clearPrevious}\u001b[1;{column}H{style}{label}\u001b[0m\u001b8";
+                await output
+                    .WriteAsync(Encoding.UTF8.GetBytes(overlay), lifetime.Token)
+                    .ConfigureAwait(false);
                 await output.FlushAsync(lifetime.Token).ConfigureAwait(false);
+                notificationColumn = column;
+                notificationLength = label.Length;
             }
             finally
             {
                 hostOutputGate.Release();
             }
 
-            // Do not hold the output gate while the popup is visible: PTY output
-            // must keep flowing while the user continues typing.
-            await Task.Delay(TimeSpan.FromMilliseconds(1500), lifetime.Token).ConfigureAwait(false);
+            await Task.Delay(displayDuration, lifetime.Token).ConfigureAwait(false);
+            if (Volatile.Read(ref notificationVersion) != version)
+            {
+                return;
+            }
+
             await hostOutputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
             try
             {
-                var clear = $"\u001b7\u001b[1;{column}H{new string(' ', label.Length)}\u001b8";
-                await output.WriteAsync(Encoding.UTF8.GetBytes(clear), lifetime.Token).ConfigureAwait(false);
+                if (Volatile.Read(ref notificationVersion) != version)
+                {
+                    return;
+                }
+
+                var clear =
+                    $"\u001b7\u001b[1;{notificationColumn}H{new string(' ', notificationLength)}\u001b8";
+                await output
+                    .WriteAsync(Encoding.UTF8.GetBytes(clear), lifetime.Token)
+                    .ConfigureAwait(false);
                 await output.FlushAsync(lifetime.Token).ConfigureAwait(false);
+                notificationLength = 0;
             }
             finally
             {
@@ -147,9 +188,98 @@ public static class InteractiveRecorder
             }
         }
 
-        void ShowNotification(string message)
+        (long Version, Task Completion) ShowNotification(
+            string message,
+            bool isRecording = false,
+            TimeSpan? displayDuration = null
+        )
         {
-            _ = NotifyAsync(message).ContinueWith(
+            var version = Interlocked.Increment(ref notificationVersion);
+            var notification = NotifyAsync(
+                    message,
+                    isRecording,
+                    version,
+                    displayDuration ?? TimeSpan.FromMilliseconds(1500)
+                );
+            _ = notification.ContinueWith(
+                task => logger.ZLogDebug(task.Exception, $"Interactive notification failed."),
+                TaskContinuationOptions.OnlyOnFaulted
+            );
+            return (version, notification);
+        }
+
+        async Task RenderPersistentIndicatorAsync()
+        {
+            if (Console.IsOutputRedirected)
+            {
+                return;
+            }
+
+            var isRecording = Volatile.Read(ref recordingIndicatorActive) != 0;
+            if (!isRecording && Volatile.Read(ref startupIndicatorActive) == 0)
+            {
+                return;
+            }
+
+            var label = isRecording
+                ? "  ● REC  "
+                : "  F9: Record start   F10: Capture  ";
+            var width = Math.Max(20, Console.WindowWidth);
+            var column = Math.Max(1, width - label.Length);
+            var clearPrevious = notificationLength == 0
+                ? string.Empty
+                : $"\u001b[1;{notificationColumn}H{new string(' ', notificationLength)}";
+            var overlay =
+                isRecording
+                    ? $"\u001b7{clearPrevious}\u001b[1;{column}H\u001b[1;31;48;5;236m{label}\u001b[0m\u001b8"
+                    : $"\u001b7{clearPrevious}\u001b[1;{column}H\u001b[30;48;5;114m{label}\u001b[0m\u001b8";
+            await output
+                .WriteAsync(Encoding.UTF8.GetBytes(overlay), lifetime.Token)
+                .ConfigureAwait(false);
+            await output.FlushAsync(lifetime.Token).ConfigureAwait(false);
+            notificationColumn = column;
+            notificationLength = label.Length;
+        }
+
+        void ShowRecordingStartedNotification()
+        {
+            Interlocked.Exchange(ref startupIndicatorActive, 0);
+            ShowNotification("Started");
+            _ = Task.Run(
+                async () =>
+                {
+                    try
+                    {
+                        await Task
+                            .Delay(TimeSpan.FromMilliseconds(1500), lifetime.Token)
+                            .ConfigureAwait(false);
+                        lock (captureGate)
+                        {
+                            if (videoFrames is null)
+                            {
+                                return;
+                            }
+                        }
+
+                        Interlocked.Exchange(ref recordingIndicatorActive, 1);
+                        Interlocked.Increment(ref notificationVersion);
+                        await hostOutputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
+                        try
+                        {
+                            await RenderPersistentIndicatorAsync().ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            hostOutputGate.Release();
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // The session ended before the recording indicator was due.
+                    }
+                },
+                CancellationToken.None
+            ).ContinueWith(
                 task => logger.ZLogDebug(task.Exception, $"Interactive notification failed."),
                 TaskContinuationOptions.OnlyOnFaulted
             );
@@ -179,10 +309,60 @@ public static class InteractiveRecorder
 
         async Task SaveCaptureAsync(InteractiveCapture capture)
         {
+            ShowNotification("Saving...");
             var message = await onCapture(capture).ConfigureAwait(false);
             if (!string.IsNullOrWhiteSpace(message))
             {
-                ShowNotification(message);
+                var savedNotification = ShowNotification(message);
+                _ = Task.Run(
+                    async () =>
+                    {
+                        try
+                        {
+                            await savedNotification.Completion.ConfigureAwait(false);
+                            if (
+                                Volatile.Read(ref notificationVersion) != savedNotification.Version
+                                || Volatile.Read(ref recordingIndicatorActive) != 0
+                            )
+                            {
+                                return;
+                            }
+
+                            lock (captureGate)
+                            {
+                                if (videoFrames is not null)
+                                {
+                                    return;
+                                }
+                            }
+
+                            Interlocked.Exchange(ref startupIndicatorActive, 1);
+                            await hostOutputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
+                            try
+                            {
+                                if (
+                                    Volatile.Read(ref notificationVersion)
+                                    == savedNotification.Version
+                                )
+                                {
+                                    await RenderPersistentIndicatorAsync().ConfigureAwait(false);
+                                }
+                            }
+                            finally
+                            {
+                                hostOutputGate.Release();
+                            }
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            // The session ended before restoring the startup indicator.
+                        }
+                    },
+                    CancellationToken.None
+                ).ContinueWith(
+                    task => logger.ZLogDebug(task.Exception, $"Interactive notification failed."),
+                    TaskContinuationOptions.OnlyOnFaulted
+                );
             }
         }
 
@@ -213,7 +393,7 @@ public static class InteractiveRecorder
 
             if (isStarting)
             {
-                ShowNotification("Recording started");
+                ShowRecordingStartedNotification();
                 return null;
             }
 
@@ -228,6 +408,7 @@ public static class InteractiveRecorder
                 );
                 videoFrames = null;
             }
+            Interlocked.Exchange(ref recordingIndicatorActive, 0);
 
             return capture;
         }
@@ -288,6 +469,7 @@ public static class InteractiveRecorder
                                             .WriteAsync(text.AsMemory(), lifetime.Token)
                                             .ConfigureAwait(false);
                                         await outputWriter.FlushAsync(lifetime.Token).ConfigureAwait(false);
+                                        await RenderPersistentIndicatorAsync().ConfigureAwait(false);
                                     }
                                     finally
                                     {
@@ -298,10 +480,19 @@ public static class InteractiveRecorder
                         }
                         else
                         {
-                            await output
-                                .WriteAsync(bytes, 0, count, lifetime.Token)
-                                .ConfigureAwait(false);
-                            await output.FlushAsync(lifetime.Token).ConfigureAwait(false);
+                            await hostOutputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
+                            try
+                            {
+                                await output
+                                    .WriteAsync(bytes, 0, count, lifetime.Token)
+                                    .ConfigureAwait(false);
+                                await output.FlushAsync(lifetime.Token).ConfigureAwait(false);
+                                await RenderPersistentIndicatorAsync().ConfigureAwait(false);
+                            }
+                            finally
+                            {
+                                hostOutputGate.Release();
+                            }
                         }
                     }
                 }
@@ -319,6 +510,30 @@ public static class InteractiveRecorder
 
         var captureQueueGate = new object();
         Task captureQueue = Task.CompletedTask;
+
+        void QueueSaveCapture(InteractiveCapture capture)
+        {
+            lock (captureQueueGate)
+            {
+                captureQueue = captureQueue.ContinueWith(
+                    async _ =>
+                    {
+                        try
+                        {
+                            await SaveCaptureAsync(capture).ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.ZLogError(ex, $"Interactive capture failed.");
+                        }
+                    },
+                    CancellationToken.None,
+                    TaskContinuationOptions.None,
+                    TaskScheduler.Default
+                ).Unwrap();
+            }
+        }
+
         var inputTask = Task.Run(
             async () =>
             {
@@ -369,29 +584,6 @@ public static class InteractiveRecorder
                         },
                         CancellationToken.None
                     );
-                }
-
-                void QueueSaveCapture(InteractiveCapture capture)
-                {
-                    lock (captureQueueGate)
-                    {
-                        captureQueue = captureQueue.ContinueWith(
-                            async _ =>
-                            {
-                                try
-                                {
-                                    await SaveCaptureAsync(capture).ConfigureAwait(false);
-                                }
-                                catch (Exception ex)
-                                {
-                                    logger.ZLogError(ex, $"Interactive capture failed.");
-                                }
-                            },
-                            CancellationToken.None,
-                            TaskContinuationOptions.None,
-                            TaskScheduler.Default
-                        ).Unwrap();
-                    }
                 }
 
                 try
@@ -518,12 +710,25 @@ public static class InteractiveRecorder
             {
                 try
                 {
+                    var initialNotificationVersion = Volatile.Read(ref notificationVersion);
                     // cmd/Clink and Starship often clear the terminal while their
                     // startup scripts run. Wait for that output to finish before
                     // drawing the host-only key guide.
                     await Task.Delay(500, lifetime.Token).ConfigureAwait(false);
                     await WaitForOutputToSettleAsync().ConfigureAwait(false);
-                    ShowNotification("F9: Record start   F10: Capture");
+                    if (Volatile.Read(ref notificationVersion) == initialNotificationVersion)
+                    {
+                        Interlocked.Exchange(ref startupIndicatorActive, 1);
+                        await hostOutputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
+                        try
+                        {
+                            await RenderPersistentIndicatorAsync().ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            hostOutputGate.Release();
+                        }
+                    }
                 }
                 catch (OperationCanceledException)
                 {
@@ -545,6 +750,34 @@ public static class InteractiveRecorder
         }
         finally
         {
+            var childExited = connection.WaitForExit(0);
+            if (childExited)
+            {
+                // Drain the PTY before completing the recording so its final output
+                // becomes part of the saved capture.
+                await IgnoreFailureAsync(outputTask).ConfigureAwait(false);
+                InteractiveCapture? capture = null;
+                lock (captureGate)
+                {
+                    if (videoFrames is not null)
+                    {
+                        capture = CompleteRecording(
+                            videoFrames,
+                            stopwatch.Elapsed.TotalSeconds - videoStarted,
+                            emulator.Buffer
+                        );
+                        videoFrames = null;
+                    }
+                }
+
+                if (capture is not null)
+                {
+                    Interlocked.Exchange(ref recordingIndicatorActive, 0);
+                    Interlocked.Increment(ref notificationVersion);
+                    QueueSaveCapture(capture);
+                }
+            }
+
             await lifetime.CancelAsync().ConfigureAwait(false);
             connection.Dispose();
             await IgnoreFailureAsync(outputTask).ConfigureAwait(false);
@@ -559,7 +792,20 @@ public static class InteractiveRecorder
             // mode. Reset it before restoring the host input mode so selection is
             // available after an interactive session ends.
             PtyRecorder.TryDisableTerminalMouseTracking(forwardToConsole: true, logger);
-            await ClearHostTerminalAsync().ConfigureAwait(false);
+            try
+            {
+                await ClearHostTerminalAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                rawInput?.Dispose();
+            }
+            await Console.Out
+                .WriteLineAsync(
+                    "console2svg interactive mode finished".AsMemory(),
+                    CancellationToken.None
+                )
+                .ConfigureAwait(false);
         }
     }
 

--- a/src/ConsoleToSvg.Record/InteractiveRecorder.cs
+++ b/src/ConsoleToSvg.Record/InteractiveRecorder.cs
@@ -1,0 +1,365 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using ConsoleToSvg.Terminal;
+using Microsoft.Extensions.Logging;
+using ZLogger;
+
+namespace ConsoleToSvg.Recording;
+
+public sealed class InteractiveCapture
+{
+    public InteractiveCapture(ScreenBuffer screen)
+    {
+        Screen = screen;
+        Frames = [];
+    }
+
+    public InteractiveCapture(IReadOnlyList<TerminalFrame> frames)
+    {
+        Frames = frames;
+        Screen = frames[0].Buffer;
+    }
+
+    public ScreenBuffer Screen { get; }
+
+    public IReadOnlyList<TerminalFrame> Frames { get; }
+
+    public bool IsVideo => Frames.Count > 0;
+}
+
+/// <summary>Runs an interactive shell in a PTY and emits snapshots without sending capture keys to it.</summary>
+public static class InteractiveRecorder
+{
+    public static async Task RunAsync(
+        int width,
+        int height,
+        Theme theme,
+        ReadOnlyMemory<byte> captureKey,
+        bool video,
+        bool noDeleteEnvs,
+        Func<InteractiveCapture, Task> onCapture,
+        CancellationToken cancellationToken,
+        ILogger? logger = null
+    )
+    {
+        if (captureKey.IsEmpty)
+        {
+            throw new ArgumentException("A capture key is required.", nameof(captureKey));
+        }
+
+        logger ??= Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
+        var emulator = new TerminalEmulator(width, height, theme);
+        var captureGate = new object();
+        List<TerminalFrame>? videoFrames = null;
+        var videoStarted = 0d;
+        var stopwatch = Stopwatch.StartNew();
+
+        var options = BuildOptions(width, height, noDeleteEnvs);
+        using var connection = await NativePty
+            .SpawnAsync(options, cancellationToken)
+            .ConfigureAwait(false);
+        using var lifetime = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        using var rawInput = PtyRecorder.ConsoleInputMode.TryEnableRaw(logger);
+        var output = Console.OpenStandardOutput();
+        var outputWriter =
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected
+                ? Console.Out
+                : null;
+        var input = Console.OpenStandardInput();
+
+        async Task CaptureAsync()
+        {
+            InteractiveCapture capture;
+            lock (captureGate)
+            {
+                if (!video)
+                {
+                    capture = new InteractiveCapture(emulator.Buffer.Clone());
+                }
+                else if (videoFrames is null)
+                {
+                    videoStarted = stopwatch.Elapsed.TotalSeconds;
+                    videoFrames = [new TerminalFrame(0d, emulator.Buffer.Clone())];
+                    return;
+                }
+                else
+                {
+                    capture = new InteractiveCapture(videoFrames);
+                    videoFrames = null;
+                }
+            }
+
+            await onCapture(capture).ConfigureAwait(false);
+        }
+
+        var outputTask = Task.Run(
+            async () =>
+            {
+                var bytes = new byte[4096];
+                var chars = new char[8192];
+                var outputEncoding = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? Console.OutputEncoding
+                    : Encoding.UTF8;
+                var decoder = outputEncoding.GetDecoder();
+                try
+                {
+                    while (!lifetime.IsCancellationRequested)
+                    {
+                        var count = await connection.ReaderStream
+                            .ReadAsync(bytes, 0, bytes.Length, lifetime.Token)
+                            .ConfigureAwait(false);
+                        if (count <= 0)
+                        {
+                            break;
+                        }
+
+                        var charCount = decoder.GetChars(bytes, 0, count, chars, 0, flush: false);
+                        lock (captureGate)
+                        {
+                            if (charCount > 0)
+                            {
+                                var text = new string(chars, 0, charCount);
+                                emulator.Process(text);
+                                if (videoFrames is not null)
+                                {
+                                    videoFrames.Add(
+                                        new TerminalFrame(
+                                            stopwatch.Elapsed.TotalSeconds - videoStarted,
+                                            emulator.Buffer.Clone()
+                                        )
+                                    );
+                                }
+                            }
+                        }
+
+                        if (outputWriter is not null)
+                        {
+                            if (charCount > 0)
+                            {
+                                await outputWriter
+                                    .WriteAsync(chars.AsMemory(0, charCount), lifetime.Token)
+                                    .ConfigureAwait(false);
+                                await outputWriter.FlushAsync(lifetime.Token).ConfigureAwait(false);
+                            }
+                        }
+                        else
+                        {
+                            await output
+                                .WriteAsync(bytes, 0, count, lifetime.Token)
+                                .ConfigureAwait(false);
+                            await output.FlushAsync(lifetime.Token).ConfigureAwait(false);
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Normal shutdown.
+                }
+                catch (IOException) when (lifetime.IsCancellationRequested)
+                {
+                    // Closing a Unix PTY may surface as EIO.
+                }
+            },
+            CancellationToken.None
+        );
+
+        var inputTask = Task.Run(
+            async () =>
+            {
+                var bytes = new byte[256];
+                var pending = new List<byte>(captureKey.Length);
+                try
+                {
+                    while (!lifetime.IsCancellationRequested)
+                    {
+                        var count = await input
+                            .ReadAsync(bytes, 0, bytes.Length, lifetime.Token)
+                            .ConfigureAwait(false);
+                        if (count <= 0)
+                        {
+                            break;
+                        }
+
+                        for (var i = 0; i < count; i++)
+                        {
+                            pending.Add(bytes[i]);
+                            while (pending.Count > 0)
+                            {
+                                if (IsPrefix(pending, captureKey.Span))
+                                {
+                                    if (pending.Count == captureKey.Length)
+                                    {
+                                        pending.Clear();
+                                        try
+                                        {
+                                            await CaptureAsync().ConfigureAwait(false);
+                                        }
+                                        catch (Exception ex)
+                                        {
+                                            logger.ZLogError(ex, $"Interactive capture failed.");
+                                            await Console.Error.WriteLineAsync(
+                                                $"Interactive capture failed: {ex.Message}".AsMemory(),
+                                                CancellationToken.None
+                                            );
+                                        }
+                                    }
+                                    break;
+                                }
+
+                                await connection.WriterStream
+                                    .WriteAsync(new byte[] { pending[0] }, lifetime.Token)
+                                    .ConfigureAwait(false);
+                                pending.RemoveAt(0);
+                            }
+                        }
+
+                        // F12 begins with ESC. Do not indefinitely swallow a standalone
+                        // Escape key when an application receives it in a separate read.
+                        if (pending.Count == 1 && pending[0] == 0x1b)
+                        {
+                            await connection.WriterStream
+                                .WriteAsync(new byte[] { pending[0] }, lifetime.Token)
+                                .ConfigureAwait(false);
+                            pending.Clear();
+                        }
+
+                        await connection.WriterStream.FlushAsync(lifetime.Token).ConfigureAwait(false);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Normal shutdown.
+                }
+                catch (IOException)
+                {
+                    // The shell exited while input was being forwarded.
+                }
+                catch (Exception ex)
+                {
+                    logger.ZLogError(ex, $"Interactive input or capture failed.");
+                    await Console.Error.WriteLineAsync(
+                        $"Interactive capture failed: {ex.Message}".AsMemory(),
+                        CancellationToken.None
+                    );
+                }
+            },
+            CancellationToken.None
+        );
+
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested && !outputTask.IsCompleted)
+            {
+                if (connection.WaitForExit(50))
+                {
+                    break;
+                }
+            }
+        }
+        finally
+        {
+            await lifetime.CancelAsync().ConfigureAwait(false);
+            connection.Dispose();
+            await IgnoreFailureAsync(outputTask).ConfigureAwait(false);
+            await IgnoreFailureAsync(inputTask).ConfigureAwait(false);
+        }
+    }
+
+    private static bool IsPrefix(List<byte> value, ReadOnlySpan<byte> expected)
+    {
+        if (value.Count > expected.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < value.Count; i++)
+        {
+            if (value[i] != expected[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static async Task IgnoreFailureAsync(Task task)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+        catch
+        {
+            // PTY shutdown races are expected.
+        }
+    }
+
+    private static NativePtyOptions BuildOptions(int width, int height, bool noDeleteEnvs)
+    {
+        var environment = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (System.Collections.DictionaryEntry entry in Environment.GetEnvironmentVariables())
+        {
+            if (entry.Key is string key && entry.Value is string value)
+            {
+                environment[key] = value;
+            }
+        }
+
+        environment["COLUMNS"] = width.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        environment["LINES"] = height.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        if (!noDeleteEnvs)
+        {
+            environment.Remove("CI");
+            environment.Remove("TF_BUILD");
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var shell = Environment.GetEnvironmentVariable("COMSPEC");
+            if (string.IsNullOrWhiteSpace(shell))
+            {
+                shell = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.System),
+                    "cmd.exe"
+                );
+            }
+
+            return new NativePtyOptions
+            {
+                Name = "console2svg",
+                Cols = width,
+                Rows = height,
+                Cwd = Environment.CurrentDirectory,
+                App = shell,
+                Args = ["/d", "/k"],
+                Environment = environment,
+                DisableInputEcho = false,
+            };
+        }
+
+        var unixShell = Environment.GetEnvironmentVariable("SHELL");
+        if (string.IsNullOrWhiteSpace(unixShell))
+        {
+            unixShell = "/bin/sh";
+        }
+
+        return new NativePtyOptions
+        {
+            Name = "console2svg",
+            Cols = width,
+            Rows = height,
+            Cwd = Environment.CurrentDirectory,
+            App = unixShell,
+            Args = ["-i"],
+            Environment = environment,
+            DisableInputEcho = false,
+        };
+    }
+}

--- a/src/ConsoleToSvg.Record/InteractiveRecorder.cs
+++ b/src/ConsoleToSvg.Record/InteractiveRecorder.cs
@@ -186,7 +186,7 @@ public static class InteractiveRecorder
             }
         }
 
-        async Task CaptureScreenshotAsync()
+        async Task<InteractiveCapture> CaptureScreenshotAsync()
         {
             await WaitForOutputToSettleAsync().ConfigureAwait(false);
             InteractiveCapture capture;
@@ -195,10 +195,10 @@ public static class InteractiveRecorder
                 capture = new InteractiveCapture(emulator.Buffer.Clone());
             }
 
-            await SaveCaptureAsync(capture).ConfigureAwait(false);
+            return capture;
         }
 
-        async Task ToggleRecordingAsync()
+        async Task<InteractiveCapture?> ToggleRecordingAsync()
         {
             var isStarting = false;
             lock (captureGate)
@@ -214,7 +214,7 @@ public static class InteractiveRecorder
             if (isStarting)
             {
                 ShowNotification("Recording started");
-                return;
+                return null;
             }
 
             await WaitForOutputToSettleAsync().ConfigureAwait(false);
@@ -229,7 +229,7 @@ public static class InteractiveRecorder
                 videoFrames = null;
             }
 
-            await SaveCaptureAsync(capture).ConfigureAwait(false);
+            return capture;
         }
 
         var outputTask = Task.Run(
@@ -317,6 +317,8 @@ public static class InteractiveRecorder
             CancellationToken.None
         );
 
+        var captureQueueGate = new object();
+        Task captureQueue = Task.CompletedTask;
         var inputTask = Task.Run(
             async () =>
             {
@@ -367,6 +369,29 @@ public static class InteractiveRecorder
                         },
                         CancellationToken.None
                     );
+                }
+
+                void QueueSaveCapture(InteractiveCapture capture)
+                {
+                    lock (captureQueueGate)
+                    {
+                        captureQueue = captureQueue.ContinueWith(
+                            async _ =>
+                            {
+                                try
+                                {
+                                    await SaveCaptureAsync(capture).ConfigureAwait(false);
+                                }
+                                catch (Exception ex)
+                                {
+                                    logger.ZLogError(ex, $"Interactive capture failed.");
+                                }
+                            },
+                            CancellationToken.None,
+                            TaskContinuationOptions.None,
+                            TaskScheduler.Default
+                        ).Unwrap();
+                    }
                 }
 
                 try
@@ -426,7 +451,9 @@ public static class InteractiveRecorder
                                     case InteractiveInputAction.Screenshot:
                                         try
                                         {
-                                            await CaptureScreenshotAsync().ConfigureAwait(false);
+                                            QueueSaveCapture(
+                                                await CaptureScreenshotAsync().ConfigureAwait(false)
+                                            );
                                         }
                                         catch (Exception ex)
                                         {
@@ -436,7 +463,11 @@ public static class InteractiveRecorder
                                     case InteractiveInputAction.ToggleRecording:
                                         try
                                         {
-                                            await ToggleRecordingAsync().ConfigureAwait(false);
+                                            var capture = await ToggleRecordingAsync().ConfigureAwait(false);
+                                            if (capture is not null)
+                                            {
+                                                QueueSaveCapture(capture);
+                                            }
                                         }
                                         catch (Exception ex)
                                         {
@@ -518,6 +549,12 @@ public static class InteractiveRecorder
             connection.Dispose();
             await IgnoreFailureAsync(outputTask).ConfigureAwait(false);
             await IgnoreFailureAsync(inputTask).ConfigureAwait(false);
+            Task pendingCaptures;
+            lock (captureQueueGate)
+            {
+                pendingCaptures = captureQueue;
+            }
+            await IgnoreFailureAsync(pendingCaptures).ConfigureAwait(false);
             // A child application can leave the outer terminal in mouse-reporting
             // mode. Reset it before restoring the host input mode so selection is
             // available after an interactive session ends.

--- a/src/ConsoleToSvg.Record/InteractiveRecorder.cs
+++ b/src/ConsoleToSvg.Record/InteractiveRecorder.cs
@@ -61,6 +61,7 @@ public static class InteractiveRecorder
         List<TerminalFrame>? videoFrames = null;
         var videoStarted = 0d;
         var stopwatch = Stopwatch.StartNew();
+        long lastOutputTimestamp = Stopwatch.GetTimestamp();
 
         var options = BuildOptions(width, height, noDeleteEnvs, command);
         using var connection = await NativePty
@@ -76,6 +77,29 @@ public static class InteractiveRecorder
         var input = Console.OpenStandardInput();
         PtyRecorder.TryDisableTerminalMouseTracking(forwardToConsole: true, logger);
 
+        async Task ClearHostTerminalAsync()
+        {
+            if (Console.IsOutputRedirected)
+            {
+                return;
+            }
+
+            await hostOutputGate.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+            try
+            {
+                // Match the visible part of `cls` without sending anything to the
+                // child PTY. The child will still receive Ctrl+L and redraw itself.
+                var clear = "\u001b[2J\u001b[H";
+                await output.WriteAsync(Encoding.ASCII.GetBytes(clear), CancellationToken.None)
+                    .ConfigureAwait(false);
+                await output.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+            finally
+            {
+                hostOutputGate.Release();
+            }
+        }
+
         async Task NotifyAsync(string message)
         {
             if (Console.IsOutputRedirected)
@@ -83,23 +107,34 @@ public static class InteractiveRecorder
                 return;
             }
 
+            var width = Math.Max(20, Console.WindowWidth);
+            var label = $"  {message}  ";
+            if (label.Length > width - 2)
+            {
+                label = label[..Math.Max(1, width - 2)];
+            }
+
+            var column = Math.Max(1, width - label.Length);
             await hostOutputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
             try
             {
                 // This is deliberately written to the host terminal, never the PTY.
                 // Saving/restoring the cursor prevents it from becoming shell input.
-                var width = Math.Max(20, Console.WindowWidth);
-                var label = $"  {message}  ";
-                if (label.Length > width - 2)
-                {
-                    label = label[..Math.Max(1, width - 2)];
-                }
-
-                var column = Math.Max(1, width - label.Length);
                 var overlay = $"\u001b7\u001b[1;{column}H\u001b[30;48;5;114m{label}\u001b[0m\u001b8";
                 await output.WriteAsync(Encoding.UTF8.GetBytes(overlay), lifetime.Token).ConfigureAwait(false);
                 await output.FlushAsync(lifetime.Token).ConfigureAwait(false);
-                await Task.Delay(TimeSpan.FromMilliseconds(1500), lifetime.Token).ConfigureAwait(false);
+            }
+            finally
+            {
+                hostOutputGate.Release();
+            }
+
+            // Do not hold the output gate while the popup is visible: PTY output
+            // must keep flowing while the user continues typing.
+            await Task.Delay(TimeSpan.FromMilliseconds(1500), lifetime.Token).ConfigureAwait(false);
+            await hostOutputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
+            try
+            {
                 var clear = $"\u001b7\u001b[1;{column}H{new string(' ', label.Length)}\u001b8";
                 await output.WriteAsync(Encoding.UTF8.GetBytes(clear), lifetime.Token).ConfigureAwait(false);
                 await output.FlushAsync(lifetime.Token).ConfigureAwait(false);
@@ -110,17 +145,48 @@ public static class InteractiveRecorder
             }
         }
 
+        void ShowNotification(string message)
+        {
+            _ = NotifyAsync(message).ContinueWith(
+                task => logger.ZLogDebug(task.Exception, $"Interactive notification failed."),
+                TaskContinuationOptions.OnlyOnFaulted
+            );
+        }
+
+        async Task WaitForOutputToSettleAsync()
+        {
+            const int quietMilliseconds = 100;
+            const int maxWaitMilliseconds = 750;
+            // Allow output caused by the immediately preceding Enter/key press to
+            // reach the PTY before considering the terminal idle.
+            await Task.Delay(150, lifetime.Token).ConfigureAwait(false);
+            var started = Stopwatch.GetTimestamp();
+            while (!lifetime.IsCancellationRequested)
+            {
+                var now = Stopwatch.GetTimestamp();
+                var quietFor = (now - Volatile.Read(ref lastOutputTimestamp)) * 1000 / Stopwatch.Frequency;
+                var waited = (now - started) * 1000 / Stopwatch.Frequency;
+                if (quietFor >= quietMilliseconds || waited >= maxWaitMilliseconds)
+                {
+                    return;
+                }
+
+                await Task.Delay(20, lifetime.Token).ConfigureAwait(false);
+            }
+        }
+
         async Task SaveCaptureAsync(InteractiveCapture capture)
         {
             var message = await onCapture(capture).ConfigureAwait(false);
             if (!string.IsNullOrWhiteSpace(message))
             {
-                await NotifyAsync(message).ConfigureAwait(false);
+                ShowNotification(message);
             }
         }
 
         async Task CaptureScreenshotAsync()
         {
+            await WaitForOutputToSettleAsync().ConfigureAwait(false);
             InteractiveCapture capture;
             lock (captureGate)
             {
@@ -132,25 +198,33 @@ public static class InteractiveRecorder
 
         async Task ToggleRecordingAsync()
         {
-            InteractiveCapture? capture = null;
+            var isStarting = false;
             lock (captureGate)
             {
                 if (videoFrames is null)
                 {
                     videoStarted = stopwatch.Elapsed.TotalSeconds;
                     videoFrames = [new TerminalFrame(0d, emulator.Buffer.Clone())];
-                }
-                else
-                {
-                    capture = new InteractiveCapture(videoFrames);
-                    videoFrames = null;
+                    isStarting = true;
                 }
             }
 
-            if (capture is null)
+            if (isStarting)
             {
-                await NotifyAsync("Recording started").ConfigureAwait(false);
+                ShowNotification("Recording started");
                 return;
+            }
+
+            await WaitForOutputToSettleAsync().ConfigureAwait(false);
+            InteractiveCapture capture;
+            lock (captureGate)
+            {
+                capture = CompleteRecording(
+                    videoFrames,
+                    stopwatch.Elapsed.TotalSeconds - videoStarted,
+                    emulator.Buffer
+                );
+                videoFrames = null;
             }
 
             await SaveCaptureAsync(capture).ConfigureAwait(false);
@@ -185,6 +259,7 @@ public static class InteractiveRecorder
                             {
                                 var text = new string(chars, 0, charCount);
                                 emulator.Process(text);
+                                Volatile.Write(ref lastOutputTimestamp, Stopwatch.GetTimestamp());
                                 if (videoFrames is not null)
                                 {
                                     videoFrames.Add(
@@ -244,8 +319,7 @@ public static class InteractiveRecorder
             async () =>
             {
                 var bytes = new byte[256];
-                var pending = new List<byte>(Math.Max(screenshotKey.Length, recordingKey.Length));
-                var discardingSgrMouseReport = false;
+                var router = new InteractiveInputRouter(screenshotKey.Span, recordingKey.Span);
                 var inputGate = new SemaphoreSlim(1, 1);
                 long escapePendingVersion = 0;
 
@@ -262,14 +336,14 @@ public static class InteractiveRecorder
                                 {
                                     if (
                                         Volatile.Read(ref escapePendingVersion) == version
-                                        && pending.Count == 1
-                                        && pending[0] == 0x1b
+                                        && router.HasStandaloneEscape
                                     )
                                     {
+                                        var forwarded = new List<byte>(1);
+                                        router.ForwardPending(forwarded);
                                         await connection.WriterStream
-                                            .WriteAsync(pending.ToArray(), lifetime.Token)
+                                            .WriteAsync(forwarded.ToArray(), lifetime.Token)
                                             .ConfigureAwait(false);
-                                        pending.Clear();
                                         await connection.WriterStream
                                             .FlushAsync(lifetime.Token)
                                             .ConfigureAwait(false);
@@ -298,6 +372,10 @@ public static class InteractiveRecorder
                             .ConfigureAwait(false);
                         if (count <= 0)
                         {
+                            // An EOF from the outer terminal is another form of
+                            // Ctrl+D. Do not leave the child shell running after its
+                            // input owner has gone away.
+                            await lifetime.CancelAsync().ConfigureAwait(false);
                             break;
                         }
 
@@ -308,72 +386,46 @@ public static class InteractiveRecorder
                             Interlocked.Increment(ref escapePendingVersion);
                             for (var i = 0; i < count; i++)
                             {
-                                if (discardingSgrMouseReport)
+                                var forwarded = new List<byte>();
+                                var action = router.Process(bytes[i], forwarded);
+                                if (forwarded.Count > 0)
                                 {
-                                    if (bytes[i] is (byte)'M' or (byte)'m')
-                                    {
-                                        discardingSgrMouseReport = false;
-                                    }
-
-                                    continue;
+                                    await connection.WriterStream
+                                        .WriteAsync(forwarded.ToArray(), lifetime.Token)
+                                        .ConfigureAwait(false);
                                 }
 
-                                pending.Add(bytes[i]);
-                                while (pending.Count > 0)
+                                switch (action)
                                 {
-                                    if (IsPrefix(pending, screenshotKey.Span) || IsPrefix(pending, recordingKey.Span))
-                                    {
-                                        if (pending.Count == screenshotKey.Length && IsPrefix(pending, screenshotKey.Span))
+                                    case InteractiveInputAction.Exit:
+                                        await lifetime.CancelAsync().ConfigureAwait(false);
+                                        return;
+                                    case InteractiveInputAction.Screenshot:
+                                        try
                                         {
-                                            pending.Clear();
-                                            try
-                                            {
-                                                await CaptureScreenshotAsync().ConfigureAwait(false);
-                                            }
-                                            catch (Exception ex)
-                                            {
-                                                logger.ZLogError(ex, $"Interactive capture failed.");
-                                            }
+                                            await CaptureScreenshotAsync().ConfigureAwait(false);
                                         }
-                                        else if (pending.Count == recordingKey.Length && IsPrefix(pending, recordingKey.Span))
+                                        catch (Exception ex)
                                         {
-                                            pending.Clear();
-                                            try
-                                            {
-                                                await ToggleRecordingAsync().ConfigureAwait(false);
-                                            }
-                                            catch (Exception ex)
-                                            {
-                                                logger.ZLogError(ex, $"Interactive recording capture failed.");
-                                            }
+                                            logger.ZLogError(ex, $"Interactive capture failed.");
                                         }
                                         break;
-                                    }
-
-                                    // ENABLE_VIRTUAL_TERMINAL_INPUT can surface host mouse
-                                    // reports as CSI <... M/m. They are neither shell input
-                                    // nor capture keys; forwarding them produces visible
-                                    // fragments such as "[<35;..." in line editors.
-                                    if (IsSgrMouseReportPrefix(pending))
-                                    {
-                                        pending.Clear();
-                                        discardingSgrMouseReport = true;
+                                    case InteractiveInputAction.ToggleRecording:
+                                        try
+                                        {
+                                            await ToggleRecordingAsync().ConfigureAwait(false);
+                                        }
+                                        catch (Exception ex)
+                                        {
+                                            logger.ZLogError(ex, $"Interactive recording capture failed.");
+                                        }
                                         break;
-                                    }
-
-                                    // Any non-capture sequence is opaque input. Forward
-                                    // it as received rather than special-casing cursor
-                                    // keys, paste markers, modifiers, or future VT keys.
-                                    await connection.WriterStream
-                                        .WriteAsync(pending.ToArray(), lifetime.Token)
-                                        .ConfigureAwait(false);
-                                    pending.Clear();
                                 }
                             }
 
                             // Function keys and other VT input can arrive across reads.
                             // Give a lone Escape a short grace period before forwarding it.
-                            if (pending.Count == 1 && pending[0] == 0x1b)
+                            if (router.HasStandaloneEscape)
                             {
                                 var version = Interlocked.Increment(ref escapePendingVersion);
                                 ScheduleStandaloneEscape(version);
@@ -407,6 +459,26 @@ public static class InteractiveRecorder
             CancellationToken.None
         );
 
+        _ = Task.Run(
+            async () =>
+            {
+                try
+                {
+                    // cmd/Clink and Starship often clear the terminal while their
+                    // startup scripts run. Wait for that output to finish before
+                    // drawing the host-only key guide.
+                    await Task.Delay(500, lifetime.Token).ConfigureAwait(false);
+                    await WaitForOutputToSettleAsync().ConfigureAwait(false);
+                    ShowNotification("F9: Record start   F10: Capture");
+                }
+                catch (OperationCanceledException)
+                {
+                    // The shell exited before its startup hint was needed.
+                }
+            },
+            CancellationToken.None
+        );
+
         try
         {
             while (!cancellationToken.IsCancellationRequested && !outputTask.IsCompleted)
@@ -427,31 +499,21 @@ public static class InteractiveRecorder
             // mode. Reset it before restoring the host input mode so selection is
             // available after an interactive session ends.
             PtyRecorder.TryDisableTerminalMouseTracking(forwardToConsole: true, logger);
+            await ClearHostTerminalAsync().ConfigureAwait(false);
         }
     }
 
-    private static bool IsPrefix(List<byte> value, ReadOnlySpan<byte> expected)
+    public static InteractiveCapture CompleteRecording(
+        List<TerminalFrame> frames,
+        double elapsedSeconds,
+        ScreenBuffer finalScreen
+    )
     {
-        if (value.Count > expected.Length)
-        {
-            return false;
-        }
-
-        for (var i = 0; i < value.Count; i++)
-        {
-            if (value[i] != expected[i])
-            {
-                return false;
-            }
-        }
-
-        return true;
+        frames.Add(new TerminalFrame(elapsedSeconds, finalScreen.Clone()));
+        return new InteractiveCapture(frames.ToArray());
     }
 
-    private static bool IsSgrMouseReportPrefix(List<byte> value) =>
-        value.Count == 3 && value[0] == 0x1b && value[1] == (byte)'[' && value[2] == (byte)'<';
-
-    private sealed class HostTerminalSequenceFilter
+    public sealed class HostTerminalSequenceFilter
     {
         private static readonly HashSet<string> SuppressedPrivateModes =
             ["9", "1000", "1002", "1003", "1004", "1005", "1006", "1015", "1016", "9001"];

--- a/src/ConsoleToSvg.Record/InteractiveRecorder.cs
+++ b/src/ConsoleToSvg.Record/InteractiveRecorder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
@@ -797,26 +798,27 @@ public static class InteractiveRecorder
                 // Drain the PTY before completing the recording so its final output
                 // becomes part of the saved capture.
                 await IgnoreFailureAsync(outputTask).ConfigureAwait(false);
-                InteractiveCapture? capture = null;
-                lock (captureGate)
-                {
-                    if (videoFrames is not null)
-                    {
-                        capture = CompleteRecording(
-                            videoFrames,
-                            stopwatch.Elapsed.TotalSeconds - videoStarted,
-                            emulator.Buffer
-                        );
-                        videoFrames = null;
-                    }
-                }
+            }
 
-                if (capture is not null)
+            InteractiveCapture? capture = null;
+            lock (captureGate)
+            {
+                if (videoFrames is not null)
                 {
-                    Interlocked.Exchange(ref recordingIndicatorActive, 0);
-                    Interlocked.Increment(ref notificationVersion);
-                    QueueSaveCapture(capture);
+                    capture = CompleteRecording(
+                        videoFrames,
+                        stopwatch.Elapsed.TotalSeconds - videoStarted,
+                        emulator.Buffer
+                    );
+                    videoFrames = null;
                 }
+            }
+
+            if (capture is not null)
+            {
+                Interlocked.Exchange(ref recordingIndicatorActive, 0);
+                Interlocked.Increment(ref notificationVersion);
+                QueueSaveCapture(capture);
             }
 
             await lifetime.CancelAsync().ConfigureAwait(false);
@@ -920,7 +922,10 @@ public static class InteractiveRecorder
                 }
 
                 var end = index + 3;
-                while (end < _pending.Length && char.IsDigit(_pending[end]))
+                while (
+                    end < _pending.Length
+                    && (char.IsDigit(_pending[end]) || _pending[end] == ';')
+                )
                 {
                     end++;
                 }
@@ -931,7 +936,10 @@ public static class InteractiveRecorder
                 }
 
                 var mode = _pending.ToString(index + 3, end - index - 3);
-                if ((_pending[end] is 'h' or 'l') && SuppressedPrivateModes.Contains(mode))
+                if (
+                    (_pending[end] is 'h' or 'l')
+                    && mode.Split(';').All(SuppressedPrivateModes.Contains)
+                )
                 {
                     index = end + 1;
                     continue;

--- a/src/ConsoleToSvg.Record/InteractiveRecorder.cs
+++ b/src/ConsoleToSvg.Record/InteractiveRecorder.cs
@@ -44,6 +44,7 @@ public static class InteractiveRecorder
         ReadOnlyMemory<byte> recordingKey,
         bool noDeleteEnvs,
         string[]? command,
+        bool exitOnCtrlD,
         Func<InteractiveCapture, Task<string?>> onCapture,
         CancellationToken cancellationToken,
         ILogger? logger = null
@@ -107,6 +108,10 @@ public static class InteractiveRecorder
             .SpawnAsync(options, cancellationToken)
             .ConfigureAwait(false);
         var rawInput = PtyRecorder.ConsoleInputMode.TryEnableRaw(logger);
+        using var utf8OutputScope = PtyRecorder.TryUseUtf8ConsoleOutputEncoding(
+            forwardToConsole: true,
+            logger
+        );
         await ClearHostTerminalAsync().ConfigureAwait(false);
 
         async Task NotifyAsync(string message, bool isRecording, long version)
@@ -494,11 +499,22 @@ public static class InteractiveRecorder
                         }
                         else
                         {
+                            var text = hostSequenceFilter.Filter(
+                                Encoding.UTF8.GetString(bytes, 0, count)
+                            );
+                            if (text.Length == 0)
+                            {
+                                continue;
+                            }
+
                             await hostOutputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
                             try
                             {
                                 await output
-                                    .WriteAsync(bytes, 0, count, lifetime.Token)
+                                    .WriteAsync(
+                                        Encoding.UTF8.GetBytes(text),
+                                        lifetime.Token
+                                    )
                                     .ConfigureAwait(false);
                                 await output.FlushAsync(lifetime.Token).ConfigureAwait(false);
                                 await RenderPersistentIndicatorAsync().ConfigureAwait(false);
@@ -627,6 +643,7 @@ public static class InteractiveRecorder
                         }
 
                         await inputGate.WaitAsync(lifetime.Token).ConfigureAwait(false);
+                        var captures = new List<InteractiveCapture>();
                         try
                         {
                             // A new byte invalidates any pending standalone-Escape timer.
@@ -645,7 +662,10 @@ public static class InteractiveRecorder
                                 switch (action)
                                 {
                                     case InteractiveInputAction.Exit:
-                                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                                        if (
+                                            exitOnCtrlD
+                                            && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                                        )
                                         {
                                             await lifetime.CancelAsync().ConfigureAwait(false);
                                             return;
@@ -657,7 +677,7 @@ public static class InteractiveRecorder
                                     case InteractiveInputAction.Screenshot:
                                         try
                                         {
-                                            QueueSaveCapture(
+                                            captures.Add(
                                                 await CaptureScreenshotAsync().ConfigureAwait(false)
                                             );
                                         }
@@ -672,7 +692,7 @@ public static class InteractiveRecorder
                                             var capture = await ToggleRecordingAsync().ConfigureAwait(false);
                                             if (capture is not null)
                                             {
-                                                QueueSaveCapture(capture);
+                                                captures.Add(capture);
                                             }
                                         }
                                         catch (Exception ex)
@@ -696,6 +716,13 @@ public static class InteractiveRecorder
                         finally
                         {
                             inputGate.Release();
+                        }
+
+                        // Rendering and conversion run after input forwarding releases
+                        // its gate, so an expensive save cannot hold terminal input.
+                        foreach (var capture in captures)
+                        {
+                            QueueSaveCapture(capture);
                         }
                     }
                 }

--- a/src/ConsoleToSvg.Record/InteractiveRecorder.cs
+++ b/src/ConsoleToSvg.Record/InteractiveRecorder.cs
@@ -125,7 +125,16 @@ public static class InteractiveRecorder
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected
                 ? Console.Out
                 : null;
-        await ClearHostTerminalAsync().ConfigureAwait(false);
+        try
+        {
+            await ClearHostTerminalAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            rawInput?.Dispose();
+            connection.Dispose();
+            throw;
+        }
 
         async Task NotifyAsync(string message, bool isRecording, long version)
         {
@@ -1050,12 +1059,26 @@ public static class InteractiveRecorder
                     break;
                 }
 
-                var mode = _pending.ToString(index + 3, end - index - 3);
-                if (
-                    (_pending[end] is 'h' or 'l')
-                    && mode.Split(';').All(SuppressedPrivateModes.Contains)
-                )
+                if (_pending[end] is 'h' or 'l')
                 {
+                    var modes = _pending
+                        .ToString(index + 3, end - index - 3)
+                        .Split(';');
+                    var retainedModes = modes
+                        .Where(mode => !SuppressedPrivateModes.Contains(mode))
+                        .ToArray();
+                    if (retainedModes.Length == modes.Length)
+                    {
+                        output.Append(_pending[index++]);
+                        continue;
+                    }
+
+                    if (retainedModes.Length > 0)
+                    {
+                        output.Append("\u001b[?");
+                        output.Append(string.Join(";", retainedModes));
+                        output.Append(_pending[end]);
+                    }
                     index = end + 1;
                     continue;
                 }

--- a/src/ConsoleToSvg.Record/PtyRecorder.cs
+++ b/src/ConsoleToSvg.Record/PtyRecorder.cs
@@ -626,7 +626,7 @@ public static class PtyRecorder
         return exception.Message.Contains("Input/output error", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static IDisposable? TryUseUtf8ConsoleOutputEncoding(
+    public static IDisposable? TryUseUtf8ConsoleOutputEncoding(
         bool forwardToConsole,
         ILogger logger
     )

--- a/src/ConsoleToSvg.Record/PtyRecorder.cs
+++ b/src/ConsoleToSvg.Record/PtyRecorder.cs
@@ -1360,18 +1360,21 @@ public static class PtyRecorder
                 const int stdinFd = 0;
                 if (tcgetattr(stdinFd, out var termios) != 0)
                 {
+                    logger.ZLogDebug($"tcgetattr failed while enabling raw terminal input. errno={Marshal.GetLastWin32Error()}");
                     return null;
                 }
 
                 var raw = termios;
-                raw.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
-                raw.c_oflag &= ~OPOST;
-                raw.c_cflag |= CS8;
-                raw.c_lflag &= ~(ICANON | ECHO | IEXTEN | ISIG);
+                // Let libc select the platform's complete raw-mode bit set. The
+                // previous hand-maintained flags worked on some Unix terminals but
+                // left WSL input in a cooked mode, so Ctrl keys and F-key VT
+                // sequences were consumed before the PTY forwarder could read them.
+                cfmakeraw(ref raw);
                 raw.c_cc[VMIN] = 1;
                 raw.c_cc[VTIME] = 0;
                 if (tcsetattr(stdinFd, TCSANOW, ref raw) != 0)
                 {
+                    logger.ZLogDebug($"tcsetattr failed while enabling raw terminal input. errno={Marshal.GetLastWin32Error()}");
                     return null;
                 }
 
@@ -1414,17 +1417,6 @@ public static class PtyRecorder
         }
 
         private const int TCSANOW = 0;
-        private const uint BRKINT = 0x0002;
-        private const uint ICRNL = 0x0100;
-        private const uint INPCK = 0x0010;
-        private const uint ISTRIP = 0x0020;
-        private const uint IXON = 0x0400;
-        private const uint OPOST = 0x0001;
-        private const uint CS8 = 0x0030;
-        private const uint ICANON = 0x0002;
-        private const uint ECHO = 0x0008;
-        private const uint IEXTEN = 0x8000;
-        private const uint ISIG = 0x0001;
         private const int VTIME = 5;
         private const int VMIN = 6;
 
@@ -1449,6 +1441,9 @@ public static class PtyRecorder
 
         [DllImport("libc", SetLastError = true)]
         private static extern int tcsetattr(int fd, int optional_actions, ref Termios termios);
+
+        [DllImport("libc")]
+        private static extern void cfmakeraw(ref Termios termios);
 
         [DllImport("kernel32.dll")]
         private static extern IntPtr GetStdHandle(uint nStdHandle);

--- a/src/ConsoleToSvg.Record/PtyRecorder.cs
+++ b/src/ConsoleToSvg.Record/PtyRecorder.cs
@@ -1258,7 +1258,7 @@ public static class PtyRecorder
         return Path.Combine(systemDir, "cmd.exe");
     }
 
-    private sealed class ConsoleInputMode : IDisposable
+    internal sealed class ConsoleInputMode : IDisposable
     {
         private const uint StdInputHandle = 0xFFFFFFF6;
         private const uint EnableProcessedInput = 0x0001;

--- a/src/ConsoleToSvg.Record/PtyRecorder.cs
+++ b/src/ConsoleToSvg.Record/PtyRecorder.cs
@@ -17,7 +17,7 @@ public static class PtyRecorder
 {
     // This sequence disables various mouse tracking modes in the terminal, which can be left enabled by some applications and cause issues with input forwarding (e.g. mouse clicks not working in Vim). It's safe to send this on every recording stop, even if the child process has already exited or doesn't support these modes.
     private const string DisableMouseTrackingSequence =
-        "\u001b[?9l\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1004l\u001b[?1005l\u001b[?1006l\u001b[?1015l\u001b[?1016l";
+        "\u001b[?9l\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1004l\u001b[?1005l\u001b[?1006l\u001b[?1015l\u001b[?1016l\u001b[?9001l";
 
     // remove some CI environments to avoid apps switching to no-color mode.
     // for example: chalk(Node.js) checks "CI" to disable colors on CI environments:
@@ -1082,7 +1082,7 @@ public static class PtyRecorder
         }
     }
 
-    private static void TryDisableTerminalMouseTracking(bool forwardToConsole, ILogger logger)
+    internal static void TryDisableTerminalMouseTracking(bool forwardToConsole, ILogger logger)
     {
         if (!forwardToConsole || Console.IsOutputRedirected)
         {
@@ -1264,6 +1264,7 @@ public static class PtyRecorder
         private const uint EnableProcessedInput = 0x0001;
         private const uint EnableLineInput = 0x0002;
         private const uint EnableEchoInput = 0x0004;
+        private const uint EnableMouseInput = 0x0010;
         private const uint EnableQuickEditMode = 0x0040;
         private const uint EnableExtendedFlags = 0x0080;
         private const uint EnableVirtualTerminalInput = 0x0200;
@@ -1321,9 +1322,11 @@ public static class PtyRecorder
                 }
 
                 var newMode = mode;
-                newMode |= EnableVirtualTerminalInput | EnableExtendedFlags;
+                newMode |= EnableVirtualTerminalInput | EnableExtendedFlags | EnableQuickEditMode;
                 newMode &= ~(EnableLineInput | EnableEchoInput | EnableProcessedInput);
-                newMode &= ~EnableQuickEditMode;
+                // Keep host-side text selection available. Mouse reports, if a host
+                // still emits them as VT input, are discarded by InteractiveRecorder.
+                newMode &= ~EnableMouseInput;
 
                 if (newMode == mode)
                 {

--- a/src/ConsoleToSvg/Cli/AppOptions.cs
+++ b/src/ConsoleToSvg/Cli/AppOptions.cs
@@ -12,7 +12,7 @@ public enum OutputMode
 
 public sealed class AppOptions
 {
-        public bool Verbose { get; set; }
+    public bool Verbose { get; set; }
 
     public string? VerboseLogPath { get; set; }
 
@@ -118,6 +118,9 @@ public sealed class AppOptions
 
     /// <summary>Write SVG output to stdout instead of a file. PTY forwarding is suppressed.</summary>
     public bool StdOut { get; set; }
+
+    /// <summary>Run the user's shell in a PTY and capture the terminal on demand.</summary>
+    public bool Interactive { get; set; }
 
     /// <summary>Directory path to save individual static SVG frames (one per visual frame).</summary>
     public string? SaveFramesDir { get; set; }

--- a/src/ConsoleToSvg/Cli/AppOptions.cs
+++ b/src/ConsoleToSvg/Cli/AppOptions.cs
@@ -23,6 +23,12 @@ public sealed class AppOptions
 
     public string? Command { get; set; }
 
+    /// <summary>
+    /// Unmodified arguments following <c>--</c>. Interactive mode uses these to
+    /// start the requested program without losing argument boundaries.
+    /// </summary>
+    public string[]? DelimitedCommand { get; set; }
+
     public string? InputCastPath { get; set; }
 
     public string OutputPath { get; set; } = "output.svg";

--- a/src/ConsoleToSvg/Cli/OptionParser.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.cs
@@ -21,6 +21,7 @@ public static class OptionParser
                 -w, --width <int|adjust>  Terminal width in characters (default: auto[pipe], 100[pty]).
                 -h, --height <int|adjust> Terminal height in rows (default: auto).
                 -v                        Output animated SVG (alias for --mode video).
+                -i, --interactive         Run an interactive shell; press F12 to capture.
                 -c, --with-command        Prepend the command line to the output.
                 -d, --window [style]      Window chrome: none, macos, windows, macos-pc, windows-pc, transparent.
                 --background <color> [color]  Background color, gradient, or image path.
@@ -73,10 +74,10 @@ public static class OptionParser
                 --header <text>           Override command header text (shown even without -c).
                 --prompt <text>           Prompt prefix for -c (default: $ or # when root).
                 -d, --window [none|macos|windows|macos-pc|windows-pc|transparent|path/to/chrome.json]
-                                          Terminal window chrome style (default: none, or macos if specified without a value).
-                                          Built-in styles: none, macos, windows, transparent.
-                                          Any built-in style can be suffixed with -pc to enable desktop (floating window) mode.
-                                          Custom: provide a path to a .json chrome definition file.
+                    Terminal window chrome style (default: none, or macos if specified without a value).
+                    Built-in styles: none, macos, windows, transparent.
+                    Any built-in style can be suffixed with -pc to enable desktop (floating window) mode.
+                    Custom: provide a path to a .json chrome definition file.
                 --pcmode                  Enable PC (desktop) mode for the selected window style.
                                           Appends -pc to any window style that does not already end in -pc.
                 --pc-padding <px>         Override the outer desktop padding in PC mode (default: 20).
@@ -125,14 +126,19 @@ public static class OptionParser
                                           deterministic: normalize frame times to reduce output diffs.
                                           realtime: preserve measured event timing as-is.
 
+            Options (Interactive mode):
+                -i, --interactive         Run an interactive shell; press F12 to capture.
+                                          In video mode, press once to start and once more
+                                          to write the animation.
+
             Options (Conversion):
                 --svg-converter <auto|ffmpeg|rsvg-convert|resvg>
-                                          SVG → raster converter (default: auto).
-                                          auto: prefer the bundled resvg host, then ffmpeg+librsvg.
-                                          ffmpeg: force ffmpeg (requires librsvg input device).
-                                          rsvg-convert: force the rsvg-convert CLI tool (librsvg2-bin / brew install librsvg).
-                                          resvg: force the bundled resvg renderer.
-                                          When a fallback handles SVG→PNG, ffmpeg is only used for subsequent format conversion.
+                    SVG → raster converter (default: auto).
+                    auto: prefer the bundled resvg host, then ffmpeg+librsvg.
+                    ffmpeg: force ffmpeg (requires librsvg input device).
+                    rsvg-convert: force the rsvg-convert CLI tool (librsvg2-bin / brew install librsvg).
+                    resvg: force the bundled resvg renderer.
+                    When a fallback handles SVG→PNG, ffmpeg is only used for subsequent format conversion.
             """;
 
     public static bool TryParse(
@@ -290,7 +296,9 @@ public static class OptionParser
             && !string.Equals(name, "-d", StringComparison.OrdinalIgnoreCase)
             && !string.Equals(name, "--window", StringComparison.OrdinalIgnoreCase)
             && !string.Equals(name, "--pcmode", StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(name, "--stdout", StringComparison.OrdinalIgnoreCase);
+            && !string.Equals(name, "--stdout", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(name, "-i", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(name, "--interactive", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsVerboseLogPathValue(string token) =>
@@ -697,6 +705,10 @@ public static class OptionParser
                 return true;
             case "--stdout":
                 options.StdOut = true;
+                return true;
+            case "-i":
+            case "--interactive":
+                options.Interactive = true;
                 return true;
             case "--pc-padding":
                 if (!TryParseDouble(value, "--pc-padding", out var pcPadding, out error))
@@ -1127,6 +1139,42 @@ public static class OptionParser
         {
             error = "--timeout must be greater than 0.";
             return false;
+        }
+
+        if (options.Interactive)
+        {
+            if (!string.IsNullOrWhiteSpace(options.Command))
+            {
+                error = "--interactive cannot be used with a command.";
+                return false;
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.InputCastPath))
+            {
+                error = "--interactive cannot be used with --in.";
+                return false;
+            }
+
+            if (options.StdOut)
+            {
+                error = "--interactive cannot be used with --stdout.";
+                return false;
+            }
+
+            if (options.Mode == OutputMode.Repeat)
+            {
+                error = "--interactive cannot be used with --mode repeat.";
+                return false;
+            }
+
+            if (
+                !string.IsNullOrWhiteSpace(options.ReplayPath)
+                || !string.IsNullOrWhiteSpace(options.ReplaySavePath)
+            )
+            {
+                error = "--interactive cannot be used with replay options.";
+                return false;
+            }
         }
 
         if (

--- a/src/ConsoleToSvg/Cli/OptionParser.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.cs
@@ -21,7 +21,8 @@ public static class OptionParser
                 -w, --width <int|adjust>  Terminal width in characters (default: auto[pipe], 100[pty]).
                 -h, --height <int|adjust> Terminal height in rows (default: auto).
                 -v                        Output animated SVG (alias for --mode video).
-                -i, --interactive         Run an interactive shell; press F12 to capture.
+                -i, --interactive         Run an interactive shell; F9 records and F10 takes a screenshot.
+                                          Use -- to start another interactive program (e.g. -i -- pwsh).
                 -c, --with-command        Prepend the command line to the output.
                 -d, --window [style]      Window chrome: none, macos, windows, macos-pc, windows-pc, transparent.
                 --background <color> [color]  Background color, gradient, or image path.
@@ -127,9 +128,10 @@ public static class OptionParser
                                           realtime: preserve measured event timing as-is.
 
             Options (Interactive mode):
-                -i, --interactive         Run an interactive shell; press F12 to capture.
-                                          In video mode, press once to start and once more
-                                          to write the animation.
+                -i, --interactive         Run an interactive shell. F9 starts/stops an animation recording;
+                                          F10 saves a static screenshot. These keys work independently of -v.
+                                          Use -- to start another interactive program, preserving its arguments
+                                          (e.g. -i -- pwsh, -i -- vim README.md).
 
             Options (Conversion):
                 --svg-converter <auto|ffmpeg|rsvg-convert|resvg>
@@ -172,7 +174,8 @@ public static class OptionParser
                     return false;
                 }
 
-                options.Command = string.Join(' ', args, i + 1, args.Length - (i + 1));
+                options.DelimitedCommand = args[(i + 1)..];
+                options.Command = string.Join(' ', options.DelimitedCommand);
                 break;
             }
 
@@ -1143,9 +1146,9 @@ public static class OptionParser
 
         if (options.Interactive)
         {
-            if (!string.IsNullOrWhiteSpace(options.Command))
+            if (!string.IsNullOrWhiteSpace(options.Command) && options.DelimitedCommand is null)
             {
-                error = "--interactive cannot be used with a command.";
+                error = "An interactive program must be specified after -- (for example: -i -- vim).";
                 return false;
             }
 

--- a/src/ConsoleToSvg/Cli/OptionParser.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.cs
@@ -1162,6 +1162,12 @@ public static class OptionParser
                 return false;
             }
 
+            if (!string.IsNullOrWhiteSpace(options.SaveCastPath))
+            {
+                error = "--interactive cannot be used with --save-cast.";
+                return false;
+            }
+
             if (options.Mode == OutputMode.Repeat)
             {
                 error = "--interactive cannot be used with --mode repeat.";

--- a/src/ConsoleToSvg/Cli/OptionParser.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.cs
@@ -27,8 +27,6 @@ public static class OptionParser
                 -d, --window [style]      Window chrome: none, macos, windows, macos-pc, windows-pc, transparent.
                 --background <color> [color]  Background color, gradient, or image path.
                 --crop-top/bottom/left/right  Crop by px, ch, or text pattern.
-                --forecolor <color>       Override default foreground color.
-                --adjust <value>          SVG text lengthAdjust (default: spacing).
                 --header <text>           Override command header text.
                 --prompt <text>           Override prompt prefix for -c (default: $ or # when root).
                 --verbose [path]          Enable verbose logging (log to path, default: console2svg.log).

--- a/src/ConsoleToSvg/Cli/OptionParser.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.cs
@@ -21,7 +21,7 @@ public static class OptionParser
                 -w, --width <int|adjust>  Terminal width in characters (default: auto[pipe], 100[pty]).
                 -h, --height <int|adjust> Terminal height in rows (default: auto).
                 -v                        Output animated SVG (alias for --mode video).
-                -i, --interactive         Run an interactive shell; F9 records and F10 takes a screenshot.
+                -i, --interactive         Run an interactive shell; F9 records, F12 pauses, and F10 takes a screenshot.
                                           Use -- to start another interactive program (e.g. -i -- pwsh).
                 -c, --with-command        Prepend the command line to the output.
                 -d, --window [style]      Window chrome: none, macos, windows, macos-pc, windows-pc, transparent.
@@ -127,7 +127,7 @@ public static class OptionParser
 
             Options (Interactive mode):
                 -i, --interactive         Run an interactive shell. F9 starts/stops an animation recording;
-                                          F10 saves a static screenshot. These keys work independently of -v.
+                                          F12 pauses/resumes it, and F10 saves a static screenshot. These keys work independently of -v.
                                           Use -- to start another interactive program, preserving its arguments
                                           (e.g. -i -- pwsh, -i -- vim README.md).
 

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -495,18 +495,15 @@ internal static class Program
             theme = theme.WithForeground(renderOptions.ForeColor);
         }
 
-        await Console.Error.WriteLineAsync(
-            "Interactive shell started. Press F12 to capture.".AsMemory(),
-            CancellationToken.None
-        );
         await InteractiveRecorder
             .RunAsync(
                 width,
                 height,
                 theme,
-                Encoding.ASCII.GetBytes("\u001b[24~"),
-                options.Mode == OutputMode.Video,
+                Encoding.ASCII.GetBytes("\u001b[21~"),
+                Encoding.ASCII.GetBytes("\u001b[20~"),
                 options.NoDeleteEnvs,
+                options.DelimitedCommand,
                 async capture =>
                 {
                     var outputPath = GetInteractiveOutputPath(options.OutputPath);
@@ -518,10 +515,7 @@ internal static class Program
                             loggerFactory.CreateLogger("ConsoleToSvg.InteractiveCapture")
                         )
                         .ConfigureAwait(false);
-                    await Console.Error.WriteLineAsync(
-                        $"Captured: {outputPath}",
-                        CancellationToken.None
-                    );
+                    return capture.IsVideo ? "Recording saved" : "Screenshot saved";
                 },
                 cancellationToken,
                 loggerFactory.CreateLogger("ConsoleToSvg.InteractiveRecorder")

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -136,7 +136,7 @@ internal static class Program
 
                     SvgConverter.VerifyConversionPipeline(
                         options.SvgConverter,
-                        options.Interactive || RequiresFfmpeg(options, preCheckExt),
+                        RequiresFfmpeg(options, preCheckExt),
                         logger
                     );
                     logger.ZLogDebug(
@@ -508,6 +508,7 @@ internal static class Program
                 options.NoDeleteEnvs,
                 options.DelimitedCommand,
                 options.DelimitedCommand is null or { Length: 0 },
+                IsInteractiveRecordingFormat(options.OutputPath),
                 async capture =>
                 {
                     var outputPath = GetInteractiveOutputPath(options.OutputPath);
@@ -542,7 +543,7 @@ internal static class Program
             extension = ".svg";
         }
 
-        var stamp = DateTime.Now.ToString("yyyyMMdd_HHmmss", System.Globalization.CultureInfo.InvariantCulture);
+        var stamp = DateTime.Now.ToString("yyyyMMdd_HHmmssfff", System.Globalization.CultureInfo.InvariantCulture);
         var candidateName = $"{name}_{stamp}{extension}";
         var candidate = string.IsNullOrEmpty(directory)
             ? candidateName
@@ -569,12 +570,12 @@ internal static class Program
     )
     {
         EnsureDirectory(outputPath);
-        var svg = capture.IsVideo
-            ? AnimatedSvgRenderer.RenderFrames(capture.Frames, renderOptions)
-            : SvgRenderer.Render(capture.Screen, renderOptions);
         var extension = Path.GetExtension(outputPath).TrimStart('.').ToLowerInvariant();
         if (string.IsNullOrEmpty(extension) || extension == "svg")
         {
+            var svg = capture.IsVideo
+                ? AnimatedSvgRenderer.RenderFrames(capture.Frames, renderOptions)
+                : SvgRenderer.Render(capture.Screen, renderOptions);
             await File.WriteAllTextAsync(
                     outputPath,
                     svg,
@@ -582,6 +583,30 @@ internal static class Program
                     CancellationToken.None
                 )
                 .ConfigureAwait(false);
+
+            if (capture.IsVideo && !string.IsNullOrWhiteSpace(options.SaveFramesDir))
+            {
+                var framesPath = Path.Combine(
+                    options.SaveFramesDir,
+                    Path.GetFileNameWithoutExtension(outputPath)
+                );
+                Directory.CreateDirectory(framesPath);
+                var frames = SampleInteractiveFrames(
+                    FilterInteractiveFrames(capture.Frames, renderOptions),
+                    options.VideoFps
+                );
+                var utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+                for (var i = 0; i < frames.Count; i++)
+                {
+                    await File.WriteAllTextAsync(
+                            Path.Combine(framesPath, $"frame-{i:D4}.svg"),
+                            SvgRenderer.Render(frames[i].Buffer, renderOptions),
+                            utf8,
+                            CancellationToken.None
+                        )
+                        .ConfigureAwait(false);
+                }
+            }
             return;
         }
 
@@ -593,12 +618,12 @@ internal static class Program
             logger
         );
         var preserveFrames = capture.IsVideo && !string.IsNullOrWhiteSpace(options.SaveFramesDir);
-        var workPath = preserveFrames
-            ? Path.Combine(
-                options.SaveFramesDir!,
-                Path.GetFileNameWithoutExtension(outputPath)
-            )
-            : Path.Combine(Path.GetTempPath(), $"c2s-{Guid.NewGuid():N}");
+        var preservedFramesPath = preserveFrames
+            ? Path.Combine(options.SaveFramesDir!, Path.GetFileNameWithoutExtension(outputPath))
+            : null;
+        // Conversion may replace SVGs with PNG intermediates. Keep that work
+        // separate from --save-frames so the requested SVG frames survive.
+        var workPath = Path.Combine(Path.GetTempPath(), $"c2s-{Guid.NewGuid():N}");
         try
         {
             if (capture.IsVideo)
@@ -611,13 +636,20 @@ internal static class Program
                 for (var i = 0; i < frames.Count; i++)
                 {
                     var frameSvg = SvgRenderer.Render(frames[i].Buffer, renderOptions);
+                    var fileName = $"frame-{i:D4}.svg";
+                    var utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
                     await File.WriteAllTextAsync(
-                            Path.Combine(workPath, $"frame-{i:D4}.svg"),
-                            frameSvg,
-                            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
-                            CancellationToken.None
+                            Path.Combine(workPath, fileName), frameSvg, utf8, CancellationToken.None
                         )
                         .ConfigureAwait(false);
+                    if (preservedFramesPath is not null)
+                    {
+                        Directory.CreateDirectory(preservedFramesPath);
+                        await File.WriteAllTextAsync(
+                                Path.Combine(preservedFramesPath, fileName), frameSvg, utf8, CancellationToken.None
+                            )
+                            .ConfigureAwait(false);
+                    }
                 }
 
                 await SvgConverter.ConvertFramesToVideoAsync(
@@ -635,6 +667,7 @@ internal static class Program
             }
             else
             {
+                var svg = SvgRenderer.Render(capture.Screen, renderOptions);
                 var temporarySvg = workPath + ".svg";
                 await File.WriteAllTextAsync(
                         temporarySvg,
@@ -661,11 +694,11 @@ internal static class Program
         {
             try
             {
-                if (!preserveFrames && Directory.Exists(workPath))
+                if (Directory.Exists(workPath))
                 {
                     Directory.Delete(workPath, recursive: true);
                 }
-                else if (!preserveFrames && File.Exists(workPath + ".svg"))
+                else if (File.Exists(workPath + ".svg"))
                 {
                     File.Delete(workPath + ".svg");
                 }
@@ -727,6 +760,7 @@ internal static class Program
             return frames;
         }
 
+        var hasStart = renderOptions.TimeStart.HasValue;
         var start = renderOptions.TimeStart ?? double.MinValue;
         var end = renderOptions.TimeEnd ?? double.MaxValue;
         var filtered = new List<TerminalFrame>(frames.Count);
@@ -749,7 +783,9 @@ internal static class Program
 
         if (lastBeforeStart is not null)
         {
-            filtered.Insert(0, lastBeforeStart);
+            // Carry the visible terminal state into the requested range rather
+            // than extending the clip backwards to its previous update.
+            filtered.Insert(0, new TerminalFrame(start, lastBeforeStart.Buffer));
         }
 
         if (filtered.Count == 0)
@@ -757,7 +793,7 @@ internal static class Program
             return [frames[0]];
         }
 
-        var baseTime = filtered[0].Time;
+        var baseTime = hasStart ? start : filtered[0].Time;
         for (var i = 0; i < filtered.Count; i++)
         {
             filtered[i] = new TerminalFrame(filtered[i].Time - baseTime, filtered[i].Buffer);
@@ -871,6 +907,14 @@ internal static class Program
     };
 
     private static bool IsVideoFormat(string extension) => VideoExtensions.Contains(extension);
+
+    private static bool IsInteractiveRecordingFormat(string outputPath)
+    {
+        var extension = Path.GetExtension(outputPath).TrimStart('.');
+        return string.IsNullOrEmpty(extension)
+            || string.Equals(extension, "svg", StringComparison.OrdinalIgnoreCase)
+            || IsVideoFormat(extension);
+    }
 
     /// <summary>
     /// Determines whether ffmpeg is required to produce the final output format.

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -517,7 +517,7 @@ internal static class Program
                             loggerFactory.CreateLogger("ConsoleToSvg.InteractiveCapture")
                         )
                         .ConfigureAwait(false);
-                    return capture.IsVideo ? "Recording saved" : "Screenshot saved";
+                    return "Saved";
                 },
                 cancellationToken,
                 loggerFactory.CreateLogger("ConsoleToSvg.InteractiveRecorder")

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using ConsoleToSvg.Cli;
 using ConsoleToSvg.Recording;
 using ConsoleToSvg.Svg;
+using ConsoleToSvg.Terminal;
 using Microsoft.Extensions.Logging;
 using ZLogger;
 
@@ -112,6 +113,16 @@ internal static class Program
 
         try
         {
+            if (options.Interactive)
+            {
+                return await RunInteractiveAsync(
+                        options,
+                        loggerFactory,
+                        cancellationTokenSource.Token
+                    )
+                    .ConfigureAwait(false);
+            }
+
             // Pre-check: verify ffmpeg and converter availability BEFORE starting
             // the recording, so a missing tool surfaces immediately instead of
             // wasting the recorded session (issue #78). Only raster/video outputs
@@ -463,6 +474,293 @@ internal static class Program
                 loggerFactory.CreateLogger("ConsoleToSvg.PipeRecorder")
             )
             .ConfigureAwait(false);
+    }
+
+    private static async Task<int> RunInteractiveAsync(
+        AppOptions options,
+        ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken
+    )
+    {
+        var renderOptions = SvgRenderOptionsFactory.Create(options);
+        var width = ResolveSize(options.Width, options.WidthAdjust, TryGetConsoleWidth, DefaultWidth);
+        var height = ResolveSize(options.Height, options.HeightAdjust, TryGetConsoleHeight, DefaultHeight);
+        var theme = Theme.Resolve(renderOptions.Theme);
+        if (!string.IsNullOrWhiteSpace(renderOptions.BackColor))
+        {
+            theme = theme.WithBackground(renderOptions.BackColor);
+        }
+        if (!string.IsNullOrWhiteSpace(renderOptions.ForeColor))
+        {
+            theme = theme.WithForeground(renderOptions.ForeColor);
+        }
+
+        await Console.Error.WriteLineAsync(
+            "Interactive shell started. Press F12 to capture.".AsMemory(),
+            CancellationToken.None
+        );
+        await InteractiveRecorder
+            .RunAsync(
+                width,
+                height,
+                theme,
+                Encoding.ASCII.GetBytes("\u001b[24~"),
+                options.Mode == OutputMode.Video,
+                options.NoDeleteEnvs,
+                async capture =>
+                {
+                    var outputPath = GetInteractiveOutputPath(options.OutputPath);
+                    await WriteInteractiveCaptureAsync(
+                            capture,
+                            outputPath,
+                            renderOptions,
+                            options,
+                            loggerFactory.CreateLogger("ConsoleToSvg.InteractiveCapture")
+                        )
+                        .ConfigureAwait(false);
+                    await Console.Error.WriteLineAsync(
+                        $"Captured: {outputPath}",
+                        CancellationToken.None
+                    );
+                },
+                cancellationToken,
+                loggerFactory.CreateLogger("ConsoleToSvg.InteractiveRecorder")
+            )
+            .ConfigureAwait(false);
+        return 0;
+    }
+
+    private static string GetInteractiveOutputPath(string configuredPath)
+    {
+        var directory = Path.GetDirectoryName(configuredPath);
+        var extension = Path.GetExtension(configuredPath);
+        var name = Path.GetFileNameWithoutExtension(configuredPath);
+        if (string.IsNullOrEmpty(name))
+        {
+            name = "output";
+        }
+        if (string.IsNullOrEmpty(extension))
+        {
+            extension = ".svg";
+        }
+
+        var stamp = DateTime.Now.ToString("yyyyMMdd_HHmmss", System.Globalization.CultureInfo.InvariantCulture);
+        var candidateName = $"{name}_{stamp}{extension}";
+        var candidate = string.IsNullOrEmpty(directory)
+            ? candidateName
+            : Path.Combine(directory, candidateName);
+        var suffix = 1;
+        while (File.Exists(candidate))
+        {
+            candidateName = $"{name}_{stamp}_{suffix}{extension}";
+            candidate = string.IsNullOrEmpty(directory)
+                ? candidateName
+                : Path.Combine(directory, candidateName);
+            suffix++;
+        }
+
+        return candidate;
+    }
+
+    private static async Task WriteInteractiveCaptureAsync(
+        InteractiveCapture capture,
+        string outputPath,
+        SvgRenderOptions renderOptions,
+        AppOptions options,
+        ILogger logger
+    )
+    {
+        EnsureDirectory(outputPath);
+        var svg = capture.IsVideo
+            ? AnimatedSvgRenderer.RenderFrames(capture.Frames, renderOptions)
+            : SvgRenderer.Render(capture.Screen, renderOptions);
+        var extension = Path.GetExtension(outputPath).TrimStart('.').ToLowerInvariant();
+        if (string.IsNullOrEmpty(extension) || extension == "svg")
+        {
+            await File.WriteAllTextAsync(
+                    outputPath,
+                    svg,
+                    new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                    CancellationToken.None
+                )
+                .ConfigureAwait(false);
+            return;
+        }
+
+        var ffmpegPath = FindFfmpegExecutable();
+        SvgConverter.SetFfmpegPath(ffmpegPath);
+        var converter = SvgConverter.ResolveConverter(
+            options.SvgConverter,
+            ffmpegAvailableOverride: SvgConverter.IsFfmpegAvailable,
+            logger
+        );
+        var outputDirectory = Path.GetDirectoryName(Path.GetFullPath(outputPath))!;
+        var workPath = Path.Combine(outputDirectory, $".console2svg-{Guid.NewGuid():N}");
+        try
+        {
+            if (capture.IsVideo)
+            {
+                Directory.CreateDirectory(workPath);
+                var frames = SampleInteractiveFrames(
+                    FilterInteractiveFrames(capture.Frames, renderOptions),
+                    options.VideoFps
+                );
+                for (var i = 0; i < frames.Count; i++)
+                {
+                    var frameSvg = SvgRenderer.Render(frames[i].Buffer, renderOptions);
+                    await File.WriteAllTextAsync(
+                            Path.Combine(workPath, $"frame-{i:D4}.svg"),
+                            frameSvg,
+                            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                            CancellationToken.None
+                        )
+                        .ConfigureAwait(false);
+                }
+
+                await SvgConverter.ConvertFramesToVideoAsync(
+                        workPath,
+                        options.VideoFps,
+                        outputPath,
+                        converter,
+                        ffmpegPath,
+                        options.SizeWidth,
+                        options.SizeHeight,
+                        logger,
+                        CancellationToken.None
+                    )
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                var temporarySvg = workPath + ".svg";
+                await File.WriteAllTextAsync(
+                        temporarySvg,
+                        svg,
+                        new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                        CancellationToken.None
+                    )
+                    .ConfigureAwait(false);
+                await SvgConverter.ConvertSvgToImageAsync(
+                        temporarySvg,
+                        outputPath,
+                        converter,
+                        ffmpegPath,
+                        options.SizeWidth,
+                        options.SizeHeight,
+                        logger,
+                        CancellationToken.None
+                    )
+                    .ConfigureAwait(false);
+            }
+        }
+
+        finally
+        {
+            try
+            {
+                if (Directory.Exists(workPath))
+                {
+                    Directory.Delete(workPath, recursive: true);
+                }
+                else if (File.Exists(workPath + ".svg"))
+                {
+                    File.Delete(workPath + ".svg");
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.ZLogDebug(ex, $"Failed to remove interactive conversion work path {workPath}.");
+            }
+        }
+    }
+
+    private static IReadOnlyList<TerminalFrame> SampleInteractiveFrames(
+        IReadOnlyList<TerminalFrame> frames,
+        double fps
+    )
+    {
+        if (frames.Count <= 1 || fps <= 0d)
+        {
+            return frames;
+        }
+
+        var interval = 1d / fps;
+        var duration = frames[frames.Count - 1].Time;
+        var count = (int)Math.Floor(duration * fps) + 1;
+        var sampled = new List<TerminalFrame>(count + 1);
+        var sourceIndex = 0;
+        for (var index = 0; index < count; index++)
+        {
+            var time = index * interval;
+            while (
+                sourceIndex + 1 < frames.Count
+                && frames[sourceIndex + 1].Time <= time + 1e-9
+            )
+            {
+                sourceIndex++;
+            }
+
+            sampled.Add(new TerminalFrame(time, frames[sourceIndex].Buffer));
+        }
+
+        if (!ReferenceEquals(sampled[sampled.Count - 1].Buffer, frames[frames.Count - 1].Buffer))
+        {
+            sampled.Add(new TerminalFrame(duration, frames[frames.Count - 1].Buffer));
+        }
+
+        return sampled;
+    }
+
+    private static IReadOnlyList<TerminalFrame> FilterInteractiveFrames(
+        IReadOnlyList<TerminalFrame> frames,
+        SvgRenderOptions renderOptions
+    )
+    {
+        if (
+            frames.Count == 0
+            || (!renderOptions.TimeStart.HasValue && !renderOptions.TimeEnd.HasValue)
+        )
+        {
+            return frames;
+        }
+
+        var start = renderOptions.TimeStart ?? double.MinValue;
+        var end = renderOptions.TimeEnd ?? double.MaxValue;
+        var filtered = new List<TerminalFrame>(frames.Count);
+        TerminalFrame? lastBeforeStart = null;
+        foreach (var frame in frames)
+        {
+            if (frame.Time < start - 1e-9)
+            {
+                lastBeforeStart = frame;
+                continue;
+            }
+
+            if (frame.Time > end + 1e-9)
+            {
+                break;
+            }
+
+            filtered.Add(frame);
+        }
+
+        if (lastBeforeStart is not null)
+        {
+            filtered.Insert(0, lastBeforeStart);
+        }
+
+        if (filtered.Count == 0)
+        {
+            return [frames[0]];
+        }
+
+        var baseTime = filtered[0].Time;
+        for (var i = 0; i < filtered.Count; i++)
+        {
+            filtered[i] = new TerminalFrame(filtered[i].Time - baseTime, filtered[i].Buffer);
+        }
+
+        return filtered;
     }
 
     private static string GetCancellationCause(AppOptions options, bool canceledByCtrlC)

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -590,7 +590,10 @@ internal static class Program
             ffmpegAvailableOverride: SvgConverter.IsFfmpegAvailable,
             logger
         );
-        var workPath = Path.Combine(Path.GetTempPath(), $"c2s-{Guid.NewGuid():N}");
+        var preserveFrames = capture.IsVideo && !string.IsNullOrWhiteSpace(options.SaveFramesDir);
+        var workPath = preserveFrames
+            ? options.SaveFramesDir!
+            : Path.Combine(Path.GetTempPath(), $"c2s-{Guid.NewGuid():N}");
         try
         {
             if (capture.IsVideo)
@@ -653,11 +656,11 @@ internal static class Program
         {
             try
             {
-                if (Directory.Exists(workPath))
+                if (!preserveFrames && Directory.Exists(workPath))
                 {
                     Directory.Delete(workPath, recursive: true);
                 }
-                else if (File.Exists(workPath + ".svg"))
+                else if (!preserveFrames && File.Exists(workPath + ".svg"))
                 {
                     File.Delete(workPath + ".svg");
                 }

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -136,7 +136,7 @@ internal static class Program
 
                     SvgConverter.VerifyConversionPipeline(
                         options.SvgConverter,
-                        RequiresFfmpeg(options, preCheckExt),
+                        options.Interactive || RequiresFfmpeg(options, preCheckExt),
                         logger
                     );
                     logger.ZLogDebug(
@@ -506,6 +506,7 @@ internal static class Program
                 Encoding.ASCII.GetBytes("\u001b[20~"),
                 options.NoDeleteEnvs,
                 options.DelimitedCommand,
+                options.DelimitedCommand is null or { Length: 0 },
                 async capture =>
                 {
                     var outputPath = GetInteractiveOutputPath(options.OutputPath);
@@ -592,7 +593,10 @@ internal static class Program
         );
         var preserveFrames = capture.IsVideo && !string.IsNullOrWhiteSpace(options.SaveFramesDir);
         var workPath = preserveFrames
-            ? options.SaveFramesDir!
+            ? Path.Combine(
+                options.SaveFramesDir!,
+                Path.GetFileNameWithoutExtension(outputPath)
+            )
             : Path.Combine(Path.GetTempPath(), $"c2s-{Guid.NewGuid():N}");
         try
         {

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -590,8 +590,7 @@ internal static class Program
             ffmpegAvailableOverride: SvgConverter.IsFfmpegAvailable,
             logger
         );
-        var outputDirectory = Path.GetDirectoryName(Path.GetFullPath(outputPath))!;
-        var workPath = Path.Combine(outputDirectory, $".console2svg-{Guid.NewGuid():N}");
+        var workPath = Path.Combine(Path.GetTempPath(), $"c2s-{Guid.NewGuid():N}");
         try
         {
             if (capture.IsVideo)

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -511,7 +511,10 @@ internal static class Program
                 IsInteractiveRecordingFormat(options.OutputPath),
                 async capture =>
                 {
-                    var outputPath = GetInteractiveOutputPath(options.OutputPath);
+                    var outputPath = GetInteractiveOutputPath(
+                        options.OutputPath,
+                        capture.IsVideo ? null : ".svg"
+                    );
                     await WriteInteractiveCaptureAsync(
                             capture,
                             outputPath,
@@ -529,10 +532,10 @@ internal static class Program
         return 0;
     }
 
-    private static string GetInteractiveOutputPath(string configuredPath)
+    private static string GetInteractiveOutputPath(string configuredPath, string? extensionOverride = null)
     {
         var directory = Path.GetDirectoryName(configuredPath);
-        var extension = Path.GetExtension(configuredPath);
+        var extension = extensionOverride ?? Path.GetExtension(configuredPath);
         var name = Path.GetFileNameWithoutExtension(configuredPath);
         if (string.IsNullOrEmpty(name))
         {

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -502,8 +502,9 @@ internal static class Program
                 width,
                 height,
                 theme,
-                Encoding.ASCII.GetBytes("\u001b[21~"),
-                Encoding.ASCII.GetBytes("\u001b[20~"),
+                Encoding.ASCII.GetBytes("\u001b[21~"), // F10
+                Encoding.ASCII.GetBytes("\u001b[20~"), // F9
+                Encoding.ASCII.GetBytes("\u001b[24~"), // F12
                 options.NoDeleteEnvs,
                 options.DelimitedCommand,
                 options.DelimitedCommand is null or { Length: 0 },

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -113,20 +113,12 @@ internal static class Program
 
         try
         {
-            if (options.Interactive)
-            {
-                return await RunInteractiveAsync(
-                        options,
-                        loggerFactory,
-                        cancellationTokenSource.Token
-                    )
-                    .ConfigureAwait(false);
-            }
-
             // Pre-check: verify ffmpeg and converter availability BEFORE starting
             // the recording, so a missing tool surfaces immediately instead of
-            // wasting the recorded session (issue #78). Only raster/video outputs
-            // need conversion tools; pure SVG output (including --stdout) does not.
+            // wasting the recorded session. This also applies to interactive
+            // capture, where frames cannot be recovered after a failed save.
+            // Only raster/video outputs need conversion tools; pure SVG output
+            // (including --stdout) does not.
             if (!options.StdOut)
             {
                 var preCheckExt = Path.GetExtension(options.OutputPath)
@@ -151,6 +143,16 @@ internal static class Program
                         $"Pre-conversion check passed: converter verified for .{preCheckExt} output."
                     );
                 }
+            }
+
+            if (options.Interactive)
+            {
+                return await RunInteractiveAsync(
+                        options,
+                        loggerFactory,
+                        cancellationTokenSource.Token
+                    )
+                    .ConfigureAwait(false);
             }
 
             var session = await LoadOrRecordAsync(

--- a/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.cs
+++ b/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.cs
@@ -7,6 +7,43 @@ namespace ConsoleToSvg.Tests.Cli;
 public sealed class OptionParserTests
 {
     [Test]
+    public void InteractiveModeIsEnabled()
+    {
+        var ok = OptionParser.TryParse(new[] { "--interactive" }, out var options, out _, out _);
+
+        ok.ShouldBeTrue();
+        options!.Interactive.ShouldBeTrue();
+    }
+
+    [Test]
+    public void InteractiveModeRejectsRemovedKeybindOption()
+    {
+        var ok = OptionParser.TryParse(
+            new[] { "--interactive", "--keybind", "Ctrl+G" },
+            out _,
+            out var error,
+            out _
+        );
+
+        ok.ShouldBeFalse();
+        error.ShouldBe("Unknown option: --keybind");
+    }
+
+    [Test]
+    [Arguments(new[] { "--interactive", "echo hi" }, "--interactive cannot be used with a command.")]
+    [Arguments(new[] { "--interactive", "--in", "record.cast" }, "--interactive cannot be used with --in.")]
+    [Arguments(new[] { "--interactive", "--stdout" }, "--interactive cannot be used with --stdout.")]
+    [Arguments(new[] { "--interactive", "--mode", "repeat" }, "--interactive cannot be used with --mode repeat.")]
+    [Arguments(new[] { "--interactive", "--replay", "input.json" }, "--interactive cannot be used with replay options.")]
+    public void InteractiveModeRejectsIncompatibleSources(string[] args, string expectedError)
+    {
+        var ok = OptionParser.TryParse(args, out _, out var error, out _);
+
+        ok.ShouldBeFalse();
+        error.ShouldBe(expectedError);
+    }
+
+    [Test]
     public void ShortFlagWidthParsed()
     {
         var ok = OptionParser.TryParse(new[] { "-w", "120" }, out var options, out _, out _);

--- a/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.cs
+++ b/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.cs
@@ -40,6 +40,7 @@ public sealed class OptionParserTests
     [Arguments(new[] { "--interactive", "echo hi" }, "An interactive program must be specified after -- (for example: -i -- vim).")]
     [Arguments(new[] { "--interactive", "--in", "record.cast" }, "--interactive cannot be used with --in.")]
     [Arguments(new[] { "--interactive", "--stdout" }, "--interactive cannot be used with --stdout.")]
+    [Arguments(new[] { "--interactive", "--save-cast", "trace.cast" }, "--interactive cannot be used with --save-cast.")]
     [Arguments(new[] { "--interactive", "--mode", "repeat" }, "--interactive cannot be used with --mode repeat.")]
     [Arguments(new[] { "--interactive", "--replay", "input.json" }, "--interactive cannot be used with replay options.")]
     public void InteractiveModeRejectsIncompatibleSources(string[] args, string expectedError)

--- a/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.cs
+++ b/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.cs
@@ -16,6 +16,13 @@ public sealed class OptionParserTests
     }
 
     [Test]
+    public void InteractiveHelpDocumentsF9RecordingAndF10Screenshot()
+    {
+        OptionParser.HelpText.ShouldContain("F9 starts/stops an animation recording");
+        OptionParser.HelpText.ShouldContain("F10 saves a static screenshot");
+    }
+
+    [Test]
     public void InteractiveModeRejectsRemovedKeybindOption()
     {
         var ok = OptionParser.TryParse(

--- a/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.cs
+++ b/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.cs
@@ -30,7 +30,7 @@ public sealed class OptionParserTests
     }
 
     [Test]
-    [Arguments(new[] { "--interactive", "echo hi" }, "--interactive cannot be used with a command.")]
+    [Arguments(new[] { "--interactive", "echo hi" }, "An interactive program must be specified after -- (for example: -i -- vim).")]
     [Arguments(new[] { "--interactive", "--in", "record.cast" }, "--interactive cannot be used with --in.")]
     [Arguments(new[] { "--interactive", "--stdout" }, "--interactive cannot be used with --stdout.")]
     [Arguments(new[] { "--interactive", "--mode", "repeat" }, "--interactive cannot be used with --mode repeat.")]
@@ -41,6 +41,21 @@ public sealed class OptionParserTests
 
         ok.ShouldBeFalse();
         error.ShouldBe(expectedError);
+    }
+
+    [Test]
+    public void InteractiveModeStartsDelimitedProgramWithUnmodifiedArguments()
+    {
+        var ok = OptionParser.TryParse(
+            new[] { "-i", "--", "vim", "file name.txt" },
+            out var options,
+            out _,
+            out _
+        );
+
+        ok.ShouldBeTrue();
+        options!.Command.ShouldBe("vim file name.txt");
+        options.DelimitedCommand.ShouldBe(new[] { "vim", "file name.txt" });
     }
 
     [Test]

--- a/tests/ConsoleToSvg.Tests/Recording/InteractiveRecorderTests.cs
+++ b/tests/ConsoleToSvg.Tests/Recording/InteractiveRecorderTests.cs
@@ -14,23 +14,26 @@ public sealed class InteractiveRecorderTests
 {
     private static readonly byte[] ScreenshotKey = Encoding.ASCII.GetBytes("\u001b[21~");
     private static readonly byte[] RecordingKey = Encoding.ASCII.GetBytes("\u001b[20~");
+    private static readonly byte[] PauseKey = Encoding.ASCII.GetBytes("\u001b[24~");
 
     [Test]
-    public void F9AndF10AreConsumedAsRecordingAndScreenshotActions()
+    public void F9F10AndF12AreConsumedAsInteractiveCaptureActions()
     {
-        var router = new InteractiveInputRouter(ScreenshotKey, RecordingKey);
+        var router = new InteractiveInputRouter(ScreenshotKey, RecordingKey, PauseKey);
         var forwarded = new List<byte>();
 
         Process(router, RecordingKey, forwarded).ShouldBe(InteractiveInputAction.ToggleRecording);
         forwarded.ShouldBeEmpty();
         Process(router, ScreenshotKey, forwarded).ShouldBe(InteractiveInputAction.Screenshot);
         forwarded.ShouldBeEmpty();
+        Process(router, PauseKey, forwarded).ShouldBe(InteractiveInputAction.TogglePause);
+        forwarded.ShouldBeEmpty();
     }
 
     [Test]
     public void NonCaptureVtSequencesAreForwardedUnchangedEvenWhenSplitAcrossReads()
     {
-        var router = new InteractiveInputRouter(ScreenshotKey, RecordingKey);
+        var router = new InteractiveInputRouter(ScreenshotKey, RecordingKey, PauseKey);
         var forwarded = new List<byte>();
         var cursorUp = Encoding.ASCII.GetBytes("\u001b[A");
 
@@ -45,7 +48,7 @@ public sealed class InteractiveRecorderTests
     [Test]
     public void CtrlLIsForwardedWithoutInteractiveRecorderIntervention()
     {
-        var router = new InteractiveInputRouter(ScreenshotKey, RecordingKey);
+        var router = new InteractiveInputRouter(ScreenshotKey, RecordingKey, PauseKey);
         var forwarded = new List<byte>();
 
         router.Process(0x0c, forwarded).ShouldBe(InteractiveInputAction.None);
@@ -56,7 +59,7 @@ public sealed class InteractiveRecorderTests
     [Test]
     public void SgrMouseReportsAreDiscarded()
     {
-        var router = new InteractiveInputRouter(ScreenshotKey, RecordingKey);
+        var router = new InteractiveInputRouter(ScreenshotKey, RecordingKey, PauseKey);
         var forwarded = new List<byte>();
 
         foreach (var value in Encoding.ASCII.GetBytes("\u001b[<35;10;5M"))
@@ -70,7 +73,7 @@ public sealed class InteractiveRecorderTests
     [Test]
     public void CtrlDRequestsInteractiveExit()
     {
-        var router = new InteractiveInputRouter(ScreenshotKey, RecordingKey);
+        var router = new InteractiveInputRouter(ScreenshotKey, RecordingKey, PauseKey);
         var forwarded = new List<byte>();
 
         router.Process(0x04, forwarded).ShouldBe(InteractiveInputAction.Exit);

--- a/tests/ConsoleToSvg.Tests/Recording/InteractiveRecorderTests.cs
+++ b/tests/ConsoleToSvg.Tests/Recording/InteractiveRecorderTests.cs
@@ -141,6 +141,16 @@ public sealed class InteractiveRecorderTests
         filter.Filter("06hready").ShouldBe("ready");
     }
 
+    [Test]
+    public void HostFilterRemovesCombinedInputModes()
+    {
+        var filter = new InteractiveRecorder.HostTerminalSequenceFilter();
+
+        var result = filter.Filter("\u001b[?1000;1006hready");
+
+        result.ShouldBe("ready");
+    }
+
     private static InteractiveInputAction Process(
         InteractiveInputRouter router,
         IEnumerable<byte> values,

--- a/tests/ConsoleToSvg.Tests/Recording/InteractiveRecorderTests.cs
+++ b/tests/ConsoleToSvg.Tests/Recording/InteractiveRecorderTests.cs
@@ -71,8 +71,10 @@ public sealed class InteractiveRecorderTests
     public void CtrlDRequestsInteractiveExit()
     {
         var router = new InteractiveInputRouter(ScreenshotKey, RecordingKey);
+        var forwarded = new List<byte>();
 
-        router.Process(0x04, new List<byte>()).ShouldBe(InteractiveInputAction.Exit);
+        router.Process(0x04, forwarded).ShouldBe(InteractiveInputAction.Exit);
+        forwarded.ToArray().ShouldBe(new byte[] { 0x04 });
     }
 
     [Test]

--- a/tests/ConsoleToSvg.Tests/Recording/InteractiveRecorderTests.cs
+++ b/tests/ConsoleToSvg.Tests/Recording/InteractiveRecorderTests.cs
@@ -132,6 +132,15 @@ public sealed class InteractiveRecorderTests
         result.ShouldBe("\u001b[2J\u001b[H");
     }
 
+    [Test]
+    public void HostFilterRemovesInputModesSplitAcrossOutputReads()
+    {
+        var filter = new InteractiveRecorder.HostTerminalSequenceFilter();
+
+        filter.Filter("\u001b[?10").ShouldBeEmpty();
+        filter.Filter("06hready").ShouldBe("ready");
+    }
+
     private static InteractiveInputAction Process(
         InteractiveInputRouter router,
         IEnumerable<byte> values,

--- a/tests/ConsoleToSvg.Tests/Recording/InteractiveRecorderTests.cs
+++ b/tests/ConsoleToSvg.Tests/Recording/InteractiveRecorderTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using ConsoleToSvg.Recording;
+using ConsoleToSvg.Terminal;
+
+namespace ConsoleToSvg.Tests.Recording;
+
+public sealed class InteractiveRecorderTests
+{
+    private static readonly byte[] ScreenshotKey = Encoding.ASCII.GetBytes("\u001b[21~");
+    private static readonly byte[] RecordingKey = Encoding.ASCII.GetBytes("\u001b[20~");
+
+    [Test]
+    public void F9AndF10AreConsumedAsRecordingAndScreenshotActions()
+    {
+        var router = new InteractiveInputRouter(ScreenshotKey, RecordingKey);
+        var forwarded = new List<byte>();
+
+        Process(router, RecordingKey, forwarded).ShouldBe(InteractiveInputAction.ToggleRecording);
+        forwarded.ShouldBeEmpty();
+        Process(router, ScreenshotKey, forwarded).ShouldBe(InteractiveInputAction.Screenshot);
+        forwarded.ShouldBeEmpty();
+    }
+
+    [Test]
+    public void NonCaptureVtSequencesAreForwardedUnchangedEvenWhenSplitAcrossReads()
+    {
+        var router = new InteractiveInputRouter(ScreenshotKey, RecordingKey);
+        var forwarded = new List<byte>();
+        var cursorUp = Encoding.ASCII.GetBytes("\u001b[A");
+
+        foreach (var value in cursorUp)
+        {
+            router.Process(value, forwarded).ShouldBe(InteractiveInputAction.None);
+        }
+
+        forwarded.ToArray().ShouldBe(cursorUp);
+    }
+
+    [Test]
+    public void CtrlLIsForwardedWithoutInteractiveRecorderIntervention()
+    {
+        var router = new InteractiveInputRouter(ScreenshotKey, RecordingKey);
+        var forwarded = new List<byte>();
+
+        router.Process(0x0c, forwarded).ShouldBe(InteractiveInputAction.None);
+
+        forwarded.ToArray().ShouldBe(new byte[] { 0x0c });
+    }
+
+    [Test]
+    public void SgrMouseReportsAreDiscarded()
+    {
+        var router = new InteractiveInputRouter(ScreenshotKey, RecordingKey);
+        var forwarded = new List<byte>();
+
+        foreach (var value in Encoding.ASCII.GetBytes("\u001b[<35;10;5M"))
+        {
+            router.Process(value, forwarded);
+        }
+
+        forwarded.ShouldBeEmpty();
+    }
+
+    [Test]
+    public void CtrlDRequestsInteractiveExit()
+    {
+        var router = new InteractiveInputRouter(ScreenshotKey, RecordingKey);
+
+        router.Process(0x04, new List<byte>()).ShouldBe(InteractiveInputAction.Exit);
+    }
+
+    [Test]
+    public async Task ExitedInteractiveChildIsObservedWithoutHanging()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var cmd = System.IO.Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.System),
+            "cmd.exe"
+        );
+        using var connection = await NativePty.SpawnAsync(
+            new NativePtyOptions
+            {
+                Name = "console2svg-test",
+                Cols = 80,
+                Rows = 24,
+                Cwd = Environment.CurrentDirectory,
+                App = cmd,
+                Args = ["/d", "/c", "exit"],
+            },
+            CancellationToken.None
+        );
+
+        var stopwatch = Stopwatch.StartNew();
+        while (!connection.WaitForExit(50) && stopwatch.Elapsed < TimeSpan.FromSeconds(5)) { }
+
+        stopwatch.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public void CompleteRecordingAppendsTheFinalScreenAfterTheLastInput()
+    {
+        var emulator = new TerminalEmulator(20, 2, Theme.Resolve("dark"));
+        emulator.Process("dotnet --version\r\n");
+        var frames = new List<TerminalFrame> { new(0d, emulator.Buffer.Clone()) };
+        emulator.Process("10.0.201");
+
+        var capture = InteractiveRecorder.CompleteRecording(frames, 1d, emulator.Buffer);
+
+        capture.Frames.Count.ShouldBe(2);
+        GetRowText(capture.Frames[^1].Buffer, 1).ShouldBe("10.0.201");
+    }
+
+    [Test]
+    public void HostFilterKeepsClearScreenSequencesWhileRemovingInputModes()
+    {
+        var filter = new InteractiveRecorder.HostTerminalSequenceFilter();
+
+        var result = filter.Filter("\u001b[?9001h\u001b[?1004h\u001b[2J\u001b[H");
+
+        result.ShouldBe("\u001b[2J\u001b[H");
+    }
+
+    private static InteractiveInputAction Process(
+        InteractiveInputRouter router,
+        IEnumerable<byte> values,
+        List<byte> forwarded
+    )
+    {
+        var action = InteractiveInputAction.None;
+        foreach (var value in values)
+        {
+            action = router.Process(value, forwarded);
+        }
+
+        return action;
+    }
+
+    private static string GetRowText(ScreenBuffer buffer, int row)
+    {
+        var text = new StringBuilder();
+        for (var col = 0; col < buffer.Width; col++)
+        {
+            text.Append(buffer.GetCell(row, col).Text);
+        }
+
+        return text.ToString().TrimEnd();
+    }
+}

--- a/tests/ConsoleToSvg.Tests/Svg/AnimatedSvgRendererTests.cs
+++ b/tests/ConsoleToSvg.Tests/Svg/AnimatedSvgRendererTests.cs
@@ -2,11 +2,32 @@ using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using ConsoleToSvg.Recording;
+using ConsoleToSvg.Terminal;
 
 namespace ConsoleToSvg.Tests.Svg;
 
 public sealed class AnimatedSvgRendererTests
 {
+    [Test]
+    public void RenderFramesStartsWithProvidedTerminalState()
+    {
+        var emulator = new TerminalEmulator(12, 2, Theme.Resolve("dark"));
+        emulator.Process("before");
+        var initial = emulator.Buffer.Clone();
+        emulator.Process("\rafter");
+
+        var svg = ConsoleToSvg.Svg.AnimatedSvgRenderer.RenderFrames(
+            [
+                new TerminalFrame(0, initial),
+                new TerminalFrame(0.2, emulator.Buffer.Clone()),
+            ],
+            new ConsoleToSvg.Svg.SvgRenderOptions { Theme = "dark", VideoFps = 30 }
+        );
+
+        svg.ShouldContain("before");
+        svg.ShouldContain("after");
+    }
+
     [Test]
     public void RenderAnimatedSvgIncludesKeyframes()
     {

--- a/tests/ConsoleToSvg.Tests/Svg/SvgConverterTests.cs
+++ b/tests/ConsoleToSvg.Tests/Svg/SvgConverterTests.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using ConsoleToSvg.Svg;
+
+namespace ConsoleToSvg.Tests.Svg;
+
+public sealed class SvgConverterTests
+{
+    [Test]
+    public void FfmpegProcessRedirectsOutputAwayFromParentTerminal()
+    {
+        var method = typeof(SvgConverter).GetMethod(
+            "CreateFfmpegStartInfo",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        method.ShouldNotBeNull();
+
+        var startInfo = (ProcessStartInfo)method.Invoke(
+            null,
+            ["ffmpeg", new[] { "-version" }]
+        )!;
+
+        startInfo.UseShellExecute.ShouldBeFalse();
+        startInfo.RedirectStandardOutput.ShouldBeTrue();
+        startInfo.RedirectStandardError.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Implement interactive capture feature for Issue #84.

* `-i -- <program>` to launch any interactive program
* F9 to start/stop recording, F10 to save screenshots
* Forward VT input as-is, filtering out mouse reports
* Exit with Ctrl+D, clear terminal after exit, add final frame on recording stop
* Host-side save notification without PTY
* Add regression tests for interactive input, recording, and exit handling

## Verification

* Run `dotnet test --project tests\ConsoleToSvg.Tests\ConsoleToSvg.Tests.csproj -f net10.0 -p:ResvgBuild=false --no-restore`
* 317 tests passed

close #84

## Preview

Run `wsl dotnet run --project src/ConsoleToSvg -f net10.0 -p BuildResvgNative=false -- -i -d -o output.mp4` on Windows 11

https://github.com/user-attachments/assets/62f363a0-658f-4255-adc7-167ee4fbe138




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added interactive PTY mode with hotkeys for static capture (F10), recording (F9), and pause toggling, saving SVG directly or converting to video/images. Preserves command arguments after `--`.
* **Bug Fixes**
  * Improved animated SVG/frame rendering when filtering results in no frames.
  * Improved ffmpeg reliability by preventing output-pipe blocking and including clearer stderr excerpts on failure.
  * Improved interactive input handling (e.g., mouse-report filtering and Ctrl+D exit).
* **Documentation**
  * Expanded README and CLI help with interactive mode usage, constraints, and examples.
* **Tests**
  * Added/expanded test coverage for interactive capture/router and ffmpeg/SVG behavior.
* **Chores**
  * Updated ignore patterns, native build flag mapping, and CI environment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->