### PR TITLE
Fix: Download binary at dotnet tool install time

### DIFF
--- a/wrapper/dotnet/ConsoleToSvg.Tool.csproj
+++ b/wrapper/dotnet/ConsoleToSvg.Tool.csproj
@@ -23,5 +23,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <None Include="../../README.md" Pack="true" PackagePath="\" />
+    <None Include="build/ConsoleToSvg.Tool.targets" Pack="true" PackagePath="tools/$(TargetFramework)/any/build/" />
   </ItemGroup>
 </Project>

--- a/wrapper/dotnet/Program.cs
+++ b/wrapper/dotnet/Program.cs
@@ -10,6 +10,11 @@ internal static class Program
 
     public static async Task<int> Main(string[] args)
     {
+        if (args.Length == 1 && args[0] == "--post-install")
+        {
+            return await RunPostInstallAsync().ConfigureAwait(false);
+        }
+
         if (!TryGetRuntimeAsset(out var rid, out var executableName, out var archiveExtension))
         {
             await Console.Error.WriteLineAsync(
@@ -98,6 +103,55 @@ internal static class Program
             );
             return 1;
         }
+    }
+
+    private static async Task<int> RunPostInstallAsync()
+    {
+        if (!TryGetRuntimeAsset(out var rid, out var executableName, out var archiveExtension))
+        {
+            await Console.Error.WriteLineAsync(
+                $"console2svg: unsupported platform: {RuntimeInformation.OSDescription} {RuntimeInformation.ProcessArchitecture}."
+            );
+            return 1;
+        }
+
+        var distributionDirectory = GetDistributionDirectory();
+        var executablePath = Path.Combine(distributionDirectory, executableName);
+        if (File.Exists(executablePath))
+        {
+            return 0;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(distributionDirectory);
+            await using var installationLock = await AcquireInstallationLockAsync(distributionDirectory)
+                .ConfigureAwait(false);
+            if (!File.Exists(executablePath))
+            {
+                await DownloadAndExtractAsync(rid, executableName, archiveExtension, distributionDirectory)
+                    .ConfigureAwait(false);
+                if (!OperatingSystem.IsWindows())
+                {
+                    await MakeExecutableAsync(executablePath).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            await Console.Error.WriteLineAsync($"console2svg: failed to install the native binary: {ex.Message}");
+            return 1;
+        }
+
+        if (!File.Exists(executablePath))
+        {
+            await Console.Error.WriteLineAsync(
+                $"console2svg: the native binary was not found at '{executablePath}' after installation."
+            );
+            return 1;
+        }
+
+        return 0;
     }
 
     private static bool TryGetRuntimeAsset(

--- a/wrapper/dotnet/build/ConsoleToSvg.Tool.targets
+++ b/wrapper/dotnet/build/ConsoleToSvg.Tool.targets
@@ -1,0 +1,12 @@
+<Project>
+  <Target Name="ConsoleToSvgPostInstall" AfterTargets="Restore">
+    <Exec Command="dotnet exec &quot;$(MSBuildThisFileDirectory)../ConsoleToSvg.Tool.dll&quot; --post-install"
+          IgnoreExitCode="true"
+          StandardOutputImportance="low"
+          StandardErrorImportance="high">
+      <Output TaskParameter="ExitCode" PropertyName="ConsoleToSvgPostInstallExitCode" />
+    </Exec>
+    <Warning Condition="'$(ConsoleToSvgPostInstallExitCode)' != '0'"
+             Text="console2svg: post-install binary download failed (exit code $(ConsoleToSvgPostInstallExitCode)). The native binary will be downloaded on first use." />
+  </Target>
+</Project>


### PR DESCRIPTION
## Summary
- Add `--post-install` command to download native binary during install
- Add MSBuild targets file that runs post-install after NuGet restore
- Include targets file in NuGet package via ConsoleToSvg.Tool.csproj

## Changes
- Binary is now downloaded when user runs `dotnet tool install`
- Fallback download on first use remains for robustness

Fixes #99