### PR TITLE
chore: add WinGet release publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -231,7 +231,7 @@ jobs:
         uses: vedantmgoyal9/winget-releaser@v2
         with:
           identifier: arika0093.console2svg
-          installers-regex: '^console2svg-win-(x64|arm64)\.exe$'
+          installers-regex: '^console2svg-win-(x64|arm64)\.zip$'
           release-tag: v${{ needs.build-nupkg.outputs.version }}
           token: ${{ secrets.WINGET_TOKEN }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -219,6 +219,22 @@ jobs:
         working-directory: wrapper/npm
         run: npm publish --provenance --access public
 
+  release-winget:
+    needs: [build-nupkg, release-github]
+    if: ${{ needs.build-nupkg.outputs.prerelease != 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Publish to WinGet
+        # winget-releaser installs and invokes Komac to generate the manifests
+        # and submit the update to microsoft/winget-pkgs.
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: arika0093.console2svg
+          installers-regex: '^console2svg-win-(x64|arm64)\.exe$'
+          release-tag: v${{ needs.build-nupkg.outputs.version }}
+          token: ${{ secrets.WINGET_TOKEN }}
+
   image-gen:
     runs-on: ubuntu-latest
     needs: [release-github]

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 ![console2svg hero image with oh-my-logo](./assets/cmd-hero.svg)
 
-[![NuGet Version](https://img.shields.io/nuget/v/ConsoleToSvg?style=flat-square&logo=NuGet&color=0080CC)](https://www.nuget.org/packages/ConsoleToSvg/) [![npm version](https://img.shields.io/npm/v/console2svg?style=flat-square&logo=npm&color=0080CC)](https://www.npmjs.com/package/console2svg) [![GitHub Release](https://img.shields.io/github/v/release/arika0093/console2svg?style=flat-square&logo=github&label=GitHub%20Release&color=%230080CC)](https://github.com/arika0093/console2svg/releases/latest)
+[![NuGet Version](https://img.shields.io/nuget/v/ConsoleToSvg?style=flat-square&logo=NuGet&color=0080CC)](https://www.nuget.org/packages/ConsoleToSvg/) [![npm version](https://img.shields.io/npm/v/console2svg?style=flat-square&logo=npm&color=0080CC)](https://www.npmjs.com/package/console2svg) [![GitHub Release](https://img.shields.io/github/v/release/arika0093/console2svg?style=flat-square&logo=github&label=GitHub%20Release&color=%230080CC)](https://github.com/arika0093/console2svg/releases/latest) [![WinGet Package Version](https://img.shields.io/winget/v/arika0093.console2svg?style=flat-square&logo=gitlfs&label=WinGet)](https://winget.run/pkg/arika0093.console2svg)
 
-Easily convert terminal output into SVG images. <br/>
+
+Easily convert terminal output into SVG images.  
 Truecolor, animation, cropping and many appearance options are supported.
 
 > Of course, this hero image is [generated](https://github.com/arika0093/console2svg/blob/main/scripts/image-gen.sh#L2-L3) using console2svg itself.
@@ -97,6 +98,9 @@ dotnet tool install -g ConsoleToSvg
 
 # npm global package (Windows / Linux / macOS)
 npm install -g console2svg
+
+# Windows Package Manager (WinGet)
+winget install arika0093.console2svg
 ```
 
 You can also install from the [release archives](https://github.com/arika0093/console2svg/releases/latest) manually, or use the `.deb` / `.rpm` packages on Linux.


### PR DESCRIPTION
## Summary

- publish stable releases to WinGet through Komac-backed `winget-releaser`
- document the WinGet installation command
- match the published portable ZIP assets for both x64 and arm64

## Why

The initial WinGet manifest uses `arika0093.console2svg` and portable ZIP installers. The release workflow must target the same package identifier and artifacts so it can submit subsequent version updates.

## Validation

- `git diff --check`
- Parsed `.github/workflows/release.yaml` with Prettier

Closes #76 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WinGet distribution for stable Windows releases, supporting x64 and ARM64 installers.
  * Added documented WinGet installation instructions and a package version badge to the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->