### PR TITLE
fix: feat: publish package to winget

### DIFF
--- a/.github/workflows/winget-publish.yaml
+++ b/.github/workflows/winget-publish.yaml
@@ -1,0 +1,19 @@
+name: Publish to Winget
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Publish to Winget
+        uses: russellbanks/Komac@v2
+        with:
+          identifier: arika0093.console2svg
+          installers-url: https://github.com/arika0093/console2svg/releases/download/{version}/ConsoleToSvg-{version}-win-x64.exe
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated publishing of released versions to the Windows Package Manager (Winget).
  * Configured release uploads using the Windows installer download URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->