### PR TITLE
chore: reapply WinGet release publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -223,6 +223,22 @@ jobs:
         working-directory: wrapper/npm
         run: npm publish --provenance --access public
 
+  release-winget:
+    needs: [build-nupkg, release-github]
+    if: ${{ needs.build-nupkg.outputs.prerelease != 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Publish to WinGet
+        # winget-releaser installs and invokes Komac to generate the manifests
+        # and submit the update to microsoft/winget-pkgs.
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: arika0093.console2svg
+          installers-regex: '^console2svg-win-(x64|arm64)\.zip$'
+          release-tag: v${{ needs.build-nupkg.outputs.version }}
+          token: ${{ secrets.WINGET_TOKEN }}
+
   image-gen:
     runs-on: ubuntu-latest
     needs: [release-github]

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 ![console2svg hero image with oh-my-logo](./assets/cmd-hero.svg)
 
-[![NuGet Version](https://img.shields.io/nuget/v/ConsoleToSvg?style=flat-square&logo=NuGet&color=0080CC)](https://www.nuget.org/packages/ConsoleToSvg/) [![npm version](https://img.shields.io/npm/v/console2svg?style=flat-square&logo=npm&color=0080CC)](https://www.npmjs.com/package/console2svg) [![GitHub Release](https://img.shields.io/github/v/release/arika0093/console2svg?style=flat-square&logo=github&label=GitHub%20Release&color=%230080CC)](https://github.com/arika0093/console2svg/releases/latest)
+[![NuGet Version](https://img.shields.io/nuget/v/ConsoleToSvg?style=flat-square&logo=NuGet&color=0080CC)](https://www.nuget.org/packages/ConsoleToSvg/) [![npm version](https://img.shields.io/npm/v/console2svg?style=flat-square&logo=npm&color=0080CC)](https://www.npmjs.com/package/console2svg) [![GitHub Release](https://img.shields.io/github/v/release/arika0093/console2svg?style=flat-square&logo=github&label=GitHub%20Release&color=%230080CC)](https://github.com/arika0093/console2svg/releases/latest) [![WinGet Package Version](https://img.shields.io/winget/v/arika0093.console2svg?style=flat-square&logo=gitlfs&label=WinGet)](https://winget.run/pkg/arika0093.console2svg)
 
-Easily convert terminal output into SVG images. <br/>
+
+Easily convert terminal output into SVG images.  
 Truecolor, animation, cropping and many appearance options are supported.
 
 > Of course, this hero image is [generated](https://github.com/arika0093/console2svg/blob/main/scripts/image-gen.sh#L2-L3) using console2svg itself.
@@ -97,6 +98,9 @@ dotnet tool install -g ConsoleToSvg
 
 # npm global package (Windows / Linux / macOS)
 npm install -g console2svg
+
+# Windows Package Manager (WinGet)
+winget install arika0093.console2svg
 ```
 
 You can also install from the [release archives](https://github.com/arika0093/console2svg/releases/latest) manually, or use the `.deb` / `.rpm` packages on Linux.


### PR DESCRIPTION
## Summary

- reapply the WinGet release publishing changes from reverted PR #98
- publish stable releases through Komac-backed winget-releaser
- document the WinGet installation command and package version badge

## Why

PR #98 was merged unintentionally and then reverted. This PR restores the same WinGet distribution support for stable Windows releases.

## Validation

- inspected the re-applied diff against the revert commit
- git diff --check reports the pre-existing Markdown hard line break in README.md, retained unchanged from PR #98

Closes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WinGet distribution support for non-prerelease releases, publishing Windows x64 and arm64 ZIP installers automatically.
  * Added a WinGet version badge and installation instructions to the README.

* **Documentation**
  * Updated the project introduction formatting in the README for cleaner display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->