### PR TITLE
Fix: Bundle native binaries in dotnet tool package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,10 @@ jobs:
         shell: bash
         run: bash scripts/release/stage-native-assets.sh
 
+      - name: Stage native tool assets for NuGet
+        shell: bash
+        run: bash scripts/release/stage-native-tool-assets.sh
+
       - name: Export package iteration
         id: package-iteration
         shell: bash
@@ -62,7 +66,7 @@ jobs:
         run: dotnet pack src/ConsoleToSvg.Converter/ConsoleToSvg.Converter.csproj --no-build -c Release --output ./nuget-artifacts -p:ResvgNativeAssetsDirectory="$GITHUB_WORKSPACE/native-assets" -p:RequireResvgNativeAssets=true
 
       - name: Pack ConsoleToSvg tool
-        run: dotnet pack wrapper/dotnet/ConsoleToSvg.Tool.csproj --no-build -c Release --output ./nuget-artifacts
+        run: dotnet pack wrapper/dotnet/ConsoleToSvg.Tool.csproj --no-build -c Release --output ./nuget-artifacts -p:ToolNativeAssetsDirectory="$GITHUB_WORKSPACE/tool-native-assets" -p:RequireToolNativeAssets=true
 
       - name: Upload NuGet artifacts
         uses: actions/upload-artifact@v7

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ irm https://raw.githubusercontent.com/arika0093/console2svg/main/install.ps1 | i
 You can also install via package managers.
 
 ```sh
-# dotnet global tool (downloads the platform-native binary on first run)
+# dotnet global tool (bundles the platform-native binary for offline first use)
 dotnet tool install -g ConsoleToSvg
 
 # npm global package (Windows / Linux / macOS)

--- a/scripts/release/stage-native-tool-assets.sh
+++ b/scripts/release/stage-native-tool-assets.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tool_assets_dir="./tool-native-assets"
+rm -rf "$tool_assets_dir"
+
+for rid in linux-x64 linux-arm64 osx-x64 osx-arm64; do
+  src="./native-artifacts/native-${rid}"
+  dest="${tool_assets_dir}/${rid}"
+  test -f "${src}/console2svg"
+  mkdir -p "$dest"
+  cp "${src}/console2svg" "$dest/"
+  find "$src" -maxdepth 1 -type f \( -name '*.so' -o -name '*.dylib' \) -exec cp {} "$dest/" \;
+done
+
+for rid in win-x64 win-arm64; do
+  src="./native-artifacts/native-${rid}"
+  dest="${tool_assets_dir}/${rid}"
+  test -f "${src}/console2svg.exe"
+  mkdir -p "$dest"
+  find "$src" -maxdepth 1 -type f \( -name '*.exe' -o -name '*.dll' \) -exec cp {} "$dest/" \;
+
+  case "$rid" in
+    win-x64) ffmpeg_zip_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-lgpl-shared.zip" ;;
+    win-arm64) ffmpeg_zip_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-winarm64-lgpl-shared.zip" ;;
+  esac
+
+  ffmpeg_extract="${tool_assets_dir}/.ffmpeg-${rid}"
+  curl -fsSL -o "${ffmpeg_extract}.zip" "$ffmpeg_zip_url"
+  unzip -q "${ffmpeg_extract}.zip" -d "$ffmpeg_extract"
+  ffmpeg_bin_dir="$(find "$ffmpeg_extract" -type f -name ffmpeg.exe -printf '%h\n' | head -n 1)"
+  test -n "$ffmpeg_bin_dir"
+  mkdir -p "${dest}/ffmpeg"
+  cp "${ffmpeg_bin_dir}"/*.exe "${dest}/ffmpeg/"
+  cp "${ffmpeg_bin_dir}"/*.dll "${dest}/ffmpeg/"
+  cp "$(dirname "$ffmpeg_bin_dir")/LICENSE.txt" "${dest}/ffmpeg/ffmpeg-LICENSE.txt"
+  rm -rf "$ffmpeg_extract" "${ffmpeg_extract}.zip"
+done

--- a/wrapper/dotnet/ConsoleToSvg.Tool.csproj
+++ b/wrapper/dotnet/ConsoleToSvg.Tool.csproj
@@ -16,6 +16,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <NBGV_ThisAssemblyIncludesPackageVersion>true</NBGV_ThisAssemblyIncludesPackageVersion>
+    <ToolNativeAssetsDirectory Condition="'$(ToolNativeAssetsDirectory)' == ''">$(BaseIntermediateOutputPath)native-assets</ToolNativeAssetsDirectory>
+    <RequireToolNativeAssets Condition="'$(RequireToolNativeAssets)' == ''">false</RequireToolNativeAssets>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.*">
@@ -23,5 +25,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <None Include="../../README.md" Pack="true" PackagePath="\" />
+    <None Include="$(ToolNativeAssetsDirectory)/**/*" Pack="true" PackagePath="tools/$(TargetFramework)/any/native/%(RecursiveDir)" Visible="false" Condition="Exists('$(ToolNativeAssetsDirectory)')" />
   </ItemGroup>
+  <Target Name="ValidateToolNativeAssets" BeforeTargets="Pack" Condition="'$(RequireToolNativeAssets)' == 'true'">
+    <Error Condition="!Exists('$(ToolNativeAssetsDirectory)/linux-x64/console2svg')" Text="Missing native tool asset for linux-x64." />
+    <Error Condition="!Exists('$(ToolNativeAssetsDirectory)/linux-arm64/console2svg')" Text="Missing native tool asset for linux-arm64." />
+    <Error Condition="!Exists('$(ToolNativeAssetsDirectory)/win-x64/console2svg.exe')" Text="Missing native tool asset for win-x64." />
+    <Error Condition="!Exists('$(ToolNativeAssetsDirectory)/win-arm64/console2svg.exe')" Text="Missing native tool asset for win-arm64." />
+    <Error Condition="!Exists('$(ToolNativeAssetsDirectory)/osx-x64/console2svg')" Text="Missing native tool asset for osx-x64." />
+    <Error Condition="!Exists('$(ToolNativeAssetsDirectory)/osx-arm64/console2svg')" Text="Missing native tool asset for osx-arm64." />
+  </Target>
 </Project>

--- a/wrapper/dotnet/Program.cs
+++ b/wrapper/dotnet/Program.cs
@@ -1,16 +1,13 @@
 using System.Diagnostics;
-using System.IO.Compression;
 using System.Runtime.InteropServices;
 
 namespace ConsoleToSvg.Tool;
 
 internal static class Program
 {
-    private const string ReleaseBaseUrl = "https://github.com/arika0093/console2svg/releases/download";
-
     public static async Task<int> Main(string[] args)
     {
-        if (!TryGetRuntimeAsset(out var rid, out var executableName, out var archiveExtension))
+        if (!TryGetRuntimeAsset(out var rid, out var executableName))
         {
             await Console.Error.WriteLineAsync(
                 $"console2svg: unsupported platform: {RuntimeInformation.OSDescription} {RuntimeInformation.ProcessArchitecture}."
@@ -29,13 +26,7 @@ internal static class Program
                     .ConfigureAwait(false);
                 if (!File.Exists(executablePath))
                 {
-                    await DownloadAndExtractAsync(
-                            rid,
-                            executableName,
-                            archiveExtension,
-                            distributionDirectory
-                        )
-                        .ConfigureAwait(false);
+                    CopyBundledFiles(rid, executableName, distributionDirectory);
                     if (!OperatingSystem.IsWindows())
                     {
                         await MakeExecutableAsync(executablePath).ConfigureAwait(false);
@@ -102,8 +93,7 @@ internal static class Program
 
     private static bool TryGetRuntimeAsset(
         out string rid,
-        out string executableName,
-        out string archiveExtension
+        out string executableName
     )
     {
         var architecture = RuntimeInformation.ProcessArchitecture switch
@@ -117,14 +107,12 @@ internal static class Program
         if (string.IsNullOrEmpty(architecture))
         {
             rid = string.Empty;
-            archiveExtension = string.Empty;
             return false;
         }
 
         if (OperatingSystem.IsWindows())
         {
             rid = $"win-{architecture}";
-            archiveExtension = "zip";
             return true;
         }
 
@@ -133,81 +121,48 @@ internal static class Program
             if (IsMuslLinux())
             {
                 rid = string.Empty;
-                archiveExtension = string.Empty;
                 return false;
             }
 
             rid = $"linux-{architecture}";
-            archiveExtension = "tar.gz";
             return true;
         }
 
         if (OperatingSystem.IsMacOS())
         {
             rid = $"osx-{architecture}";
-            archiveExtension = "tar.gz";
             return true;
         }
 
         rid = string.Empty;
-        archiveExtension = string.Empty;
         return false;
     }
 
-    private static async Task DownloadAndExtractAsync(
-        string rid,
-        string executableName,
-        string archiveExtension,
-        string distributionDirectory
-    )
+    private static void CopyBundledFiles(string rid, string executableName, string distributionDirectory)
     {
-        var version = GetReleaseVersion();
-        var archiveName = $"console2svg-{rid}.{archiveExtension}";
+        var bundledDirectory = Path.Combine(AppContext.BaseDirectory, "native", rid);
+        if (!Directory.Exists(bundledDirectory))
+        {
+            throw new InvalidOperationException($"The package does not contain native assets for '{rid}'.");
+        }
+
         var stagingDirectory = Path.Combine(
             distributionDirectory,
             $".staging-{Environment.ProcessId}-{Guid.NewGuid():N}"
         );
-        var archivePath = Path.Combine(stagingDirectory, archiveName);
-        var downloadUrl = $"{ReleaseBaseUrl}/v{version}/{archiveName}";
-
-        await Console.Error.WriteLineAsync($"console2svg: downloading {downloadUrl}");
         try
         {
             Directory.CreateDirectory(stagingDirectory);
-            using var client = new HttpClient();
-            client.DefaultRequestHeaders.UserAgent.ParseAdd("console2svg-dotnet-tool-wrapper");
-            await using var input = await client
-                .GetStreamAsync(downloadUrl)
-                .ConfigureAwait(false);
-            await using (var output = File.Create(archivePath))
+            foreach (var sourcePath in Directory.GetFiles(bundledDirectory, "*", SearchOption.AllDirectories))
             {
-                await input.CopyToAsync(output).ConfigureAwait(false);
+                var destinationPath = Path.Combine(
+                    stagingDirectory,
+                    Path.GetRelativePath(bundledDirectory, sourcePath)
+                );
+                Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+                File.Copy(sourcePath, destinationPath, overwrite: true);
             }
 
-            if (OperatingSystem.IsWindows())
-            {
-                ZipFile.ExtractToDirectory(archivePath, stagingDirectory);
-            }
-            else
-            {
-                using var tar = Process.Start(
-                    new ProcessStartInfo
-                    {
-                        FileName = "tar",
-                        UseShellExecute = false,
-                        RedirectStandardError = true,
-                        ArgumentList = { "-xzf", archivePath, "-C", stagingDirectory },
-                    }
-                ) ?? throw new InvalidOperationException("Unable to start tar.");
-                var standardError = await tar.StandardError.ReadToEndAsync().ConfigureAwait(false);
-                await tar.WaitForExitAsync().ConfigureAwait(false);
-                if (tar.ExitCode != 0)
-                {
-                    throw new InvalidOperationException($"tar failed: {standardError.Trim()}");
-                }
-            }
-
-            File.Delete(archivePath);
             PublishStagedFiles(stagingDirectory, distributionDirectory, executableName);
         }
         finally


### PR DESCRIPTION
## Summary

- Bundle NativeAOT assets for all supported RIDs in the .NET tool package.
- Copy the matching bundled asset into the local cache on first run, without a network download.
- Include the Windows LGPL FFmpeg distribution and its license in the Windows assets.

## Why

`dotnet tool install` does not run package post-install hooks. Bundling assets preserves offline first use.

## Validation

- `dotnet build wrapper/dotnet/ConsoleToSvg.Tool.csproj --configuration Debug --no-restore`
- `dotnet pack wrapper/dotnet/ConsoleToSvg.Tool.csproj --configuration Debug --no-build`
- `bash -n scripts/release/stage-native-tool-assets.sh`