### PR TITLE
feat!: make -w adjust -h adjust the default behavior for all modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,15 +169,11 @@ To disable this behavior, use the `--no-colorenv` and `--no-delete-envs` options
 ## Usage
 ### Pipe mode
 
-Width and height default to the current terminal dimensions.
-
 ```sh
 my-command | console2svg
 ```
 
 ### PTY command mode
-
-Width is 100 characters by default, and height is automatically adjusted to fit the content.
 
 ```sh
 console2svg "git log --oneline"
@@ -189,12 +185,6 @@ If you want to set a fixed width and height, you can use the `-w` and `-h` optio
 
 ```sh
 console2svg -w 120 -h 20 -- git log --oneline
-```
-
-If you want to match the current terminal width, specify `-w adjust`.
-
-```sh
-console2svg -w adjust -h 20 -- git log --oneline
 ```
 
 ### Interactive capture
@@ -488,8 +478,8 @@ console2svg -m repeat --fps 2 -- tmux capture-pane -pe -t :0
 
 * `-o`: Output SVG file path (default: `output.svg`)
 * `-c`: Prepend the command line to the output as if typed in a terminal.
-* `-w`: width of the output SVG (default: terminal width[pipe], 100ch[pty], terminal width[interactive])
-* `-h`: height of the output SVG (default: terminal height[pipe], auto[pty], terminal height[interactive])
+* `-w`: width of the output SVG (default: terminal width)
+* `-h`: height of the output SVG (default: terminal height)
 * `-v`: output to video mode SVG (animated, looped by default)
 * `-i`: interactive mode (run a shell in a PTY and capture the current screen on demand)
 * `-d`: window chrome style (none, macos, windows, macos-pc, windows-pc, transparent, ...)

--- a/scripts/image-gen.sh
+++ b/scripts/image-gen.sh
@@ -4,16 +4,16 @@ sudo apt install -y librsvg2-bin sl nyancat vim tmux ffmpeg cmatrix
 
 # --- image ---
 # required: sudo npm install -g oh-my-logo
-console2svg -o ./assets/cmd-hero.svg        --verbose ./logs/cmd-hero.log         -c -d macos-pc -h 10 --opacity 0.95 --background ./assets/image1.png -- oh-my-logo "console2svg" mint --filled --letter-spacing 0
-console2svg -o ./assets/cmd-hero-grad.svg   --verbose ./logs/cmd-hero-grad.log    -c -d macos-pc -h 10 --opacity 0.95 --background "#30a0d0" "#0060c0" -- oh-my-logo "console2svg" mint --filled --letter-spacing 0
-console2svg -o ./assets/cmd.svg             --verbose ./logs/cmd.log              console2svg 
+console2svg -o ./assets/cmd-hero.svg        --verbose ./logs/cmd-hero.log         -w 100 -h 10 -c -d macos-pc --opacity 0.95 --background ./assets/image1.png -- oh-my-logo "console2svg" mint --filled --letter-spacing 0
+console2svg -o ./assets/cmd-hero-grad.svg   --verbose ./logs/cmd-hero-grad.log    -w 100 -h 10 -c -d macos-pc --opacity 0.95 --background "#30a0d0" "#0060c0" -- oh-my-logo "console2svg" mint --filled --letter-spacing 0
+console2svg -o ./assets/cmd.svg             --verbose ./logs/cmd.log              -w 100 console2svg 
 console2svg -o ./assets/cmd-window.svg      --verbose ./logs/cmd-window.log       -w 120 -c -d macos-pc  -- console2svg
-console2svg -o ./assets/cmd-crop-word.svg   --verbose ./logs/cmd-crop-word.log    --crop-top "Host" --crop-bottom ".NET runtimes installed:-2" -- dotnet --info
-console2svg -o ./assets/cmd-term-custom.svg --verbose ./logs/cmd-term-custom.log  -h 4 --prompt "[HELLO!] $" --header "my-custom-header" --forecolor "#00f040" --backcolor "#042515" -- echo "hi"
+console2svg -o ./assets/cmd-crop-word.svg   --verbose ./logs/cmd-crop-word.log    -w 100 --crop-top "Host" --crop-bottom ".NET runtimes installed:-2" -- dotnet --info
+console2svg -o ./assets/cmd-term-custom.svg --verbose ./logs/cmd-term-custom.log  -w 100 -h 4 --prompt "[HELLO!] $" --header "my-custom-header" --forecolor "#00f040" --backcolor "#042515" -- echo "hi"
 ## background
-console2svg -o ./assets/cmd-bg1.svg       --verbose ./logs/cmd-bg1.log        -h 10 -c -d macos-pc --background "#003060" --opacity 0.85  -- dotnet --version
-console2svg -o ./assets/cmd-bg2.svg       --verbose ./logs/cmd-bg2.log        -h 10 -c -d macos-pc --background "#004060" "#0080c0" --opacity 0.85  -- dotnet --version
-console2svg -o ./assets/cmd-bg3.svg       --verbose ./logs/cmd-bg3.log        -h 10 -c -d macos-pc --background ./assets/image2.png --opacity 0.85   -- dotnet --version
+console2svg -o ./assets/cmd-bg1.svg       --verbose ./logs/cmd-bg1.log  -w 100 -h 10 -c -d macos-pc --background "#003060" --opacity 0.85 -- dotnet --version
+console2svg -o ./assets/cmd-bg2.svg       --verbose ./logs/cmd-bg2.log  -w 100 -h 10 -c -d macos-pc --background "#004060" "#0080c0" --opacity 0.85 -- dotnet --version
+console2svg -o ./assets/cmd-bg3.svg       --verbose ./logs/cmd-bg3.log  -w 100 -h 10 -c -d macos-pc --background ./assets/image2.png --opacity 0.85 -- dotnet --version
 ## window chrome
 console2svg -o ./assets/window/none.svg        -d none        -w 40 -h 4 -c -- dotnet --version
 console2svg -o ./assets/window/macos.svg       -d macos       -w 40 -h 4 -c -- dotnet --version

--- a/src/ConsoleToSvg/Cli/AppOptions.cs
+++ b/src/ConsoleToSvg/Cli/AppOptions.cs
@@ -40,11 +40,11 @@ public sealed class AppOptions
 
     public int? Width { get; set; } = null;
 
-    public bool WidthAdjust { get; set; }
+    public bool WidthAdjust { get; set; } = true;
 
     public int? Height { get; set; } = null;
 
-    public bool HeightAdjust { get; set; }
+    public bool HeightAdjust { get; set; } = true;
 
     public int? Frame { get; set; }
 

--- a/src/ConsoleToSvg/Cli/OptionParser.Options.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.Options.cs
@@ -80,6 +80,7 @@ public static partial class OptionParser
                 }
 
                 options.Width = width;
+                options.WidthAdjust = false;
                 return true;
             case "-h":
             case "--height":
@@ -95,6 +96,7 @@ public static partial class OptionParser
                 }
 
                 options.Height = height;
+                options.HeightAdjust = false;
                 return true;
             case "--frame":
                 if (!TryParseInt(value, "--frame", out var frame, out error))

--- a/src/ConsoleToSvg/Cli/OptionParser.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.cs
@@ -18,8 +18,10 @@ public static partial class OptionParser
             Major options:
                 -o, --out <path>          Output file path (default: output.svg).
                                           Non-SVG extensions trigger ffmpeg conversion (e.g. output.png, output.mp4).
-                -w, --width <int|adjust>  Terminal width in characters (default: auto[pipe], 100[pty]).
-                -h, --height <int|adjust> Terminal height in rows (default: auto).
+                -w, --width <int|adjust>  Terminal width in characters (default: adjust).
+                                          Specify an integer to use a fixed width.
+                -h, --height <int|adjust> Terminal height in rows (default: adjust).
+                                          Specify an integer to use a fixed height.
                 -v                        Output animated SVG (alias for --mode video).
                 -i, --interactive         Run an interactive shell; F9 records, F12 pauses, and F10 takes a screenshot.
                                           Use -- to start another interactive program (e.g. -i -- pwsh).
@@ -53,10 +55,10 @@ public static partial class OptionParser
                                           PTY output forwarding is suppressed so the pipe receives only SVG.
                 -m, --mode <image|video|repeat>  Output mode (default: image).
                 -v                        is alias for --mode video.
-                -w, --width <int|adjust>  Terminal width in characters (default: auto[pipe], 100[pty]).
-                                          Specify "adjust" to use the current terminal width.
-                -h, --height <int|adjust> Terminal height in rows (default: auto).
-                                          Specify "adjust" to use the current terminal height.
+                -w, --width <int|adjust>  Terminal width in characters (default: adjust).
+                                          Uses the current terminal width. Specify an integer for a fixed width.
+                -h, --height <int|adjust> Terminal height in rows (default: adjust).
+                                          Uses the current terminal height. Specify an integer for a fixed height.
                 --in <path>               Read existing asciicast file.
                 --save-cast <path>        Save captured output as asciicast file.
                 --verbose [path]          Enable verbose logging; write to path (default: console2svg.log).
@@ -258,27 +260,12 @@ public static partial class OptionParser
             i++;
         }
 
-        ApplyInteractiveSizeDefaults(options);
-
         if (!Validate(options, out error))
         {
             return false;
         }
 
         return true;
-    }
-
-    private static void ApplyInteractiveSizeDefaults(AppOptions options)
-    {
-        if (!options.Interactive)
-        {
-            return;
-        }
-
-        // Interactive captures share the host terminal viewport by default.
-        // Explicit numeric dimensions and explicit "adjust" values always take precedence.
-        options.WidthAdjust |= !options.Width.HasValue;
-        options.HeightAdjust |= !options.Height.HasValue;
     }
 
     private static bool TrySplitToken(string token, out string name, out string? inlineValue)

--- a/src/ConsoleToSvg/Program.Recording.cs
+++ b/src/ConsoleToSvg/Program.Recording.cs
@@ -98,8 +98,18 @@ internal static partial class Program
             );
         }
 
-        var pipeWidth = options.Width ?? TryGetConsoleWidth() ?? DefaultWidth;
-        var pipeHeight = options.Height ?? TryGetConsoleHeight() ?? DefaultHeight;
+        var pipeWidth = ResolveSize(
+            options.Width,
+            options.WidthAdjust,
+            TryGetConsoleWidth,
+            DefaultWidth
+        );
+        var pipeHeight = ResolveSize(
+            options.Height,
+            options.HeightAdjust,
+            TryGetConsoleHeight,
+            DefaultHeight
+        );
         logger.ZLogDebug($"Input source: stdin pipe. Width={pipeWidth} Height={pipeHeight}");
         return await PipeRecorder
             .RecordAsync(

--- a/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.cs
+++ b/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.cs
@@ -340,6 +340,33 @@ public sealed partial class OptionParserTests
     }
 
     [Test]
+    public void WidthAdjustAndHeightAdjustAreTrueByDefault()
+    {
+        var ok = OptionParser.TryParse(System.Array.Empty<string>(), out var options, out _, out _);
+        ok.ShouldBeTrue();
+        options!.WidthAdjust.ShouldBeTrue();
+        options.HeightAdjust.ShouldBeTrue();
+    }
+
+    [Test]
+    public void ExplicitNumericWidthSetsWidthAdjustFalse()
+    {
+        var ok = OptionParser.TryParse(new[] { "-w", "80" }, out var options, out _, out _);
+        ok.ShouldBeTrue();
+        options!.Width.ShouldBe(80);
+        options.WidthAdjust.ShouldBeFalse();
+    }
+
+    [Test]
+    public void ExplicitNumericHeightSetsHeightAdjustFalse()
+    {
+        var ok = OptionParser.TryParse(new[] { "-h", "24" }, out var options, out _, out _);
+        ok.ShouldBeTrue();
+        options!.Height.ShouldBe(24);
+        options.HeightAdjust.ShouldBeFalse();
+    }
+
+    [Test]
     public void WidthAdjustParsed()
     {
         var ok = OptionParser.TryParse(


### PR DESCRIPTION
## Summary

This PR makes `-w adjust -h adjust` the default behavior for all modes (pipe, interactive, and command), instead of only for interactive mode.

## Breaking Change

⚠️ **This is a breaking change**

### Before
- **Pipe mode**: Used terminal width if available, fallback to 100
- **Interactive mode**: Used terminal width (adjust behavior)
- **Command mode**: Used fixed width of 100

### After
- **All modes**: Use terminal width by default (adjust behavior), fallback to 100

Users can still specify explicit dimensions with `-w <int> -h <int>` to override the default behavior.

## Changes

- Set `WidthAdjust` and `HeightAdjust` defaults to `true` in `AppOptions.cs`
- Updated pipe mode to use `ResolveSize` for consistency with other modes
- Removed `ApplyInteractiveSizeDefaults` method (no longer needed)
- Updated help text to reflect new defaults
- Added tests for new default behavior
- Explicit numeric values now set `WidthAdjust`/`HeightAdjust` to `false`

## Testing

All 340 tests pass, including 3 new tests:
- `WidthAdjustAndHeightAdjustAreTrueByDefault` - Verifies new default behavior
- `ExplicitNumericWidthSetsWidthAdjustFalse` - Verifies explicit width disables adjust
- `ExplicitNumericHeightSetsHeightAdjustFalse` - Verifies explicit height disables adjust

## Migration Guide

If you relied on the old default behavior (fixed width of 100 for command mode), you can now explicitly specify it:

```bash
# Old behavior (fixed width 100)
console2svg "my-command" -w 100 -h 24

# New default behavior (terminal size)
console2svg "my-command"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal recordings now automatically adjust to the detected console width and height by default.
  * Added support for combining automatic sizing adjustments with explicitly detected dimensions.
* **Bug Fixes**
  * Specifying a numeric width or height now correctly disables automatic adjustment for that dimension.
* **Documentation**
  * Updated command-line help to clarify that automatic width and height adjustment is enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->