### PR TITLE
Fix cmatrix capture colors

### DIFF
--- a/src/ConsoleToSvg.Core/Svg/SvgDocumentBuilder.cs
+++ b/src/ConsoleToSvg.Core/Svg/SvgDocumentBuilder.cs
@@ -1079,14 +1079,6 @@ internal static class SvgDocumentBuilder
 
                 var effectiveFg = cell.Reversed ? cell.Background : cell.Foreground;
                 effectiveFg = ApplyIntensity(effectiveFg, cell.Bold, cell.Faint);
-                effectiveFg = ApplyContextualMatrixTint(
-                    buffer,
-                    row,
-                    col,
-                    includeScrollback,
-                    effectiveFg,
-                    theme
-                );
 
                 var cellX = (col - context.StartCol) * context.CellWidth;
                 var cellW = cell.IsWide ? context.CellWidth * 2d : context.CellWidth;
@@ -1318,64 +1310,6 @@ internal static class SvgDocumentBuilder
     private static string EscapeAttribute(string value)
     {
         return EscapeText(value);
-    }
-
-    private static string ApplyContextualMatrixTint(
-        ScreenBuffer buffer,
-        int row,
-        int col,
-        bool includeScrollback,
-        string effectiveForeground,
-        Theme theme
-    )
-    {
-        if (
-            !string.Equals(
-                effectiveForeground,
-                theme.AnsiPalette[7],
-                StringComparison.OrdinalIgnoreCase
-            )
-        )
-        {
-            return effectiveForeground;
-        }
-
-        if (
-            HasNeighborGreen(buffer, row - 1, col, includeScrollback, theme)
-            || HasNeighborGreen(buffer, row + 1, col, includeScrollback, theme)
-            || HasNeighborGreen(buffer, row, col - 1, includeScrollback, theme)
-            || HasNeighborGreen(buffer, row, col + 1, includeScrollback, theme)
-        )
-        {
-            return theme.AnsiPalette[10];
-        }
-
-        return effectiveForeground;
-    }
-
-    private static bool HasNeighborGreen(
-        ScreenBuffer buffer,
-        int row,
-        int col,
-        bool includeScrollback,
-        Theme theme
-    )
-    {
-        if (col < 0 || col >= buffer.Width)
-        {
-            return false;
-        }
-
-        var maxRows = includeScrollback ? buffer.TotalHeight : buffer.Height;
-        if (row < 0 || row >= maxRows)
-        {
-            return false;
-        }
-
-        var cell = includeScrollback ? buffer.GetCellFromTop(row, col) : buffer.GetCell(row, col);
-        var fg = cell.Reversed ? cell.Background : cell.Foreground;
-        return string.Equals(fg, theme.AnsiPalette[2], StringComparison.OrdinalIgnoreCase)
-            || string.Equals(fg, theme.AnsiPalette[10], StringComparison.OrdinalIgnoreCase);
     }
 
     private static string ApplyIntensity(string color, bool bold, bool faint)

--- a/tests/ConsoleToSvg.Tests/Svg/AnimatedSvgRendererTests.cs
+++ b/tests/ConsoleToSvg.Tests/Svg/AnimatedSvgRendererTests.cs
@@ -105,7 +105,7 @@ public sealed class AnimatedSvgRendererTests
     }
 
     [Test]
-    public void RenderAnimatedSvgPreservesRapidColorChanges()
+    public void RenderAnimatedSvgPreservesCmatrixHighlightColors()
     {
         var session = new RecordingSession(width: 8, height: 2);
         session.AddEvent(0.00, "\u001b[32mA");
@@ -118,7 +118,7 @@ public sealed class AnimatedSvgRendererTests
         );
 
         svg.ShouldContain("#0dbc79");
-        svg.ShouldContain("#23D18B");
+        svg.ShouldContain("#e5e5e5");
     }
 
     [Test]

--- a/tests/ConsoleToSvg.Tests/Svg/SvgRendererTests.cs
+++ b/tests/ConsoleToSvg.Tests/Svg/SvgRendererTests.cs
@@ -313,7 +313,7 @@ public sealed class SvgRendererTests
     }
 
     [Test]
-    public void RenderStaticSvgTintsWhiteHighlightNearGreenToBrightGreen()
+    public void RenderStaticSvgPreservesWhiteHighlightNearGreen()
     {
         var session = new RecordingSession(width: 8, height: 2);
         session.AddEvent(0.01, "\u001b[32mA\u001b[37mB\u001b[39m");
@@ -323,7 +323,7 @@ public sealed class SvgRendererTests
             new ConsoleToSvg.Svg.SvgRenderOptions { Theme = "dark" }
         );
 
-        svg.ShouldContain("fill=\"#23D18B\"");
+        svg.ShouldContain("fill=\"#e5e5e5\"");
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- Preserve ANSI highlight colors in static and animated SVG output.
- Remove the context-sensitive matrix tint that replaced white highlights near green text.
- Add regression coverage for cmatrix-style green and white output.

## Root cause
The SVG renderer rewrote white ANSI foreground cells to bright green whenever adjacent cells were green. WSL cmatrix emits green trail cells and white highlight cells, so that transformation changed the captured terminal colors.

## Validation
- Ran the full test suite: 317 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SVG rendering to preserve foreground colors instead of applying contextual green highlighting.
  * Bold text now appears brighter, while faint text appears dimmer when color adjustments are applicable.
  * Invalid or unchanged color values remain unaffected.

* **Tests**
  * Updated static and animated rendering coverage to verify preserved highlight colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->