### PR TITLE
feat: reorganize CLI around workflow verbs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,7 @@ env:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
@@ -42,7 +43,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore --disable-parallel
 
       - name: Build
         run: dotnet build tests/ConsoleToSvg.Tests/ConsoleToSvg.Tests.csproj --no-restore -f net10.0 -p:PublishAot=false

--- a/README.md
+++ b/README.md
@@ -38,22 +38,22 @@ There are similar tools, but console2svg stands out for:
 
 ## Overview
 
-The simplest way to use it is to just put the command you want to run after `console2svg`. For example, the following command converts the description text of `console2svg` into SVG (oh, how meta).
+The simplest way to use it is to put the command you want to run after `console2svg capture --`. For example, the following command converts the description text of `console2svg` into SVG (oh, how meta).
 
 ```bash
-console2svg console2svg
+console2svg capture -- console2svg
 ```
 
-![console2svg console2svg](./assets/cmd.svg)
+![console2svg capture -- console2svg](./assets/cmd.svg)
 
 You can also generate SVG with a window frame. and some options to customize the appearance.  
 For example, `-w` specifies the width, `-c` is an option to display the command at the beginning of the output, and `-d` is an option to specify the style of the window frame, where we specify a macOS-like frame. If the command is long, you can also write it together after `--`.
 
 ```bash
-console2svg -w 100 -c -d macos-pc -- fastfetch
+console2svg capture -w 100 -c -d macos-pc -- fastfetch
 ```
 
-![console2svg -w 100 -c -d macos-pc -- fastfetch](./assets/cmd-window.svg)
+![console2svg capture -w 100 -c -d macos-pc -- fastfetch](./assets/cmd-window.svg)
 
 ---
 
@@ -61,21 +61,21 @@ In video mode(`-v`), you can capture the animation of the command execution and 
 By using the [replay feature](#replay-input), you can save the command execution record and later regenerate the SVG based on that record.
 
 ```bash
-console2svg -w 90 -h 24 -v -d windows --timeout 7 -- /usr/games/pipes -t 1 -f 35
+console2svg capture -w 90 -h 24 -v -d windows --timeout 7 -- /usr/games/pipes -t 1 -f 35
 ```
 
-![console2svg -w 90 -h 24 -v -d windows --timeout 7 -- pipes.sh](./assets/cmd-loop.svg)
+![console2svg capture -w 90 -h 24 -v -d windows --timeout 7 -- pipes.sh](./assets/cmd-loop.svg)
 
 ---
 
-In interactive mode(`-i`), you can run your normal interactive shell in a PTY and capture its current screen on demand. Press `F10` to write a static SVG, or `F9` to start recording from the exact current terminal state.
+With `console2svg interactive`, you can run your normal interactive shell in a PTY and capture its current screen on demand. Press `F10` to write a static SVG, or `F9` to start recording from the exact current terminal state.
 
 ```bash
-console2svg -i -d macos -o ./captures/output.svg
+console2svg interactive -d macos -o ./captures/output.svg
 # -> saves ./captures/output_yyyyMMdd_HHmmss.svg
 ```
 
-![console2svg -i -d macos -o ./captures/output.svg](./assets/cmd-interactive.svg)
+![console2svg interactive -d macos -o ./captures/output.svg](./assets/cmd-interactive.svg)
 
 
 ## Install
@@ -147,7 +147,7 @@ jobs:
         uses: arika0093/console2svg@main
 
       - name: Generate SVG
-        run: console2svg -w 120 -c -d macos-pc -o output.svg -- dotnet --version
+        run: console2svg capture -w 120 -c -d macos-pc -o output.svg -- dotnet --version
 
       - name: Commit Changes
         uses: stefanzweifel/git-auto-commit-action@v7
@@ -175,24 +175,34 @@ To disable this behavior, use the `--no-colorenv` and `--no-delete-envs` options
 > This repository uses this action itself to automatically regenerate all the SVG images in the [`assets/`](assets/) directory whenever a new release is published.
 
 ## Usage
+
+console2svg groups workflows under explicit commands. Options belong to the workflow shown below; common output and appearance options are accepted by capture, interactive, replay, and convert.
+
+| Command | Input | Workflow-specific options |
+| --- | --- | --- |
+| `capture [options] -- <command>` | command or piped stdin | `--save-cast`, `--replay-save`, `--timeout` |
+| `interactive [options] [-- <program>]` | interactive shell/program | interactive recording controls |
+| `replay <replay.json> [options] -- <command>` | keyboard replay plus command | replay input path |
+| `convert <input.cast or input.svg> [options]` | asciicast v2 recording or SVG | rendering/export options |
+
 ### Pipe mode
 
 ```sh
-my-command | console2svg
+my-command | console2svg capture
 ```
 
 ### PTY command mode
 
 ```sh
-console2svg "git log --oneline"
+console2svg capture "git log --oneline"
 # or 
-console2svg -- git log --oneline
+console2svg capture -- git log --oneline
 ```
 
 If you want to set a fixed width and height, you can use the `-w` and `-h` options.
 
 ```sh
-console2svg -w 120 -h 20 -- git log --oneline
+console2svg capture -w 120 -h 20 -- git log --oneline
 ```
 
 ### Interactive capture
@@ -203,7 +213,7 @@ The shell's output is forwarded live to your terminal. Press `F10` to write a
 static SVG; the capture notification is printed by the host and is not sent to the shell.
 
 ```sh
-console2svg -i -o ./captures/output.svg
+console2svg interactive -o ./captures/output.svg
 # -> writes ./captures/output_yyyyMMdd_HHmmss.svg (image)
 ```
 
@@ -211,7 +221,7 @@ Press `F9` to start recording from the exact current terminal state, `F12` to pa
 The output format controls whether the capture is written as animated SVG or converted to the requested video format.
 
 ```sh
-console2svg -i -o ./captures/session.svg
+console2svg interactive -o ./captures/session.svg
 # -> writes ./captures/session_yyyyMMdd_HHmmss.svg (animation)
 ```
 
@@ -221,7 +231,7 @@ You can crop the output by specifying the number of pixels or characters to crop
 
 ```sh
 # ch: character width, px: pixel
-console2svg --crop-top 1ch --crop-left 5px --crop-right 30px -- your-command
+console2svg capture --crop-top 1ch --crop-left 5px --crop-right 30px -- your-command
 ```
 
 You can also crop at the position where a specific character appears.
@@ -230,12 +240,12 @@ When specifying a character, you can specify it like `:(number)`, which crops at
 For example, the following example crops from the line where the character `Host` is located to 2 lines above the line where the character `.NET runtimes installed:` is located.
 
 ```sh
-console2svg --crop-top "Host" --crop-bottom ".NET runtimes installed:-2" -- dotnet --info
+console2svg capture --crop-top "Host" --crop-bottom ".NET runtimes installed:-2" -- dotnet --info
 ```
 
 The result will look like this.
 
-![console2svg --crop-top "Host" --crop-bottom ".NET runtimes installed:-2" -- dotnet --info](./assets/cmd-crop-word.svg)
+![console2svg capture --crop-top "Host" --crop-bottom ".NET runtimes installed:-2" -- dotnet --info](./assets/cmd-crop-word.svg)
 
 ### Animated SVG
 
@@ -243,10 +253,10 @@ use `-m video` or `-v` to capture the animation of the command execution and sav
 
 ```sh
 # apt install sl
-console2svg -c -d -v -- sl
+console2svg capture -c -d -v -- sl
 ```
 
-![console2svg -c -d -v -- sl](./assets/cmd-sl.svg)
+![console2svg capture -c -d -v -- sl](./assets/cmd-sl.svg)
 
 You can specify the `--timeout` option to output SVG after a certain time has elapsed.
 This is useful for converting commands that do not terminate, such as `nyancat`, into SVG.
@@ -255,17 +265,17 @@ There is also a `--sleep` option to specify the stop time after playback. This a
 
 ```sh
 # apt install nyancat
-console2svg -w 160 -h 32 -c -d -v --timeout 5 --sleep 0.5 -- nyancat -d 10
+console2svg capture -w 160 -h 32 -c -d -v --timeout 5 --sleep 0.5 -- nyancat -d 10
 ```
 
-![console2svg -w 160 -h 32 -c -d -v --timeout 5 --sleep 0.5 -- nyancat -d 10](./assets/cmd-nyancat.svg)
+![console2svg capture -w 160 -h 32 -c -d -v --timeout 5 --sleep 0.5 -- nyancat -d 10](./assets/cmd-nyancat.svg)
 
 You can also write sequential SVG files starting with `frame-0000.svg` to a specific folder.
 This is useful for cherry-picking your favorite frames or converting them into a video using software like ffmpeg. 
 
 ```sh
 # apt install cmatrix
-console2svg -c -d -v --timeout 5 --fps 30 --save-frames ./frames-dir -- cmatrix -ab
+console2svg capture -c -d -v --timeout 5 --fps 30 --save-frames ./frames-dir -- cmatrix -ab
 ```
 
 ### Replay input
@@ -273,7 +283,7 @@ You can also save the command execution record and later regenerate the SVG base
 To save the record, use the `--replay-save` option to save the command execution.
 
 ```sh
-console2svg --replay-save ./replay.json -- bash
+console2svg capture --replay-save ./replay.json -- bash
 # save key inputs to replay.json
 ```
 
@@ -281,10 +291,10 @@ Then, generate the SVG based on the saved key input.
 By using this feature, you can generate an SVG that records terminal operations as shown below.
 
 ```sh
-console2svg -w 80 -h 20 -v -c -d macos --replay ./replay.json -- bash
+console2svg replay ./replay.json -w 80 -h 20 -v -c -d macos -- bash
 ```
 
-![console2svg -w 80 -h 20 -v -c -d macos --replay ./replay.json -- bash](./assets/cmd-bash-vim.svg)
+![console2svg replay ./replay.json -w 80 -h 20 -v -c -d macos -- bash](./assets/cmd-bash-vim.svg)
 
 The replay file is in a simple JSON format. If you make a mistake in the input, you can directly edit this file (or of course, you can ask AI to fix it for you).
 
@@ -342,10 +352,10 @@ Then, you can specify the output file with the desired extension. For example, t
 
 ```bash
 # apt install cmatrix
-console2svg -o ./output.gif -w 100 -h 24 -v -c -d macos-pc --timeout 5 --fps 30 -- cmatrix -ab
+console2svg capture -o ./output.gif -w 100 -h 24 -v -c -d macos-pc --timeout 5 --fps 30 -- cmatrix -ab
 ```
 
-![console2svg -o ./output.gif -w 100 -h 24 -v -c -d macos-pc --timeout 5 --fps 30 -- cmatrix -ab](./assets/cmd-matrix-video.gif)
+![console2svg capture -o ./output.gif -w 100 -h 24 -v -c -d macos-pc --timeout 5 --fps 30 -- cmatrix -ab](./assets/cmd-matrix-video.gif)
 
 You can also output as MP4, WebM, or a static PNG/JPG by changing the extension.
 
@@ -355,26 +365,26 @@ You can also output as MP4, WebM, or a static PNG/JPG by changing the extension.
 You can set the background color or image of the output SVG, and adjust the opacity of the background fill.
 
 ```sh
-console2svg -h 10 -c -d macos-pc --background "#003060" --opacity 0.85 -- dotnet --version
+console2svg capture -h 10 -c -d macos-pc --background "#003060" --opacity 0.85 -- dotnet --version
 ```
 
-![console2svg -h 10 -c -d macos-pc --background "#003060" --opacity 0.85 -- dotnet --version](./assets/cmd-bg1.svg)
+![console2svg capture -h 10 -c -d macos-pc --background "#003060" --opacity 0.85 -- dotnet --version](./assets/cmd-bg1.svg)
 
 You can also set a gradient background.
 
 ```sh
-console2svg -h 10 -c -d macos-pc --background "#004060" "#0080c0" --opacity 0.85 -- dotnet --version
+console2svg capture -h 10 -c -d macos-pc --background "#004060" "#0080c0" --opacity 0.85 -- dotnet --version
 ```
 
-![console2svg -h 10 -c -d macos-pc --background "#004060" "#0080c0" --opacity 0.85 -- dotnet --version](./assets/cmd-bg2.svg)
+![console2svg capture -h 10 -c -d macos-pc --background "#004060" "#0080c0" --opacity 0.85 -- dotnet --version](./assets/cmd-bg2.svg)
 
 Image background is also supported.
 
 ```sh
-console2svg -h 10 -c -d macos-pc --background image.png --opacity 0.85  -- dotnet --version
+console2svg capture -h 10 -c -d macos-pc --background image.png --opacity 0.85  -- dotnet --version
 ```
 
-![console2svg -h 10 -c -d macos-pc --background image.png --opacity 0.85  -- dotnet --version](./assets/cmd-bg3.svg)
+![console2svg capture -h 10 -c -d macos-pc --background image.png --opacity 0.85  -- dotnet --version](./assets/cmd-bg3.svg)
 
 ### Terminal Appearance
 
@@ -383,10 +393,10 @@ For example, in the following example, the prompt (the string displayed at the b
 the command header is changed to `my-custom-header`, and the text color is changed to `#00f040`.
 
 ```sh
-console2svg -h 4 --prompt "[HELLO!] $" --header "my-custom-header" --forecolor "#00f040" --backcolor "#042515" -- echo "hi"
+console2svg capture -h 4 --prompt "[HELLO!] $" --header "my-custom-header" --forecolor "#00f040" --backcolor "#042515" -- echo "hi"
 ```
 
-![console2svg -h 4 --prompt "[HELLO!] $" --header "my-custom-header" --forecolor "#00f040" --backcolor "#042515" -- echo "hi"](./assets/cmd-term-custom.svg)
+![console2svg capture -h 4 --prompt "[HELLO!] $" --header "my-custom-header" --forecolor "#00f040" --backcolor "#042515" -- echo "hi"](./assets/cmd-term-custom.svg)
 
 
 ### Window chrome
@@ -425,7 +435,7 @@ $ echo "say hello"
 $ echo "say goodbye"
 ```
 
-After completing the command execution you want to record, open a new window with `ctrl+b c`. Then, run `tmux capture-pane | console2svg` to save the content of the original window as SVG.
+After completing the command execution you want to record, open a new window with `ctrl+b c`. Then, run `tmux capture-pane | console2svg capture` to save the content of the original window as SVG.
 
 ```sh
 # tmux options:
@@ -434,7 +444,7 @@ After completing the command execution you want to record, open a new window wit
 #   -t :0: target the first pane (you can specify other panes as needed)
 # console2svg options:
 #   -h 12: set the height of the output SVG to 12 lines (adjust as needed)
-tmux capture-pane -pe -t :0 | console2svg -h 12 -o capture-$(date +%s).svg
+tmux capture-pane -pe -t :0 | console2svg capture -h 12 -o capture-$(date +%s).svg
 ```
 
 <details>
@@ -449,7 +459,7 @@ With the power of `console2svg`, you can even record and explain how to use `con
 <details>
 <summary>tmux capture-pane result example</summary>
 
-![tmux capture-pane -pe -t :0 | console2svg -h 12](./assets/cmd-tmux-cap.svg)
+![tmux capture-pane -pe -t :0 | console2svg capture -h 12](./assets/cmd-tmux-cap.svg)
 
 </details>
 
@@ -458,7 +468,7 @@ Then repeat the workflow: press `ctrl+b p` to return to the original window, wor
 Of course, you can also save all lines (useful for evidence). In that case, specify the `-S -` option on the tmux side to capture the entire screen.
 
 ```sh
-tmux capture-pane -pe -S - -t :0 | console2svg -o full-capture-$(date +%s).svg
+tmux capture-pane -pe -S - -t :0 | console2svg capture -o full-capture-$(date +%s).svg
 ```
 
 ### Repeat capture mode
@@ -470,7 +480,7 @@ Each result is treated as a full-screen update, so content from the previous cap
 The command runs at the interval specified by `--fps` until you stop `console2svg` with `Ctrl+C`.
 
 ```sh
-console2svg -m repeat --fps 2 -- tmux capture-pane -pe -t :0
+console2svg capture -m repeat --fps 2 -- tmux capture-pane -pe -t :0
 ```
 
 ## Supported platforms

--- a/scripts/demos/generate-interactive.sh
+++ b/scripts/demos/generate-interactive.sh
@@ -15,10 +15,10 @@ trap cleanup EXIT
 TMUX="" tmux -L "$socket" -f /dev/null new-session \
     -d -x 100 -y 20 -s "$session" -c "$work_dir" \
     "env PS1='$ ' TERM=xterm-256color '$CONSOLE2SVG_BIN' \
-        -w 100 -h 20 -v -d macos --sleep 0.5 \
+        capture -w 100 -h 20 -v -d macos --sleep 0.5 \
         --verbose '$DEMO_ROOT/logs/cmd-interactive.log' \
         -o '$work_dir/cmd-interactive.svg' \
-        -- '$CONSOLE2SVG_BIN' -i -w 100 -h 20 \
+        -- '$CONSOLE2SVG_BIN' interactive -w 100 -h 20 \
         -o '$work_dir/interactive-inner.svg' \
         -- bash --noprofile --norc"
 

--- a/scripts/demos/generate-tmux.sh
+++ b/scripts/demos/generate-tmux.sh
@@ -30,7 +30,7 @@ tmux -L "$socket" set-option -t "$session" status-right ""
 wait_for_pane "$socket" "$session:0.0" "$"
 
 "$CONSOLE2SVG_BIN" \
-    -o "$work_dir/cmd-tmux-replay.svg" \
+    capture -o "$work_dir/cmd-tmux-replay.svg" \
     --verbose "$DEMO_ROOT/logs/cmd-tmux-replay.log" \
     -w 80 -h 14 -v --sleep 0.5 \
     -- tmux -L "$socket" attach-session -t "$session" &
@@ -56,7 +56,7 @@ tmux -L "$socket" new-window \
 wait_for_pane "$socket" "$session:capture.0" "$"
 sleep 0.5
 
-capture_command='tmux capture-pane -pe -t :0 | console2svg -h 12 -o capture.svg'
+capture_command='tmux capture-pane -pe -t :0 | console2svg capture -h 12 -o capture.svg'
 type_slowly "$socket" "$session:capture.0" "$capture_command"
 tmux -L "$socket" send-keys -t "$session:capture.0" Enter
 wait_for_file "$work_dir/capture.svg"

--- a/scripts/image-gen.sh
+++ b/scripts/image-gen.sh
@@ -14,31 +14,31 @@ sudo apt update
 sudo apt install -y librsvg2-bin sl nyancat vim tmux ffmpeg cmatrix btop pipes-sh fastfetch
 
 # --- image ---
-console2svg -o ./assets/cmd-hero.svg        --verbose ./logs/cmd-hero.log         -w 100 -h 10 -c -d macos-pc --opacity 0.95 --background ./assets/image1.png -- oh-my-logo "console2svg" mint --filled --letter-spacing 0
-console2svg -o ./assets/cmd-btop.svg        --verbose ./logs/cmd-btop.log         -w 150 -h 32 -d macos-pc --opacity 0.95 --background "#30a0d0" "#0060c0" --timeout 3 -- btop -u 100
-console2svg -o ./assets/cmd.svg             --verbose ./logs/cmd.log              -w 120 console2svg 
-console2svg -o ./assets/cmd-window.svg      --verbose ./logs/cmd-window.log       -w 100 -c -d macos-pc  -- fastfetch
-console2svg -o ./assets/cmd-crop-word.svg   --verbose ./logs/cmd-crop-word.log    -w 100 --crop-top "Host" --crop-bottom ".NET runtimes installed:-2" -- dotnet --info
-console2svg -o ./assets/cmd-term-custom.svg --verbose ./logs/cmd-term-custom.log  -w 100 -h 4 --prompt "[HELLO!] $" --header "my-custom-header" --forecolor "#00f040" --backcolor "#042515" -- echo "hi"
+console2svg capture -o ./assets/cmd-hero.svg        --verbose ./logs/cmd-hero.log         -w 100 -h 10 -c -d macos-pc --opacity 0.95 --background ./assets/image1.png -- oh-my-logo "console2svg" mint --filled --letter-spacing 0
+console2svg capture -o ./assets/cmd-btop.svg        --verbose ./logs/cmd-btop.log         -w 150 -h 32 -d macos-pc --opacity 0.95 --background "#30a0d0" "#0060c0" --timeout 3 -- btop -u 100
+console2svg capture -o ./assets/cmd.svg             --verbose ./logs/cmd.log              -w 120 -- console2svg
+console2svg capture -o ./assets/cmd-window.svg      --verbose ./logs/cmd-window.log       -w 100 -c -d macos-pc  -- fastfetch
+console2svg capture -o ./assets/cmd-crop-word.svg   --verbose ./logs/cmd-crop-word.log    -w 100 --crop-top "Host" --crop-bottom ".NET runtimes installed:-2" -- dotnet --info
+console2svg capture -o ./assets/cmd-term-custom.svg --verbose ./logs/cmd-term-custom.log  -w 100 -h 4 --prompt "[HELLO!] $" --header "my-custom-header" --forecolor "#00f040" --backcolor "#042515" -- echo "hi"
 ## background
-console2svg -o ./assets/cmd-bg1.svg       --verbose ./logs/cmd-bg1.log  -w 100 -h 10 -c -d macos-pc --background "#003060" --opacity 0.85 -- dotnet --version
-console2svg -o ./assets/cmd-bg2.svg       --verbose ./logs/cmd-bg2.log  -w 100 -h 10 -c -d macos-pc --background "#004060" "#0080c0" --opacity 0.85 -- dotnet --version
-console2svg -o ./assets/cmd-bg3.svg       --verbose ./logs/cmd-bg3.log  -w 100 -h 10 -c -d macos-pc --background ./assets/image2.png --opacity 0.85 -- dotnet --version
+console2svg capture -o ./assets/cmd-bg1.svg       --verbose ./logs/cmd-bg1.log  -w 100 -h 10 -c -d macos-pc --background "#003060" --opacity 0.85 -- dotnet --version
+console2svg capture -o ./assets/cmd-bg2.svg       --verbose ./logs/cmd-bg2.log  -w 100 -h 10 -c -d macos-pc --background "#004060" "#0080c0" --opacity 0.85 -- dotnet --version
+console2svg capture -o ./assets/cmd-bg3.svg       --verbose ./logs/cmd-bg3.log  -w 100 -h 10 -c -d macos-pc --background ./assets/image2.png --opacity 0.85 -- dotnet --version
 ## window chrome
-console2svg -o ./assets/window/none.svg        -d none        -w 40 -h 4 -c -- dotnet --version
-console2svg -o ./assets/window/macos.svg       -d macos       -w 40 -h 4 -c -- dotnet --version
-console2svg -o ./assets/window/macos-pc.svg    -d macos-pc    -w 40 -h 4 -c -- dotnet --version
-console2svg -o ./assets/window/windows.svg     -d windows     -w 40 -h 4 -c -- dotnet --version
-console2svg -o ./assets/window/windows-pc.svg  -d windows-pc  -w 40 -h 4 -c -- dotnet --version
-console2svg -o ./assets/window/transparent.svg -d transparent -w 40 -h 4 -c -- dotnet --version
+console2svg capture -o ./assets/window/none.svg        -d none        -w 40 -h 4 -c -- dotnet --version
+console2svg capture -o ./assets/window/macos.svg       -d macos       -w 40 -h 4 -c -- dotnet --version
+console2svg capture -o ./assets/window/macos-pc.svg    -d macos-pc    -w 40 -h 4 -c -- dotnet --version
+console2svg capture -o ./assets/window/windows.svg     -d windows     -w 40 -h 4 -c -- dotnet --version
+console2svg capture -o ./assets/window/windows-pc.svg  -d windows-pc  -w 40 -h 4 -c -- dotnet --version
+console2svg capture -o ./assets/window/transparent.svg -d transparent -w 40 -h 4 -c -- dotnet --version
 
 # --- video ---
-console2svg -o ./assets/cmd-sl.svg            --verbose ./logs/cmd-sl.log           -w 120 -h 16 -c -d -v -- sl
-console2svg -o ./assets/cmd-nyancat.svg       --verbose ./logs/cmd-nyancat.log      -w 160 -h 28 -c -d -v --timeout 5 --sleep 0.5 -- nyancat
-console2svg -o ./assets/cmd-loop.svg          --verbose ./logs/cmd-loop.log         -w 80 -h 20 -v -d windows --timeout 10 -- /usr/games/pipes -t 0 -f 35
-# console2svg -o ./assets/cmd-bash-vim.svg      --verbose ./logs/cmd-bash-vim.log     -w 80 -h 20 -v -d --replay ./assets/cmd-bash-vim-replay.json -- bash
+console2svg capture -o ./assets/cmd-sl.svg            --verbose ./logs/cmd-sl.log           -w 120 -h 16 -c -d -v -- sl
+console2svg capture -o ./assets/cmd-nyancat.svg       --verbose ./logs/cmd-nyancat.log      -w 160 -h 28 -c -d -v --timeout 5 --sleep 0.5 -- nyancat
+console2svg capture -o ./assets/cmd-loop.svg          --verbose ./logs/cmd-loop.log         -w 80 -h 20 -v -d windows --timeout 10 -- /usr/games/pipes -t 0 -f 35
+# console2svg replay -o ./assets/cmd-bash-vim.svg      --verbose ./logs/cmd-bash-vim.log     -w 80 -h 20 -v -d --replay ./assets/cmd-bash-vim-replay.json -- bash
 bash ./scripts/demos/generate-interactive.sh
 bash ./scripts/demos/generate-tmux.sh
 
 # --- video(gif) ---
-console2svg -o ./assets/cmd-matrix-video.gif -w 100 -h 24 -v -c -d macos-pc --timeout 5 --fps 30 -- cmatrix -ab
+console2svg capture -o ./assets/cmd-matrix-video.gif -w 100 -h 24 -v -c -d macos-pc --timeout 5 --fps 30 -- cmatrix -ab

--- a/scripts/image-gen.sh
+++ b/scripts/image-gen.sh
@@ -36,7 +36,7 @@ console2svg capture -o ./assets/window/transparent.svg -d transparent -w 40 -h 4
 console2svg capture -o ./assets/cmd-sl.svg            --verbose ./logs/cmd-sl.log           -w 120 -h 16 -c -d -v -- sl
 console2svg capture -o ./assets/cmd-nyancat.svg       --verbose ./logs/cmd-nyancat.log      -w 160 -h 28 -c -d -v --timeout 5 --sleep 0.5 -- nyancat
 console2svg capture -o ./assets/cmd-loop.svg          --verbose ./logs/cmd-loop.log         -w 80 -h 20 -v -d windows --timeout 10 -- /usr/games/pipes -t 0 -f 35
-# console2svg replay -o ./assets/cmd-bash-vim.svg      --verbose ./logs/cmd-bash-vim.log     -w 80 -h 20 -v -d --replay ./assets/cmd-bash-vim-replay.json -- bash
+# console2svg replay ./assets/cmd-bash-vim-replay.json -o ./assets/cmd-bash-vim.svg --verbose ./logs/cmd-bash-vim.log -w 80 -h 20 -v -d -- bash
 bash ./scripts/demos/generate-interactive.sh
 bash ./scripts/demos/generate-tmux.sh
 

--- a/src/ConsoleToSvg/Cli/AppOptions.cs
+++ b/src/ConsoleToSvg/Cli/AppOptions.cs
@@ -11,8 +11,20 @@ public enum OutputMode
     Repeat,
 }
 
+public enum Workflow
+{
+    Legacy,
+    Capture,
+    Interactive,
+    Replay,
+    Convert,
+    Theme,
+}
+
 public sealed class AppOptions
 {
+    public Workflow Workflow { get; set; }
+
     public bool Verbose { get; set; }
 
     public string? VerboseLogPath { get; set; }
@@ -28,6 +40,8 @@ public sealed class AppOptions
     public string[]? DelimitedCommand { get; set; }
 
     public string? InputCastPath { get; set; }
+
+    public string? InputSvgPath { get; set; }
 
     public string OutputPath { get; set; } = "output.svg";
 

--- a/src/ConsoleToSvg/Cli/OptionParser.Validation.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.Validation.cs
@@ -466,10 +466,16 @@ public static partial class OptionParser
             return false;
         }
 
-        if (
-            !string.IsNullOrWhiteSpace(options.Command)
-            && !string.IsNullOrWhiteSpace(options.InputCastPath)
-        )
+        if (!string.IsNullOrWhiteSpace(options.InputSvgPath)
+            && !string.IsNullOrWhiteSpace(options.InputCastPath))
+        {
+            error = "SVG input and --in cannot be used together.";
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.Command)
+            && (!string.IsNullOrWhiteSpace(options.InputCastPath)
+                || !string.IsNullOrWhiteSpace(options.InputSvgPath)))
         {
             error = "--command and --in cannot be used together.";
             return false;

--- a/src/ConsoleToSvg/Cli/OptionParser.Validation.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.Validation.cs
@@ -403,6 +403,12 @@ public static partial class OptionParser
                 return false;
             }
 
+            if (!string.IsNullOrWhiteSpace(options.InputSvgPath))
+            {
+                error = "--interactive cannot be used with SVG input.";
+                return false;
+            }
+
             if (options.StdOut)
             {
                 error = "--interactive cannot be used with --stdout.";
@@ -473,6 +479,19 @@ public static partial class OptionParser
             return false;
         }
 
+        if (!string.IsNullOrWhiteSpace(options.InputSvgPath))
+        {
+            var outputExtension = Path.GetExtension(options.OutputPath).TrimStart('.');
+            var usesVideoOutput = options.IsModeExplicit
+                ? options.Mode is OutputMode.Video or OutputMode.Repeat
+                : IsVideoFormat(outputExtension);
+            if (usesVideoOutput)
+            {
+                error = "SVG input cannot be converted to video output.";
+                return false;
+            }
+        }
+
         if (!string.IsNullOrWhiteSpace(options.Command)
             && (!string.IsNullOrWhiteSpace(options.InputCastPath)
                 || !string.IsNullOrWhiteSpace(options.InputSvgPath)))
@@ -510,4 +529,10 @@ public static partial class OptionParser
 
         return true;
     }
+
+    private static bool IsVideoFormat(string extension) => extension.ToLowerInvariant() switch
+    {
+        "mp4" or "webm" or "avi" or "mov" or "mkv" or "ogv" or "flv" or "ts" or "wmv" or "m4v" or "gif" => true,
+        _ => false,
+    };
 }

--- a/src/ConsoleToSvg/Cli/OptionParser.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.cs
@@ -1,19 +1,56 @@
 using System;
 using System.Globalization;
+using System.IO;
 using ConsoleToSvg.Svg;
 
 namespace ConsoleToSvg.Cli;
 
 public static partial class OptionParser
 {
+    public static string GetHelpText(Workflow workflow) => workflow switch
+    {
+        Workflow.Capture => """
+            Usage: console2svg capture [options] [-- <command> [args...]]
+                   <command> | console2svg capture [options]
+
+            Capture options: --save-cast, --replay-save, --timeout.
+            Output and appearance options are also accepted.
+            """,
+        Workflow.Interactive => """
+            Usage: console2svg interactive [options] [-- <program> [args...]]
+
+            Starts an interactive shell or program.
+            F9 records, F12 pauses, and F10 takes a screenshot.
+            """,
+        Workflow.Replay => """
+            Usage: console2svg replay <replay.json> [options] -- <command> [args...]
+
+            Replays recorded keyboard input while capturing the command.
+            """,
+        Workflow.Convert => """
+            Usage: console2svg convert <input.cast|input.svg> [options]
+
+            Renders an existing recording or converts an SVG.
+            Use -o/--out to select the output format.
+            """,
+        Workflow.Theme => """
+            The 'theme' command is reserved for theme management planned in issue #115.
+            Use the existing --theme option to select a rendering color theme.
+            """,
+        _ => HelpText,
+    };
+
     public static string ShortHelpText =>
         $"""
             console2svg - Convert terminal output to SVG [Ver: {ThisAssembly.AssemblyInformationalVersion}]
 
             Usage:
-                my-command | console2svg [options]
-                console2svg "my-command with-args" [options]
-                console2svg [options] -- my-command with args
+                my-command | console2svg capture [options]
+                console2svg capture [options] -- my-command with args
+                console2svg interactive [options] [-- program args...]
+                console2svg replay <replay.json> [options] -- my-command with args
+                console2svg convert <input.cast|input.svg> [options]
+                console2svg theme              # Reserved for theme management (#115)
 
             Major options:
                 -o, --out <path>          Output file path (default: output.svg).
@@ -41,9 +78,12 @@ public static partial class OptionParser
             console2svg - Convert terminal output to SVG [Ver: {ThisAssembly.AssemblyInformationalVersion}]
 
             Usage:
-                my-command | console2svg [options]
-                console2svg "my-command with-args" [options]
-                console2svg [options] -- my-command with args
+                my-command | console2svg capture [options]
+                console2svg capture [options] -- my-command with args
+                console2svg interactive [options] [-- program args...]
+                console2svg replay <replay.json> [options] -- my-command with args
+                console2svg convert <input.cast|input.svg> [options]
+                console2svg theme              # Reserved for theme management (#115)
 
             Options (Common):
                 -o, --out <path>          Output file path (default: output.svg).
@@ -426,6 +466,16 @@ public static partial class OptionParser
         error = null;
         showHelp = false;
 
+        if (!TryNormalizeWorkflow(args, options, out args, out error, out showHelp))
+        {
+            return false;
+        }
+
+        if (options.Workflow == Workflow.Theme)
+        {
+            return true;
+        }
+
         var i = 0;
         while (i < args.Length)
         {
@@ -555,6 +605,88 @@ public static partial class OptionParser
         }
 
         return true;
+    }
+
+    private static bool TryNormalizeWorkflow(
+        string[] originalArgs,
+        AppOptions options,
+        out string[] args,
+        out string? error,
+        out bool showHelp
+    )
+    {
+        args = originalArgs;
+        error = null;
+        showHelp = false;
+        if (args.Length == 0 || args[0].StartsWith("-", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        var verb = args[0].ToLowerInvariant();
+        switch (verb)
+        {
+            case "capture":
+                options.Workflow = Workflow.Capture;
+                args = args[1..];
+                return true;
+            case "interactive":
+                options.Workflow = Workflow.Interactive;
+                options.Interactive = true;
+                args = args[1..];
+                return true;
+            case "replay":
+                options.Workflow = Workflow.Replay;
+                if (args.Length == 2 && args[1] is "--help" or "-h")
+                {
+                    showHelp = true;
+                    args = [];
+                    return true;
+                }
+                if (args.Length < 2 || args[1].StartsWith("-", StringComparison.Ordinal))
+                {
+                    error = "replay requires a replay file: console2svg replay <replay.json> [options] -- <command>.";
+                    return false;
+                }
+                options.ReplayPath = args[1];
+                args = args[2..];
+                return true;
+            case "convert":
+                options.Workflow = Workflow.Convert;
+                if (args.Length == 2 && args[1] is "--help" or "-h")
+                {
+                    showHelp = true;
+                    args = [];
+                    return true;
+                }
+                if (args.Length < 2 || args[1].StartsWith("-", StringComparison.Ordinal))
+                {
+                    error = "convert requires an input: console2svg convert <input.cast|input.svg> [options].";
+                    return false;
+                }
+                if (string.Equals(Path.GetExtension(args[1]), ".svg", StringComparison.OrdinalIgnoreCase))
+                {
+                    options.InputSvgPath = args[1];
+                }
+                else
+                {
+                    options.InputCastPath = args[1];
+                }
+                args = args[2..];
+                return true;
+            case "theme":
+                options.Workflow = Workflow.Theme;
+                if (args.Length == 1 || (args.Length == 2 && args[1] is "--help" or "-h"))
+                {
+                    showHelp = true;
+                    args = [];
+                    return true;
+                }
+                error = "The 'theme' command is reserved for issue #115 and is not implemented yet. The existing --theme option remains available.";
+                return false;
+            default:
+                return true;
+        }
     }
 
     private static bool TrySplitToken(string token, out string name, out string? inlineValue)

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -157,16 +157,6 @@ internal static partial class Program
                 }
             }
 
-            if (options.Interactive)
-            {
-                return await RunInteractiveAsync(
-                        options,
-                        loggerFactory,
-                        cancellationTokenSource.Token
-                    )
-                    .ConfigureAwait(false);
-            }
-
             if (!string.IsNullOrWhiteSpace(options.InputSvgPath))
             {
                 if (options.StdOut)
@@ -181,9 +171,20 @@ internal static partial class Program
                 }
 
                 EnsureDirectory(options.OutputPath);
-                if (string.Equals(Path.GetExtension(options.OutputPath), ".svg", StringComparison.OrdinalIgnoreCase))
+                var outputExtension = Path.GetExtension(options.OutputPath);
+                if (string.IsNullOrEmpty(outputExtension)
+                    || string.Equals(outputExtension, ".svg", StringComparison.OrdinalIgnoreCase))
                 {
-                    File.Copy(options.InputSvgPath, options.OutputPath, overwrite: true);
+                    if (!string.Equals(
+                            Path.GetFullPath(options.InputSvgPath),
+                            Path.GetFullPath(options.OutputPath),
+                            OperatingSystem.IsWindows()
+                                ? StringComparison.OrdinalIgnoreCase
+                                : StringComparison.Ordinal
+                        ))
+                    {
+                        File.Copy(options.InputSvgPath, options.OutputPath, overwrite: true);
+                    }
                 }
                 else
                 {
@@ -208,6 +209,16 @@ internal static partial class Program
                 }
                 Console.WriteLine($"Generated: {options.OutputPath}");
                 return 0;
+            }
+
+            if (options.Interactive)
+            {
+                return await RunInteractiveAsync(
+                        options,
+                        loggerFactory,
+                        cancellationTokenSource.Token
+                    )
+                    .ConfigureAwait(false);
             }
 
             var session = await LoadOrRecordAsync(

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -39,7 +39,7 @@ internal static partial class Program
 
         if (showHelp || options is null)
         {
-            WritePagedHelp(ColorizeIfSupported(OptionParser.HelpText));
+            WritePagedHelp(ColorizeIfSupported(OptionParser.GetHelpText(options?.Workflow ?? Workflow.Legacy)));
             return 0;
         }
 
@@ -165,6 +165,38 @@ internal static partial class Program
                         cancellationTokenSource.Token
                     )
                     .ConfigureAwait(false);
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.InputSvgPath))
+            {
+                EnsureDirectory(options.OutputPath);
+                if (string.Equals(Path.GetExtension(options.OutputPath), ".svg", StringComparison.OrdinalIgnoreCase))
+                {
+                    File.Copy(options.InputSvgPath, options.OutputPath, overwrite: true);
+                }
+                else
+                {
+                    var ffmpegPath = FindFfmpegExecutable();
+                    SvgConverter.SetFfmpegPath(ffmpegPath);
+                    var converter = SvgConverter.ResolveConverter(
+                        options.SvgConverter,
+                        !string.IsNullOrWhiteSpace(ffmpegPath),
+                        logger
+                    );
+                    await SvgConverter.ConvertSvgToImageAsync(
+                        options.InputSvgPath,
+                        options.OutputPath,
+                        converter,
+                        ffmpegPath,
+                        options.SizeWidth,
+                        options.SizeHeight,
+                        logger,
+                        ConsoleProgressReporter.Instance,
+                        cancellationTokenSource.Token
+                    ).ConfigureAwait(false);
+                }
+                Console.WriteLine($"Generated: {options.OutputPath}");
+                return 0;
             }
 
             var session = await LoadOrRecordAsync(

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -169,6 +169,17 @@ internal static partial class Program
 
             if (!string.IsNullOrWhiteSpace(options.InputSvgPath))
             {
+                if (options.StdOut)
+                {
+                    await using var input = File.OpenRead(options.InputSvgPath);
+                    await input.CopyToAsync(
+                        Console.OpenStandardOutput(),
+                        cancellationTokenSource.Token
+                    ).ConfigureAwait(false);
+                    await Console.Error.WriteLineAsync("Generated: (stdout)");
+                    return 0;
+                }
+
                 EnsureDirectory(options.OutputPath);
                 if (string.Equals(Path.GetExtension(options.OutputPath), ".svg", StringComparison.OrdinalIgnoreCase))
                 {

--- a/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.Workflows.cs
+++ b/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.Workflows.cs
@@ -60,6 +60,20 @@ public sealed partial class OptionParserTests
     }
 
     [Test]
+    public void ConvertSvgRejectsInteractiveMode()
+    {
+        OptionParser.TryParse(["convert", "demo.svg", "--interactive"], out _, out var error, out _).ShouldBeFalse();
+        error.ShouldBe("--interactive cannot be used with SVG input.");
+    }
+
+    [Test]
+    public void ConvertSvgRejectsVideoOutput()
+    {
+        OptionParser.TryParse(["convert", "demo.svg", "-o", "demo.mp4"], out _, out var error, out _).ShouldBeFalse();
+        error.ShouldBe("SVG input cannot be converted to video output.");
+    }
+
+    [Test]
     public void LegacyInvocationStillWorks()
     {
         OptionParser.TryParse(["-w", "80", "--", "echo", "hello"], out var options, out _, out _).ShouldBeTrue();

--- a/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.Workflows.cs
+++ b/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.Workflows.cs
@@ -1,0 +1,88 @@
+using ConsoleToSvg.Cli;
+
+namespace ConsoleToSvg.Tests.Cli;
+
+public sealed partial class OptionParserTests
+{
+    [Test]
+    public void CaptureForwardsDelimitedArguments()
+    {
+        OptionParser.TryParse(["capture", "-w", "80", "--", "dotnet", "--version"], out var options, out _, out _).ShouldBeTrue();
+        options!.Workflow.ShouldBe(Workflow.Capture);
+        options.DelimitedCommand.ShouldBe(["dotnet", "--version"]);
+    }
+
+    [Test]
+    public void InteractiveVerbEnablesInteractiveMode()
+    {
+        OptionParser.TryParse(["interactive", "-o", "capture.svg"], out var options, out _, out _).ShouldBeTrue();
+        options!.Workflow.ShouldBe(Workflow.Interactive);
+        options.Interactive.ShouldBeTrue();
+    }
+
+    [Test]
+    public void ReplayVerbOwnsReplayFile()
+    {
+        OptionParser.TryParse(["replay", "keys.json", "--", "bash", "-l"], out var options, out _, out _).ShouldBeTrue();
+        options!.ReplayPath.ShouldBe("keys.json");
+        options.DelimitedCommand.ShouldBe(["bash", "-l"]);
+    }
+
+    [Test]
+    public void ConvertVerbOwnsInputCast()
+    {
+        OptionParser.TryParse(["convert", "demo.cast", "-o", "demo.png"], out var options, out _, out _).ShouldBeTrue();
+        options!.Workflow.ShouldBe(Workflow.Convert);
+        options.InputCastPath.ShouldBe("demo.cast");
+        options.OutputPath.ShouldBe("demo.png");
+    }
+
+    [Test]
+    public void ConvertVerbAcceptsSvgInput()
+    {
+        OptionParser.TryParse(["convert", "demo.svg", "-o", "demo.png"], out var options, out _, out _).ShouldBeTrue();
+        options!.InputSvgPath.ShouldBe("demo.svg");
+        options.InputCastPath.ShouldBeNull();
+    }
+
+    [Test]
+    public void LegacyInvocationStillWorks()
+    {
+        OptionParser.TryParse(["-w", "80", "--", "echo", "hello"], out var options, out _, out _).ShouldBeTrue();
+        options!.Workflow.ShouldBe(Workflow.Legacy);
+        options.Command.ShouldBe("echo hello");
+    }
+
+    [Test]
+    public void ThemeCommandIsReserved()
+    {
+        OptionParser.TryParse(["theme"], out var options, out _, out var showHelp).ShouldBeTrue();
+        options!.Workflow.ShouldBe(Workflow.Theme);
+        showHelp.ShouldBeTrue();
+        OptionParser.GetHelpText(Workflow.Theme).ShouldContain("#115");
+    }
+
+    [Test]
+    public void ReservedThemeSubcommandReturnsActionableError()
+    {
+        OptionParser.TryParse(["theme", "list"], out _, out var error, out _).ShouldBeFalse();
+        error!.ShouldContain("reserved");
+        error!.ShouldContain("--theme");
+    }
+
+    [Test]
+    public void VerbHelpIsScoped()
+    {
+        OptionParser.TryParse(["replay", "--help"], out var options, out _, out var showHelp).ShouldBeTrue();
+        options!.Workflow.ShouldBe(Workflow.Replay);
+        showHelp.ShouldBeTrue();
+        OptionParser.GetHelpText(Workflow.Replay).ShouldContain("replay <replay.json>");
+    }
+
+    [Test]
+    public void RootHelpDocumentsOnlyVerbSyntax()
+    {
+        OptionParser.HelpText.ShouldNotContain("Legacy:");
+        OptionParser.HelpText.ShouldNotContain("console2svg [options]");
+    }
+}

--- a/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.Workflows.cs
+++ b/tests/ConsoleToSvg.Tests/Cli/OptionParserTests.Workflows.cs
@@ -46,11 +46,38 @@ public sealed partial class OptionParserTests
     }
 
     [Test]
+    public void ConvertSvgRejectsACommand()
+    {
+        OptionParser.TryParse(["convert", "demo.svg", "--", "echo", "hello"], out _, out var error, out _).ShouldBeFalse();
+        error.ShouldBe("--command and --in cannot be used together.");
+    }
+
+    [Test]
+    public void ConvertSvgRejectsAnAsciicastInput()
+    {
+        OptionParser.TryParse(["convert", "demo.svg", "--in", "other.cast"], out _, out var error, out _).ShouldBeFalse();
+        error.ShouldBe("SVG input and --in cannot be used together.");
+    }
+
+    [Test]
     public void LegacyInvocationStillWorks()
     {
         OptionParser.TryParse(["-w", "80", "--", "echo", "hello"], out var options, out _, out _).ShouldBeTrue();
         options!.Workflow.ShouldBe(Workflow.Legacy);
         options.Command.ShouldBe("echo hello");
+    }
+
+    [Test]
+    public void LegacyInputAndReplayOptionsStillWork()
+    {
+        OptionParser.TryParse(["--in", "demo.cast", "-o", "demo.svg"], out var inputOptions, out _, out _).ShouldBeTrue();
+        inputOptions!.Workflow.ShouldBe(Workflow.Legacy);
+        inputOptions.InputCastPath.ShouldBe("demo.cast");
+
+        OptionParser.TryParse(["--replay", "keys.json", "--", "bash", "-l"], out var replayOptions, out _, out _).ShouldBeTrue();
+        replayOptions!.Workflow.ShouldBe(Workflow.Legacy);
+        replayOptions.ReplayPath.ShouldBe("keys.json");
+        replayOptions.DelimitedCommand.ShouldBe(["bash", "-l"]);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- add explicit capture, interactive, eplay, and convert workflow commands
- reserve the 	heme command for #115 while keeping the existing --theme rendering option separate
- retain the legacy root invocation syntax for compatibility
- add workflow-scoped help and support conversion from asciicast or SVG input
- migrate README examples and repository scripts to the verb-based syntax
- add regression coverage for workflow parsing, argument forwarding, help, and legacy compatibility

## Testing

- dotnet test --solution ConsoleToSvg.slnx --no-restore -p:UseSharedCompilation=false (410 passed)
- git diff --check

Closes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added subcommands for capture, interactive recording, replay, and conversion workflows.
  - Added workflow-specific help and clearer command usage guidance.
  - Added SVG input handling, including direct SVG output and raster conversion.

- **Bug Fixes**
  - Improved command parsing and input validation across workflows.
  - Preserved compatibility with legacy command usage.

- **Documentation**
  - Updated README examples, installation guidance, and demo scripts to use the new command syntax.
  - Added Windows installation options and refreshed platform-specific instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->