### PR TITLE
Stream video frames in memory

### DIFF
--- a/src/ConsoleToSvg.Converter/SvgConverter.ImageConversion.cs
+++ b/src/ConsoleToSvg.Converter/SvgConverter.ImageConversion.cs
@@ -181,6 +181,104 @@ public static partial class SvgConverter
             .ConfigureAwait(false);
     }
 
+    /// <summary>Renders SVG text to PNG bytes without creating an intermediate file.</summary>
+    private static async Task<byte[]> RenderSvgToPngAsync(
+        string svg,
+        SvgConverterMode converter,
+        double? width,
+        double? height,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        if (converter == SvgConverterMode.Resvg)
+        {
+            return await Task.Run(
+                    () =>
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        try
+                        {
+                            return ResvgNative.RenderToPng(
+                                svg,
+                                width.HasValue ? ToPxInt(width.Value) : null,
+                                height.HasValue ? ToPxInt(height.Value) : null
+                            );
+                        }
+                        catch (Exception ex) when (IsResvgLoadFailure(ex))
+                        {
+                            throw new InvalidOperationException(
+                                "Bundled resvg native library failed to load. Falling back "
+                                    + "requires the resvg native runtime shipped with this build.",
+                                ex
+                            );
+                        }
+                    },
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+        }
+
+        if (converter != SvgConverterMode.RsvgConvert)
+        {
+            throw new InvalidOperationException($"Converter {converter} cannot directly produce PNG.");
+        }
+
+        var exe = FindRsvgConvertExecutable();
+        var args = new List<string>();
+        if (width.HasValue)
+        {
+            args.AddRange(["-w", FormatPx(width.Value)]);
+        }
+        if (height.HasValue)
+        {
+            args.AddRange(["-h", FormatPx(height.Value)]);
+        }
+
+        logger.ZLogDebug($"Rendering in-memory SVG ({svg.Length} chars) via rsvg-convert.");
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = exe,
+                UseShellExecute = false,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            },
+        };
+        foreach (var arg in args)
+        {
+            process.StartInfo.ArgumentList.Add(arg);
+        }
+
+        process.Start();
+        using var killOnCancel = cancellationToken.Register(() =>
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // The converter may already have exited between cancellation and Kill.
+            }
+        });
+        var errorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.StandardInput.WriteAsync(svg.AsMemory(), cancellationToken).ConfigureAwait(false);
+        await process.StandardInput.DisposeAsync().ConfigureAwait(false);
+        await using var output = new MemoryStream();
+        await process.StandardOutput.BaseStream.CopyToAsync(output, cancellationToken).ConfigureAwait(false);
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        var error = await errorTask.ConfigureAwait(false);
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"rsvg-convert exited with code {process.ExitCode}. {error}".TrimEnd());
+        }
+        return output.ToArray();
+    }
+
     /// <summary>
     /// Detects and warms the bundled resvg renderer. Loading system fonts here
     /// means all subsequent renders reuse the same native font database.

--- a/src/ConsoleToSvg.Converter/SvgConverter.ImageConversion.cs
+++ b/src/ConsoleToSvg.Converter/SvgConverter.ImageConversion.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -246,6 +247,7 @@ public static partial class SvgConverter
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 CreateNoWindow = true,
+                StandardInputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
             },
         };
         foreach (var arg in args)
@@ -253,7 +255,19 @@ public static partial class SvgConverter
             process.StartInfo.ArgumentList.Add(arg);
         }
 
-        process.Start();
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                "Failed to start rsvg-convert. Install 'librsvg2-bin' (Debian/Ubuntu) "
+                    + "or 'librsvg' (Homebrew).\n"
+                    + ex.Message,
+                ex
+            );
+        }
         using var killOnCancel = cancellationToken.Register(() =>
         {
             try
@@ -266,10 +280,11 @@ public static partial class SvgConverter
             }
         });
         var errorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+        await using var output = new MemoryStream();
+        var outputTask = process.StandardOutput.BaseStream.CopyToAsync(output, cancellationToken);
         await process.StandardInput.WriteAsync(svg.AsMemory(), cancellationToken).ConfigureAwait(false);
         await process.StandardInput.DisposeAsync().ConfigureAwait(false);
-        await using var output = new MemoryStream();
-        await process.StandardOutput.BaseStream.CopyToAsync(output, cancellationToken).ConfigureAwait(false);
+        await outputTask.ConfigureAwait(false);
         await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
         var error = await errorTask.ConfigureAwait(false);
         if (process.ExitCode != 0)

--- a/src/ConsoleToSvg.Converter/SvgConverter.InMemoryVideo.cs
+++ b/src/ConsoleToSvg.Converter/SvgConverter.InMemoryVideo.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -14,9 +13,9 @@ namespace ConsoleToSvg.Svg;
 public static partial class SvgConverter
 {
     /// <summary>
-    /// Encodes SVG frames without writing frame files. SVG-capable ffmpeg builds
-    /// receive SVG directly; other converters render each frame to PNG bytes and
-    /// feed an image2pipe PNG stream to ffmpeg.
+    /// Encodes SVG frames without writing frame files. Each frame is rendered to
+    /// PNG in memory and streamed to ffmpeg via image2pipe, avoiding intermediate
+    /// files on disk.
     /// </summary>
     public static async Task ConvertSvgFramesToVideoAsync(
         IEnumerable<string> svgFrames,
@@ -30,11 +29,13 @@ public static partial class SvgConverter
         CancellationToken cancellationToken
     )
     {
-        var effectiveConverter = ResolvePreConversionConverter(converter);
-        var codec = effectiveConverter == SvgConverterMode.Ffmpeg ? "svg" : "png";
-        var args = CreateInMemoryVideoFfmpegArgs(fps, codec, outputPath);
+        // The in-memory pipe path always renders to PNG because ffmpeg's
+        // image2pipe demuxer cannot split concatenated SVG documents into
+        // individual frames (unlike file-based frame-%04d.svg input).
+        var effectiveConverter = ResolveInMemoryPngConverter(converter);
+        var args = CreateInMemoryVideoFfmpegArgs(fps, outputPath);
 
-        logger.ZLogDebug($"Encoding video from in-memory {codec.ToUpperInvariant()} frames.");
+        logger.ZLogDebug($"Encoding video from in-memory PNG frames.");
         using var process = new Process { StartInfo = CreateFfmpegStartInfo(ffmpegPath, args) };
         process.StartInfo.RedirectStandardInput = true;
         try
@@ -65,16 +66,14 @@ public static partial class SvgConverter
             foreach (var svg in svgFrames)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var bytes = effectiveConverter == SvgConverterMode.Ffmpeg
-                    ? Encoding.UTF8.GetBytes(svg)
-                    : await RenderSvgToPngAsync(svg, effectiveConverter, width, height, logger, cancellationToken)
-                        .ConfigureAwait(false);
+                var bytes = await RenderSvgToPngAsync(svg, effectiveConverter, width, height, logger, cancellationToken)
+                    .ConfigureAwait(false);
                 await process.StandardInput.BaseStream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
             }
             await process.StandardInput.DisposeAsync().ConfigureAwait(false);
             await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
         }
-        catch
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             try
             {
@@ -84,7 +83,11 @@ public static partial class SvgConverter
             {
                 // Preserve the original write/render failure when ffmpeg is already gone.
             }
-            throw;
+            var stderrOnFailure = await standardErrorTask.ConfigureAwait(false);
+            throw new InvalidOperationException(
+                "Failed while feeding frames to ffmpeg." + FormatFfmpegError(stderrOnFailure),
+                ex
+            );
         }
 
         await standardOutputTask.ConfigureAwait(false);
@@ -101,19 +104,55 @@ public static partial class SvgConverter
 
     private static string[] CreateInMemoryVideoFfmpegArgs(
         double fps,
-        string codec,
         string outputPath
-    ) =>
-    [
-        "-y",
-        "-framerate",
-        fps.ToString(CultureInfo.InvariantCulture),
-        "-f",
-        "image2pipe",
-        "-vcodec",
-        codec,
-        "-i",
-        "pipe:0",
-        outputPath,
-    ];
+    )
+    {
+        if (fps <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(fps), fps, "Frame rate must be positive.");
+        }
+
+        return
+        [
+            "-y",
+            "-framerate",
+            fps.ToString(CultureInfo.InvariantCulture),
+            "-f",
+            "image2pipe",
+            "-vcodec",
+            "png",
+            "-i",
+            "pipe:0",
+            outputPath,
+        ];
+    }
+
+    /// <summary>
+    /// Resolves a PNG-capable converter for the in-memory pipe path. Unlike
+    /// file-based input (where ffmpeg can read individual SVG files), the
+    /// image2pipe demuxer cannot split concatenated SVG documents, so the
+    /// in-memory path always renders to PNG first.
+    /// </summary>
+    private static SvgConverterMode ResolveInMemoryPngConverter(SvgConverterMode converter)
+    {
+        if (converter != SvgConverterMode.Ffmpeg)
+        {
+            return converter;
+        }
+
+        if (_resvgAvailable.Value)
+        {
+            return SvgConverterMode.Resvg;
+        }
+
+        if (_rsvgConvertAvailable.Value)
+        {
+            return SvgConverterMode.RsvgConvert;
+        }
+
+        throw new InvalidOperationException(
+            "In-memory video rendering requires resvg or rsvg-convert. "
+                + "Install 'librsvg2-bin' (Debian/Ubuntu) or 'librsvg' (Homebrew)."
+        );
+    }
 }

--- a/src/ConsoleToSvg.Converter/SvgConverter.InMemoryVideo.cs
+++ b/src/ConsoleToSvg.Converter/SvgConverter.InMemoryVideo.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ZLogger;
+
+namespace ConsoleToSvg.Svg;
+
+public static partial class SvgConverter
+{
+    /// <summary>
+    /// Encodes SVG frames without writing frame files. SVG-capable ffmpeg builds
+    /// receive SVG directly; other converters render each frame to PNG bytes and
+    /// feed an image2pipe PNG stream to ffmpeg.
+    /// </summary>
+    public static async Task ConvertSvgFramesToVideoAsync(
+        IEnumerable<string> svgFrames,
+        double fps,
+        string outputPath,
+        SvgConverterMode converter,
+        string ffmpegPath,
+        double? width,
+        double? height,
+        ILogger logger,
+        CancellationToken cancellationToken
+    )
+    {
+        var effectiveConverter = ResolvePreConversionConverter(converter);
+        var codec = effectiveConverter == SvgConverterMode.Ffmpeg ? "svg" : "png";
+        var args = CreateInMemoryVideoFfmpegArgs(fps, codec, outputPath);
+
+        logger.ZLogDebug($"Encoding video from in-memory {codec.ToUpperInvariant()} frames.");
+        using var process = new Process { StartInfo = CreateFfmpegStartInfo(ffmpegPath, args) };
+        process.StartInfo.RedirectStandardInput = true;
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to start ffmpeg.\n" + ex.Message, ex);
+        }
+
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var standardErrorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+        using var killOnCancel = cancellationToken.Register(() =>
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // ffmpeg may already have exited between cancellation and Kill.
+            }
+        });
+
+        try
+        {
+            foreach (var svg in svgFrames)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var bytes = effectiveConverter == SvgConverterMode.Ffmpeg
+                    ? Encoding.UTF8.GetBytes(svg)
+                    : await RenderSvgToPngAsync(svg, effectiveConverter, width, height, logger, cancellationToken)
+                        .ConfigureAwait(false);
+                await process.StandardInput.BaseStream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+            }
+            await process.StandardInput.DisposeAsync().ConfigureAwait(false);
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // Preserve the original write/render failure when ffmpeg is already gone.
+            }
+            throw;
+        }
+
+        await standardOutputTask.ConfigureAwait(false);
+        var standardError = await standardErrorTask.ConfigureAwait(false);
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"ffmpeg exited with code {process.ExitCode}. "
+                    + "Ensure ffmpeg supports the requested output format."
+                    + FormatFfmpegError(standardError)
+            );
+        }
+    }
+
+    private static string[] CreateInMemoryVideoFfmpegArgs(
+        double fps,
+        string codec,
+        string outputPath
+    ) =>
+    [
+        "-y",
+        "-framerate",
+        fps.ToString(CultureInfo.InvariantCulture),
+        "-f",
+        "image2pipe",
+        "-vcodec",
+        codec,
+        "-i",
+        "pipe:0",
+        outputPath,
+    ];
+}

--- a/src/ConsoleToSvg.Converter/SvgConverter.InMemoryVideo.cs
+++ b/src/ConsoleToSvg.Converter/SvgConverter.InMemoryVideo.cs
@@ -123,6 +123,8 @@ public static partial class SvgConverter
             "png",
             "-i",
             "pipe:0",
+            "-pix_fmt",
+            "yuv420p",
             outputPath,
         ];
     }

--- a/src/ConsoleToSvg.Converter/SvgConverter.InMemoryVideo.cs
+++ b/src/ConsoleToSvg.Converter/SvgConverter.InMemoryVideo.cs
@@ -36,6 +36,7 @@ public static partial class SvgConverter
         var args = CreateInMemoryVideoFfmpegArgs(fps, outputPath);
 
         logger.ZLogDebug($"Encoding video from in-memory PNG frames.");
+        await Console.Error.WriteLineAsync("Encoding video frames...".AsMemory(), cancellationToken);
         using var process = new Process { StartInfo = CreateFfmpegStartInfo(ffmpegPath, args) };
         process.StartInfo.RedirectStandardInput = true;
         try
@@ -61,6 +62,7 @@ public static partial class SvgConverter
             }
         });
 
+        var frameCount = 0;
         try
         {
             foreach (var svg in svgFrames)
@@ -69,6 +71,7 @@ public static partial class SvgConverter
                 var bytes = await RenderSvgToPngAsync(svg, effectiveConverter, width, height, logger, cancellationToken)
                     .ConfigureAwait(false);
                 await process.StandardInput.BaseStream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+                frameCount++;
             }
             await process.StandardInput.DisposeAsync().ConfigureAwait(false);
             await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
@@ -100,6 +103,7 @@ public static partial class SvgConverter
                     + FormatFfmpegError(standardError)
             );
         }
+        await Console.Error.WriteLineAsync($"Encoded {frameCount} frames to video.".AsMemory(), CancellationToken.None);
     }
 
     private static string[] CreateInMemoryVideoFfmpegArgs(

--- a/src/ConsoleToSvg.Converter/SvgConverter.cs
+++ b/src/ConsoleToSvg.Converter/SvgConverter.cs
@@ -262,6 +262,7 @@ public static partial class SvgConverter
         var effectiveConverter = ResolvePreConversionConverter(converter);
         if (effectiveConverter == SvgConverterMode.Ffmpeg)
         {
+            await Console.Error.WriteLineAsync("Converting SVG to image...".AsMemory(), cancellationToken);
             await RunFfmpegAsync(
                     ffmpegPath,
                     ["-y", "-i", svgPath, "-frames:v", "1", "-update", "1", outputPath],
@@ -269,6 +270,7 @@ public static partial class SvgConverter
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+            await Console.Error.WriteLineAsync("Image conversion completed.".AsMemory(), CancellationToken.None);
             return;
         }
 
@@ -280,6 +282,7 @@ public static partial class SvgConverter
 
         try
         {
+            await Console.Error.WriteLineAsync("Converting SVG to PNG...".AsMemory(), cancellationToken);
             await ConvertSvgToPngAsync(
                     svgPath,
                     tempPng,
@@ -295,11 +298,13 @@ public static partial class SvgConverter
             {
                 // PNG output: ffmpeg not needed.
                 logger.ZLogDebug($"PNG written via fallback converter: {tempPng}");
+                await Console.Error.WriteLineAsync("PNG conversion completed.".AsMemory(), CancellationToken.None);
                 return;
             }
 
             // PNG → final format via ffmpeg. -frames:v 1 -update 1 avoid the
             // "image sequence pattern" warning for single-frame outputs.
+            await Console.Error.WriteLineAsync("Converting PNG to final format...".AsMemory(), cancellationToken);
             await RunFfmpegAsync(
                     ffmpegPath,
                     ["-y", "-i", tempPng, "-frames:v", "1", "-update", "1", outputPath],
@@ -307,6 +312,7 @@ public static partial class SvgConverter
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+            await Console.Error.WriteLineAsync("Image conversion completed.".AsMemory(), CancellationToken.None);
         }
         finally
         {
@@ -415,6 +421,7 @@ public static partial class SvgConverter
         }
 
         var fpsStr = fps.ToString(CultureInfo.InvariantCulture);
+        await Console.Error.WriteLineAsync("Encoding video frames...".AsMemory(), cancellationToken);
         await RunFfmpegAsync(
                 ffmpegPath,
                 ["-y", "-framerate", fpsStr, "-i", framePattern, "-pix_fmt", "yuv420p", outputPath],
@@ -422,5 +429,6 @@ public static partial class SvgConverter
                 cancellationToken
             )
             .ConfigureAwait(false);
+        await Console.Error.WriteLineAsync("Video encoding completed.".AsMemory(), CancellationToken.None);
     }
 }

--- a/src/ConsoleToSvg.Converter/SvgConverter.cs
+++ b/src/ConsoleToSvg.Converter/SvgConverter.cs
@@ -417,7 +417,7 @@ public static partial class SvgConverter
         var fpsStr = fps.ToString(CultureInfo.InvariantCulture);
         await RunFfmpegAsync(
                 ffmpegPath,
-                ["-y", "-framerate", fpsStr, "-i", framePattern, outputPath],
+                ["-y", "-framerate", fpsStr, "-i", framePattern, "-pix_fmt", "yuv420p", outputPath],
                 logger,
                 cancellationToken
             )

--- a/src/ConsoleToSvg/Program.Output.cs
+++ b/src/ConsoleToSvg/Program.Output.cs
@@ -60,14 +60,14 @@ internal static partial class Program
                 var totalFrames = (int)Math.Floor(totalTime * fps) + 1;
                 var rangeStart = baseOptions.TimeStart ?? 0.0;
                 var rangeEnd = baseOptions.TimeEnd ?? totalTime;
+                var eventIndex = 0;
                 for (var f = 0; f < totalFrames; f++)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     var t = f / fps;
                     if (t < rangeStart - 1e-9) continue;
                     if (t > rangeEnd + 1e-9) break;
-                    var eventIndex = 0;
-                    for (var i = 0; i < eventCount && session.Events[i].Time <= t + 1e-9; i++) eventIndex = i;
+                    while (eventIndex + 1 < eventCount && session.Events[eventIndex + 1].Time <= t + 1e-9) eventIndex++;
                     baseOptions.Frame = eventIndex;
                     yielded = true;
                     yield return SvgRenderer.Render(session, baseOptions);

--- a/src/ConsoleToSvg/Program.Output.cs
+++ b/src/ConsoleToSvg/Program.Output.cs
@@ -29,110 +29,73 @@ internal static partial class Program
     {
         Directory.CreateDirectory(directory);
         var utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-        var eventCount = session.Events.Count;
-        logger.ZLogDebug($"Saving individual frames to {directory}. Events={eventCount} Fps={fps}");
-
-        if (fps > 0 && eventCount > 0)
+        var savedCount = 0;
+        foreach (var frameSvg in RenderFrameSvgs(session, baseOptions, fps, cancellationToken))
         {
-            // Sample frames at exactly fps intervals so frame count = floor(totalTime * fps) + 1
-            var totalTime = session.Events[eventCount - 1].Time;
-            var totalFrames = (int)Math.Floor(totalTime * fps) + 1;
-            var interval = 1.0 / fps;
+            await File.WriteAllTextAsync(
+                    Path.Combine(directory, $"frame-{savedCount:D4}.svg"), frameSvg, utf8, cancellationToken)
+                .ConfigureAwait(false);
+            savedCount++;
+        }
+        logger.ZLogDebug($"Saved {savedCount} frames to {directory}");
+        await Console.Error.WriteLineAsync($"Saved {savedCount} frames to {directory}".AsMemory(), CancellationToken.None);
+        return savedCount;
+    }
 
-            // When a time range is specified, skip frames outside [TimeStart, TimeEnd].
-            var rangeStart = baseOptions.TimeStart ?? 0.0;
-            var rangeEnd = baseOptions.TimeEnd ?? totalTime;
-
-            var savedCount = 0;
-            for (var f = 0; f < totalFrames; f++)
+    private static IEnumerable<string> RenderFrameSvgs(
+        RecordingSession session,
+        SvgRenderOptions baseOptions,
+        double fps,
+        CancellationToken cancellationToken,
+        bool includeFallback = false
+    )
+    {
+        var eventCount = session.Events.Count;
+        var yielded = false;
+        try
+        {
+            if (fps > 0 && eventCount > 0)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var t = f * interval;
-                if (t < rangeStart - 1e-9)
+                var totalTime = session.Events[eventCount - 1].Time;
+                var totalFrames = (int)Math.Floor(totalTime * fps) + 1;
+                var rangeStart = baseOptions.TimeStart ?? 0.0;
+                var rangeEnd = baseOptions.TimeEnd ?? totalTime;
+                for (var f = 0; f < totalFrames; f++)
                 {
-                    continue;
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var t = f / fps;
+                    if (t < rangeStart - 1e-9) continue;
+                    if (t > rangeEnd + 1e-9) break;
+                    var eventIndex = 0;
+                    for (var i = 0; i < eventCount && session.Events[i].Time <= t + 1e-9; i++) eventIndex = i;
+                    baseOptions.Frame = eventIndex;
+                    yielded = true;
+                    yield return SvgRenderer.Render(session, baseOptions);
                 }
-                if (t > rangeEnd + 1e-9)
-                {
-                    break;
-                }
-
-                // Find the last event index at or before time t
-                var eventIndex = -1;
+            }
+            else
+            {
+                string? previousSvg = null;
                 for (var i = 0; i < eventCount; i++)
                 {
-                    if (session.Events[i].Time <= t + 1e-9)
-                        eventIndex = i;
-                    else
-                        break;
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var time = session.Events[i].Time;
+                    if (baseOptions.TimeStart.HasValue && time < baseOptions.TimeStart.Value - 1e-9) continue;
+                    if (baseOptions.TimeEnd.HasValue && time > baseOptions.TimeEnd.Value + 1e-9) break;
+                    baseOptions.Frame = i;
+                    var frameSvg = SvgRenderer.Render(session, baseOptions);
+                    if (frameSvg == previousSvg) continue;
+                    previousSvg = frameSvg;
+                    yielded = true;
+                    yield return frameSvg;
                 }
-
-                baseOptions.Frame = eventIndex >= 0 ? eventIndex : 0;
-                var frameSvg = SvgRenderer.Render(session, baseOptions);
-                var framePath = Path.Combine(directory, $"frame-{savedCount:D4}.svg");
-                await File.WriteAllTextAsync(framePath, frameSvg, utf8, cancellationToken)
-                    .ConfigureAwait(false);
-                savedCount++;
             }
-
-            baseOptions.Frame = null;
-            logger.ZLogDebug($"Saved {savedCount} frames to {directory}");
-            await Console.Error.WriteLineAsync(
-                $"Saved {savedCount} frames to {directory}".AsMemory(),
-                CancellationToken.None
-            );
-            return savedCount;
-        }
-        else
-        {
-            // No fps specified: save one file per unique visual state
-            var savedCount = 0;
-            string? previousSvg = null;
-
-            for (var i = 0; i < eventCount; i++)
+            if (!yielded && includeFallback)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                // Skip frames outside the time range if specified.
-                var eventTime = session.Events[i].Time;
-                if (
-                    baseOptions.TimeStart.HasValue
-                    && eventTime < baseOptions.TimeStart.Value - 1e-9
-                )
-                {
-                    continue;
-                }
-                if (baseOptions.TimeEnd.HasValue && eventTime > baseOptions.TimeEnd.Value + 1e-9)
-                {
-                    break;
-                }
-
-                baseOptions.Frame = i;
-                var frameSvg = SvgRenderer.Render(session, baseOptions);
-
-                if (frameSvg == previousSvg)
-                {
-                    continue;
-                }
-
-                previousSvg = frameSvg;
-                var framePath = Path.Combine(directory, $"frame-{savedCount:D4}.svg");
-                await File.WriteAllTextAsync(framePath, frameSvg, utf8, cancellationToken)
-                    .ConfigureAwait(false);
-                savedCount++;
+                yield return SvgRenderer.Render(session, baseOptions);
             }
-
-            baseOptions.Frame = null;
-            logger.ZLogDebug(
-                $"Saved {savedCount} unique frames (of {eventCount} events) to {directory}"
-            );
-            await Console.Error.WriteLineAsync(
-                $"Saved {savedCount} frames to {directory}".AsMemory(),
-                CancellationToken.None
-            );
-            return savedCount;
         }
+        finally { baseOptions.Frame = null; }
     }
 
     private static string GetDefaultPrompt()

--- a/src/ConsoleToSvg/Program.Recording.cs
+++ b/src/ConsoleToSvg/Program.Recording.cs
@@ -298,7 +298,6 @@ internal static partial class Program
                 );
                 if (preservedFramesPath is null)
                 {
-                    EnsureDirectory(outputPath);
                     await SvgConverter
                         .ConvertSvgFramesToVideoAsync(
                             RenderInteractiveFrameSvgs(frames, capture, renderOptions),
@@ -316,11 +315,12 @@ internal static partial class Program
                 else
                 {
                     Directory.CreateDirectory(workPath);
+                    Directory.CreateDirectory(preservedFramesPath);
+                    var utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
                     for (var i = 0; i < frames.Count; i++)
                     {
                         var frameSvg = SvgRenderer.Render(frames[i].Buffer, renderOptions);
                         var fileName = $"frame-{i:D4}.svg";
-                        var utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
                         await File.WriteAllTextAsync(
                                 Path.Combine(workPath, fileName),
                                 frameSvg,
@@ -328,7 +328,6 @@ internal static partial class Program
                                 CancellationToken.None
                             )
                             .ConfigureAwait(false);
-                        Directory.CreateDirectory(preservedFramesPath);
                         await File.WriteAllTextAsync(
                                 Path.Combine(preservedFramesPath, fileName),
                                 frameSvg,

--- a/src/ConsoleToSvg/Program.Recording.cs
+++ b/src/ConsoleToSvg/Program.Recording.cs
@@ -292,25 +292,42 @@ internal static partial class Program
         {
             if (capture.IsVideo)
             {
-                Directory.CreateDirectory(workPath);
                 var frames = SampleInteractiveFrames(
                     FilterInteractiveFrames(capture.Frames, renderOptions),
                     options.VideoFps
                 );
-                for (var i = 0; i < frames.Count; i++)
+                if (preservedFramesPath is null)
                 {
-                    var frameSvg = SvgRenderer.Render(frames[i].Buffer, renderOptions);
-                    var fileName = $"frame-{i:D4}.svg";
-                    var utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-                    await File.WriteAllTextAsync(
-                            Path.Combine(workPath, fileName),
-                            frameSvg,
-                            utf8,
+                    EnsureDirectory(outputPath);
+                    await SvgConverter
+                        .ConvertSvgFramesToVideoAsync(
+                            RenderInteractiveFrameSvgs(frames, capture, renderOptions),
+                            options.VideoFps,
+                            outputPath,
+                            converter,
+                            ffmpegPath,
+                            options.SizeWidth,
+                            options.SizeHeight,
+                            logger,
                             CancellationToken.None
                         )
                         .ConfigureAwait(false);
-                    if (preservedFramesPath is not null)
+                }
+                else
+                {
+                    Directory.CreateDirectory(workPath);
+                    for (var i = 0; i < frames.Count; i++)
                     {
+                        var frameSvg = SvgRenderer.Render(frames[i].Buffer, renderOptions);
+                        var fileName = $"frame-{i:D4}.svg";
+                        var utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+                        await File.WriteAllTextAsync(
+                                Path.Combine(workPath, fileName),
+                                frameSvg,
+                                utf8,
+                                CancellationToken.None
+                            )
+                            .ConfigureAwait(false);
                         Directory.CreateDirectory(preservedFramesPath);
                         await File.WriteAllTextAsync(
                                 Path.Combine(preservedFramesPath, fileName),
@@ -320,21 +337,21 @@ internal static partial class Program
                             )
                             .ConfigureAwait(false);
                     }
-                }
 
-                await SvgConverter
-                    .ConvertFramesToVideoAsync(
-                        workPath,
-                        options.VideoFps,
-                        outputPath,
-                        converter,
-                        ffmpegPath,
-                        options.SizeWidth,
-                        options.SizeHeight,
-                        logger,
-                        CancellationToken.None
-                    )
-                    .ConfigureAwait(false);
+                    await SvgConverter
+                        .ConvertFramesToVideoAsync(
+                            workPath,
+                            options.VideoFps,
+                            outputPath,
+                            converter,
+                            ffmpegPath,
+                            options.SizeWidth,
+                            options.SizeHeight,
+                            logger,
+                            CancellationToken.None
+                        )
+                        .ConfigureAwait(false);
+                }
             }
             else
             {
@@ -416,6 +433,24 @@ internal static partial class Program
         }
 
         return sampled;
+    }
+
+    private static IEnumerable<string> RenderInteractiveFrameSvgs(
+        IReadOnlyList<TerminalFrame> frames,
+        InteractiveCapture capture,
+        SvgRenderOptions renderOptions
+    )
+    {
+        if (frames.Count == 0)
+        {
+            yield return SvgRenderer.Render(capture.Screen, renderOptions);
+            yield break;
+        }
+
+        foreach (var frame in frames)
+        {
+            yield return SvgRenderer.Render(frame.Buffer, renderOptions);
+        }
     }
 
     private static IReadOnlyList<TerminalFrame> FilterInteractiveFrames(

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -181,10 +181,20 @@ internal static partial class Program
 
             var renderOptions = SvgRenderOptionsFactory.Create(options);
             logger.ZLogDebug($"Rendering SVG. Mode={options.Mode}");
+            var currentOutputExt = Path.GetExtension(options.OutputPath).TrimStart('.').ToLowerInvariant();
+            var isVideoOutput = !string.IsNullOrEmpty(currentOutputExt) && currentOutputExt != "svg" && IsVideoFormat(currentOutputExt);
+            if (!isVideoOutput && !options.StdOut)
+            {
+                await Console.Error.WriteLineAsync("Rendering SVG...".AsMemory(), outputToken);
+            }
             var svg = options.Mode is OutputMode.Video or OutputMode.Repeat
                 ? AnimatedSvgRenderer.Render(session, renderOptions)
                 : SvgRenderer.Render(session, renderOptions);
             logger.ZLogDebug($"Rendering completed. SvgLength={svg.Length}");
+            if (!isVideoOutput && !options.StdOut)
+            {
+                await Console.Error.WriteLineAsync("SVG rendering completed.".AsMemory(), CancellationToken.None);
+            }
 
             // Background temp-dir deletion task for the video path; awaited
             // just before the process exits so deletion completes even when

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -324,7 +324,7 @@ internal static partial class Program
                                 {
                                     try
                                     {
-                                        Directory.Delete(tempDir);
+                                        Directory.Delete(tempDir, recursive: true);
                                     }
                                     catch (Exception ex)
                                     {

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -247,76 +247,94 @@ internal static partial class Program
 
                     if (useVideoPath)
                     {
-                        // Video format: save frames to a temp dir, then invoke ffmpeg.
-                        var tempDir = Path.Combine(Path.GetTempPath(), $"c2s-{Guid.NewGuid():N}");
-                        try
+                        if (string.IsNullOrWhiteSpace(options.SaveFramesDir))
                         {
-                            logger.ZLogDebug($"Video output: saving frames to temp dir {tempDir}");
-                            var frameCount = await SaveFramesAsync(
-                                    session,
-                                    renderOptions,
-                                    tempDir,
-                                    options.VideoFps,
-                                    logger,
-                                    outputToken
-                                )
+                            EnsureDirectory(options.OutputPath);
+                            await SvgConverter.ConvertSvgFramesToVideoAsync(
+                                    RenderFrameSvgs(
+                                        session,
+                                        renderOptions,
+                                        options.VideoFps,
+                                        outputToken,
+                                        includeFallback: true
+                                    ),
+                                    options.VideoFps, options.OutputPath, converter, ffmpegPath,
+                                    options.SizeWidth, options.SizeHeight, logger, outputToken)
                                 .ConfigureAwait(false);
-
-                            // Guard against empty recordings: ensure at least one frame exists
-                            // so ffmpeg receives valid input (e.g. commands that exit without output).
-                            if (frameCount == 0)
+                        }
+                        else
+                        {
+                            // Video format: save frames to a temp dir, then invoke ffmpeg.
+                            var tempDir = Path.Combine(Path.GetTempPath(), $"c2s-{Guid.NewGuid():N}");
+                            try
                             {
-                                var utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-                                var fallbackSvg = SvgRenderer.Render(session, renderOptions);
-                                await File.WriteAllTextAsync(
-                                        Path.Combine(tempDir, "frame-0000.svg"),
-                                        fallbackSvg,
-                                        utf8,
+                                logger.ZLogDebug($"Video output: saving frames to temp dir {tempDir}");
+                                var frameCount = await SaveFramesAsync(
+                                        session,
+                                        renderOptions,
+                                        tempDir,
+                                        options.VideoFps,
+                                        logger,
                                         outputToken
                                     )
                                     .ConfigureAwait(false);
-                                logger.ZLogDebug(
-                                    $"Empty recording: wrote single fallback frame to {tempDir}"
-                                );
-                            }
 
-                            EnsureDirectory(options.OutputPath);
-                            await SvgConverter
-                                .ConvertFramesToVideoAsync(
-                                    tempDir,
-                                    options.VideoFps,
-                                    options.OutputPath,
-                                    converter,
-                                    ffmpegPath,
-                                    options.SizeWidth,
-                                    options.SizeHeight,
-                                    logger,
-                                    outputToken
-                                )
-                                .ConfigureAwait(false);
-                        }
-                        finally
-                        {
-                            // Start temp-dir deletion on a background thread so
-                            // the remaining work (writing "Generated:" message,
-                            // save-frames, etc.) can proceed concurrently. The
-                            // Task is awaited before the process exits so that
-                            // deletion actually completes even on Windows where
-                            // AV scans make recursive delete slow.
-                            tempCleanup = Task.Run(() =>
-                            {
-                                try
+                                // Guard against empty recordings: ensure at least one frame exists
+                                // so ffmpeg receives valid input (e.g. commands that exit without output).
+                                if (frameCount == 0)
                                 {
-                                    Directory.Delete(tempDir);
-                                }
-                                catch (Exception ex)
-                                {
+                                    var utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+                                    var fallbackSvg = SvgRenderer.Render(session, renderOptions);
+                                    await File.WriteAllTextAsync(
+                                            Path.Combine(tempDir, "frame-0000.svg"),
+                                            fallbackSvg,
+                                            utf8,
+                                            outputToken
+                                        )
+                                        .ConfigureAwait(false);
                                     logger.ZLogDebug(
-                                        ex,
-                                        $"Failed to delete temp dir {tempDir}: {ex.Message}"
+                                        $"Empty recording: wrote single fallback frame to {tempDir}"
                                     );
                                 }
-                            });
+
+                                EnsureDirectory(options.OutputPath);
+                                await SvgConverter
+                                    .ConvertFramesToVideoAsync(
+                                        tempDir,
+                                        options.VideoFps,
+                                        options.OutputPath,
+                                        converter,
+                                        ffmpegPath,
+                                        options.SizeWidth,
+                                        options.SizeHeight,
+                                        logger,
+                                        outputToken
+                                    )
+                                    .ConfigureAwait(false);
+                            }
+                            finally
+                            {
+                                // Start temp-dir deletion on a background thread so
+                                // the remaining work (writing "Generated:" message,
+                                // save-frames, etc.) can proceed concurrently. The
+                                // Task is awaited before the process exits so that
+                                // deletion actually completes even on Windows where
+                                // AV scans make recursive delete slow.
+                                tempCleanup = Task.Run(() =>
+                                {
+                                    try
+                                    {
+                                        Directory.Delete(tempDir);
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        logger.ZLogDebug(
+                                            ex,
+                                            $"Failed to delete temp dir {tempDir}: {ex.Message}"
+                                        );
+                                    }
+                                });
+                            }
                         }
                     }
                     else

--- a/tests/ConsoleToSvg.Tests/Svg/SvgConverterTests.cs
+++ b/tests/ConsoleToSvg.Tests/Svg/SvgConverterTests.cs
@@ -40,7 +40,7 @@ public sealed class SvgConverterTests
         args.ShouldBe(
         [
             "-y", "-framerate", "2.5", "-f", "image2pipe", "-vcodec", "png",
-            "-i", "pipe:0", "output.mp4",
+            "-i", "pipe:0", "-pix_fmt", "yuv420p", "output.mp4",
         ]
         );
     }

--- a/tests/ConsoleToSvg.Tests/Svg/SvgConverterTests.cs
+++ b/tests/ConsoleToSvg.Tests/Svg/SvgConverterTests.cs
@@ -25,4 +25,23 @@ public sealed class SvgConverterTests
         startInfo.RedirectStandardOutput.ShouldBeTrue();
         startInfo.RedirectStandardError.ShouldBeTrue();
     }
+
+    [Test]
+    public void InMemoryVideoUsesImagePipeAndInvariantFramerate()
+    {
+        var method = typeof(SvgConverter).GetMethod(
+            "CreateInMemoryVideoFfmpegArgs",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        method.ShouldNotBeNull();
+
+        var args = (string[])method.Invoke(null, [2.5d, "png", "output.mp4"])!;
+
+        args.ShouldBe(
+        [
+            "-y", "-framerate", "2.5", "-f", "image2pipe", "-vcodec", "png",
+            "-i", "pipe:0", "output.mp4",
+        ]
+        );
+    }
 }

--- a/tests/ConsoleToSvg.Tests/Svg/SvgConverterTests.cs
+++ b/tests/ConsoleToSvg.Tests/Svg/SvgConverterTests.cs
@@ -35,7 +35,7 @@ public sealed class SvgConverterTests
         );
         method.ShouldNotBeNull();
 
-        var args = (string[])method.Invoke(null, [2.5d, "png", "output.mp4"])!;
+        var args = (string[])method.Invoke(null, [2.5d, "output.mp4"])!;
 
         args.ShouldBe(
         [


### PR DESCRIPTION
## Summary

- Stream video frames directly to ffmpeg when `--save-frames` is not used.
- Keep fallback SVG-to-PNG rendering in memory for resvg and rsvg-convert.
- Preserve the existing on-disk frame workflow when users request saved frames.

## Why

Writing and deleting every intermediate SVG and PNG frame can be very slow when antivirus software scans temporary files.

## Validation

- `dotnet test --project tests/ConsoleToSvg.Tests/ConsoleToSvg.Tests.csproj --no-restore -p:TargetFramework=net10.0 -p:BuildResvgNative=false --no-build`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Video generation can process SVG frames directly in memory, reducing intermediate file usage.
  * Added support for rendering SVG frames through available converters before encoding video.
  * Added cancellation handling and clearer error reporting for rendering and video failures.

* **Improvements**
  * Frame sampling supports FPS-based rendering and removes duplicate visual frames.
  * Temporary frame files are skipped when preservation is not requested.
  * Added fallback rendering for captures without animation frames.
  * Added progress and completion messages for rendering and video conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->