### PR TITLE
Fix PTY cleanup hanging after recording timeout

### DIFF
--- a/src/ConsoleToSvg.Core/RecordingSession.cs
+++ b/src/ConsoleToSvg.Core/RecordingSession.cs
@@ -25,6 +25,8 @@ public sealed class AsciicastEvent
 
 public sealed class RecordingSession
 {
+    private readonly object _eventsLock = new();
+
     public RecordingSession(int width, int height)
     {
         Header = new AsciicastHeader
@@ -46,6 +48,16 @@ public sealed class RecordingSession
 
     public List<AsciicastEvent> Events { get; }
 
+    public object EventsLock => _eventsLock;
+
+    public int GetEventCount()
+    {
+        lock (_eventsLock)
+        {
+            return Events.Count;
+        }
+    }
+
     public void AddEvent(double timeSeconds, string data)
     {
         if (string.IsNullOrEmpty(data))
@@ -53,13 +65,16 @@ public sealed class RecordingSession
             return;
         }
 
-        Events.Add(
-            new AsciicastEvent
-            {
-                Time = timeSeconds,
-                Type = "o",
-                Data = data,
-            }
-        );
+        lock (_eventsLock)
+        {
+            Events.Add(
+                new AsciicastEvent
+                {
+                    Time = timeSeconds,
+                    Type = "o",
+                    Data = data,
+                }
+            );
+        }
     }
 }

--- a/src/ConsoleToSvg.Record/PtyRecorder.cs
+++ b/src/ConsoleToSvg.Record/PtyRecorder.cs
@@ -457,6 +457,11 @@ public static partial class PtyRecorder
             logger.ZLogDebug(
                 $"PTY output reader did not stop within {PtyCleanupTimeoutMs}ms; continuing shutdown."
             );
+            // Observe exceptions from the read task in the background to prevent unobserved task exceptions
+            _ = readTask.ContinueWith(
+                t => logger.ZLogDebug(t.Exception?.InnerException ?? t.Exception, $"PTY output reader faulted after timeout"),
+                TaskContinuationOptions.OnlyOnFaulted
+            );
             return false;
         }
 

--- a/src/ConsoleToSvg.Record/PtyRecorder.cs
+++ b/src/ConsoleToSvg.Record/PtyRecorder.cs
@@ -19,6 +19,8 @@ public static partial class PtyRecorder
     private const string DisableMouseTrackingSequence =
         "\u001b[?9l\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1004l\u001b[?1005l\u001b[?1006l\u001b[?1015l\u001b[?1016l\u001b[?9001l";
 
+    private const int PtyCleanupTimeoutMs = 1000;
+
     // remove some CI environments to avoid apps switching to no-color mode.
     // for example: chalk(Node.js) checks "CI" to disable colors on CI environments:
     // see: https://github.com/chalk/chalk/blob/aa06bb5ac3f14df9fda8cfb54274dfc165ddfdef/source/vendor/supports-color/index.js#L114
@@ -326,6 +328,13 @@ public static partial class PtyRecorder
                 }
             }
 
+            if (canceled)
+            {
+                await readCancellation.CancelAsync().ConfigureAwait(false);
+            }
+
+            await inputCancellation.CancelAsync().ConfigureAwait(false);
+
             if (canceled || eofReached || processExited)
             {
                 string msg;
@@ -347,48 +356,15 @@ public static partial class PtyRecorder
                     msg = "PTY process exited. Finalizing recording.";
                 }
                 logger.ZLogDebug($"{msg}");
-                try
-                {
-                    connection.Dispose();
-                    disposed = true;
-                }
-                catch
-                {
-                    // Ignore disposal errors during cancellation cleanup.
-                }
+                disposed = true;
+                await DisposeConnectionWithTimeoutAsync(connection, logger).ConfigureAwait(false);
             }
 
-            if (canceled)
-            {
-                await readCancellation.CancelAsync().ConfigureAwait(false);
-            }
-
-            await inputCancellation.CancelAsync().ConfigureAwait(false);
-
-            try
-            {
-                await readTask.ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                // Read task cancellation is treated as graceful completion for partial output.
-            }
-            catch (IOException ex) when (IsExpectedPtyEof(ex))
-            {
-                // On Unix PTY, child exit can surface as EIO ("Input/output error")
-                // when reading after the slave side is closed. Treat as EOF.
-            }
+            await FinishReadTaskAsync(readTask, logger).ConfigureAwait(false);
 
             if (!canceled && !eofReached && !processExited && !disposed)
             {
-                try
-                {
-                    connection.Dispose();
-                }
-                catch
-                {
-                    // Ignore disposal errors when the process has already exited
-                }
+                await DisposeConnectionWithTimeoutAsync(connection, logger).ConfigureAwait(false);
             }
 
             if (inputTask is not null)
@@ -432,6 +408,65 @@ public static partial class PtyRecorder
         finally
         {
             TryDisableTerminalMouseTracking(forwardToConsole, logger);
+        }
+    }
+
+    private static async Task DisposeConnectionWithTimeoutAsync(
+        NativePtyConnection connection,
+        ILogger logger
+    )
+    {
+        var disposeTask = Task.Run(connection.Dispose);
+        var completed = await Task.WhenAny(
+                disposeTask,
+                Task.Delay(PtyCleanupTimeoutMs, CancellationToken.None)
+            )
+            .ConfigureAwait(false);
+        if (completed != disposeTask)
+        {
+            logger.ZLogDebug(
+                $"PTY cleanup did not complete within {PtyCleanupTimeoutMs}ms; continuing shutdown."
+            );
+            return;
+        }
+
+        try
+        {
+            await disposeTask.ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.ZLogDebug(ex, $"PTY cleanup failed; continuing shutdown.");
+        }
+    }
+
+    private static async Task FinishReadTaskAsync(Task readTask, ILogger logger)
+    {
+        var completed = await Task.WhenAny(
+                readTask,
+                Task.Delay(PtyCleanupTimeoutMs, CancellationToken.None)
+            )
+            .ConfigureAwait(false);
+        if (completed != readTask)
+        {
+            logger.ZLogDebug(
+                $"PTY output reader did not stop within {PtyCleanupTimeoutMs}ms; continuing shutdown."
+            );
+            return;
+        }
+
+        try
+        {
+            await readTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Read task cancellation is treated as graceful completion for partial output.
+        }
+        catch (IOException ex) when (IsExpectedPtyEof(ex))
+        {
+            // On Unix PTY, child exit can surface as EIO ("Input/output error")
+            // when reading after the slave side is closed. Treat as EOF.
         }
     }
 

--- a/src/ConsoleToSvg.Record/PtyRecorder.cs
+++ b/src/ConsoleToSvg.Record/PtyRecorder.cs
@@ -273,7 +273,7 @@ public static partial class PtyRecorder
 
                     if (
                         startupTimeoutMs.HasValue
-                        && session.Events.Count == 0
+                        && session.GetEventCount() == 0
                         && stopwatch.ElapsedMilliseconds > startupTimeoutMs.Value
                     )
                     {
@@ -360,7 +360,7 @@ public static partial class PtyRecorder
                 await DisposeConnectionWithTimeoutAsync(connection, logger).ConfigureAwait(false);
             }
 
-            await FinishReadTaskAsync(readTask, logger).ConfigureAwait(false);
+            var readerCompleted = await FinishReadTaskAsync(readTask, logger).ConfigureAwait(false);
 
             if (!canceled && !eofReached && !processExited && !disposed)
             {
@@ -386,7 +386,7 @@ public static partial class PtyRecorder
             }
 
             logger.ZLogDebug(
-                $"PTY recording completed. Events={session.Events.Count} ElapsedMs={stopwatch.ElapsedMilliseconds}"
+                $"PTY recording completed. Events={session.GetEventCount()} ElapsedMs={stopwatch.ElapsedMilliseconds}"
             );
 
             if (replayTimeoutExceeded is double exceededDurationFinal)
@@ -401,6 +401,11 @@ public static partial class PtyRecorder
                 throw new PtyStartupHangException(
                     $"PTY process did not produce any output within {startupTimeoutMs!.Value}ms of starting."
                 );
+            }
+
+            if (!readerCompleted)
+            {
+                return SnapshotSession(session);
             }
 
             return session;
@@ -440,7 +445,7 @@ public static partial class PtyRecorder
         }
     }
 
-    private static async Task FinishReadTaskAsync(Task readTask, ILogger logger)
+    private static async Task<bool> FinishReadTaskAsync(Task readTask, ILogger logger)
     {
         var completed = await Task.WhenAny(
                 readTask,
@@ -452,7 +457,7 @@ public static partial class PtyRecorder
             logger.ZLogDebug(
                 $"PTY output reader did not stop within {PtyCleanupTimeoutMs}ms; continuing shutdown."
             );
-            return;
+            return false;
         }
 
         try
@@ -468,6 +473,24 @@ public static partial class PtyRecorder
             // On Unix PTY, child exit can surface as EIO ("Input/output error")
             // when reading after the slave side is closed. Treat as EOF.
         }
+
+        return true;
+    }
+
+    private static RecordingSession SnapshotSession(RecordingSession source)
+    {
+        var snapshot = new RecordingSession(source.Header.width, source.Header.height)
+        {
+            Header =
+            {
+                timestamp = source.Header.timestamp,
+            },
+        };
+        lock (source.EventsLock)
+        {
+            snapshot.Events.AddRange(source.Events);
+        }
+        return snapshot;
     }
 
     private static async Task<RecordingSession> RecordWithProcessFallbackAsync(
@@ -651,7 +674,7 @@ public static partial class PtyRecorder
             }
 
             logger.ZLogDebug(
-                $"Fallback recording completed. ExitCode={process.ExitCode} Events={session.Events.Count} ElapsedMs={stopwatch.ElapsedMilliseconds} Canceled={canceled}"
+                $"Fallback recording completed. ExitCode={process.ExitCode} Events={session.GetEventCount()} ElapsedMs={stopwatch.ElapsedMilliseconds} Canceled={canceled}"
             );
 
             if (replayTimedOut && replayData?.TotalDuration is double exceededDuration)

--- a/tests/ConsoleToSvg.Tests/Recording/PtyRecorderTests.cs
+++ b/tests/ConsoleToSvg.Tests/Recording/PtyRecorderTests.cs
@@ -35,7 +35,7 @@ public sealed class PtyRecorderTests
                 Task.Delay(TimeSpan.FromSeconds(3))
             );
             completed.ShouldBe(disposeTask);
-            await disposeTask.ConfigureAwait(false);
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
         }
         finally
         {

--- a/tests/ConsoleToSvg.Tests/Recording/PtyRecorderTests.cs
+++ b/tests/ConsoleToSvg.Tests/Recording/PtyRecorderTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Diagnostics;
-using System.IO;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -14,6 +14,32 @@ namespace ConsoleToSvg.Tests.Recording;
 
 public sealed class PtyRecorderTests
 {
+    [Test]
+    public async Task DisposeConnectionWithTimeoutAsync_ReturnsWhenDisposeBlocks()
+    {
+        using var releaseDispose = new ManualResetEventSlim();
+        using var reader = new MemoryStream();
+        using var writer = new MemoryStream();
+        using var connection = new NativePtyConnection(
+            reader,
+            writer,
+            _ => false,
+            () => releaseDispose.Wait()
+        );
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            await InvokeDisposeConnectionWithTimeoutAsync(connection);
+        }
+        finally
+        {
+            releaseDispose.Set();
+        }
+
+        stopwatch.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(3));
+    }
+
     [Test]
     public async Task ReadOutputAsync_ForwardsRawBytesWithoutTransform()
     {
@@ -181,10 +207,8 @@ public sealed class PtyRecorderTests
                 "PtyRecorder.ResolveOutputCoalescing was not found."
             );
 
-        var settings = ((double WindowSeconds, double MaxBatchSeconds))method.Invoke(
-            null,
-            [null, 20d]
-        )!;
+        var settings = ((double WindowSeconds, double MaxBatchSeconds))
+            method.Invoke(null, [null, 20d])!;
 
         settings.WindowSeconds.ShouldBe(0.0125d);
         settings.MaxBatchSeconds.ShouldBe(0.05d);
@@ -224,7 +248,29 @@ public sealed class PtyRecorderTests
                         videoFps,
                     ]
                 )
-            ?? throw new InvalidOperationException("PtyRecorder.ReadOutputAsync did not return a Task.");
+            ?? throw new InvalidOperationException(
+                "PtyRecorder.ReadOutputAsync did not return a Task."
+            );
+        await task.ConfigureAwait(false);
+    }
+
+    private static async Task InvokeDisposeConnectionWithTimeoutAsync(
+        NativePtyConnection connection
+    )
+    {
+        var method =
+            typeof(PtyRecorder).GetMethod(
+                "DisposeConnectionWithTimeoutAsync",
+                BindingFlags.NonPublic | BindingFlags.Static
+            )
+            ?? throw new InvalidOperationException(
+                "PtyRecorder.DisposeConnectionWithTimeoutAsync was not found."
+            );
+        var task =
+            (Task?)method.Invoke(null, [connection, NullLogger.Instance])
+            ?? throw new InvalidOperationException(
+                "PtyRecorder.DisposeConnectionWithTimeoutAsync did not return a Task."
+            );
         await task.ConfigureAwait(false);
     }
 
@@ -280,8 +326,11 @@ public sealed class PtyRecorderTests
             return _inner.ReadAsync(buffer[..max], cancellationToken);
         }
 
-        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException();
+
         public override void SetLength(long value) => throw new NotSupportedException();
+
         public override void Write(byte[] buffer, int offset, int count) =>
             throw new NotSupportedException();
 

--- a/tests/ConsoleToSvg.Tests/Recording/PtyRecorderTests.cs
+++ b/tests/ConsoleToSvg.Tests/Recording/PtyRecorderTests.cs
@@ -26,18 +26,21 @@ public sealed class PtyRecorderTests
             _ => false,
             () => releaseDispose.Wait()
         );
-        var stopwatch = Stopwatch.StartNew();
+        var disposeTask = InvokeDisposeConnectionWithTimeoutAsync(connection);
 
         try
         {
-            await InvokeDisposeConnectionWithTimeoutAsync(connection);
+            var completed = await Task.WhenAny(
+                disposeTask,
+                Task.Delay(TimeSpan.FromSeconds(3))
+            );
+            completed.ShouldBe(disposeTask);
+            await disposeTask.ConfigureAwait(false);
         }
         finally
         {
             releaseDispose.Set();
         }
-
-        stopwatch.Elapsed.ShouldBeLessThan(TimeSpan.FromSeconds(3));
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- cancel PTY input and output pumps before disposing the PTY connection
- bound synchronous PTY disposal to one second so a blocked backend cannot stall shutdown indefinitely
- bound the final output-reader wait and continue rendering partial output when cleanup does not finish
- add a regression test for a PTY connection whose dispose callback blocks

## Background

The `--timeout` cancellation stopped the recording loop, but shutdown could still hang indefinitely inside synchronous PTY disposal or while awaiting the output reader. This was observed in the asset-generation workflow when the Copilot CLI replaced child processes during startup.

The timeout now remains effective even when the PTY backend does not complete cleanup. Cleanup continues on a background task while the command proceeds with the partial recording.

## Testing

- `dotnet test --project tests/ConsoleToSvg.Tests/ConsoleToSvg.Tests.csproj --no-restore -p:UseSharedCompilation=false` (400 tests passed)
- `csharpier check src/ConsoleToSvg.Record/PtyRecorder.cs tests/ConsoleToSvg.Tests/Recording/PtyRecorderTests.cs`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recording reliability during concurrent event collection.
  * Recording shutdown now returns a consistent snapshot when reads exceed their timeout.
  * Improved cleanup behavior when native operations stall, with bounded timeouts and diagnostic logging.

* **Tests**
  * Added coverage confirming disposal completes within the expected time even when the native PTY callback blocks.
  * Added validation for reliable recording completion during timeout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->