### PR TITLE
feat: add shell completion workflow

### DIFF
--- a/src/ConsoleToSvg/Cli/AppOptions.cs
+++ b/src/ConsoleToSvg/Cli/AppOptions.cs
@@ -19,6 +19,7 @@ public enum Workflow
     Replay,
     Convert,
     Theme,
+    Completion,
 }
 
 public sealed class AppOptions
@@ -32,6 +33,8 @@ public sealed class AppOptions
     public bool ShowVersion { get; set; }
 
     public string? Command { get; set; }
+
+    public string? CompletionShell { get; set; }
 
     /// <summary>
     /// Unmodified arguments following <c>--</c>. Interactive mode uses these to

--- a/src/ConsoleToSvg/Cli/OptionParser.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.cs
@@ -37,6 +37,11 @@ public static partial class OptionParser
             The 'theme' command is reserved for theme management planned in issue #115.
             Use the existing --theme option to select a rendering color theme.
             """,
+        Workflow.Completion => """
+            Usage: console2svg completion <bash|zsh|fish|powershell>
+
+            Print shell completion code to standard output.
+            """,
         _ => HelpText,
     };
 
@@ -51,6 +56,7 @@ public static partial class OptionParser
                 console2svg replay <replay.json> [options] -- my-command with args
                 console2svg convert <input.cast|input.svg> [options]
                 console2svg theme              # Reserved for theme management (#115)
+                console2svg completion <shell> # Print shell completion code
 
             Major options:
                 -o, --out <path>          Output file path (default: output.svg).
@@ -684,6 +690,13 @@ public static partial class OptionParser
                 }
                 error = "The 'theme' command is reserved for issue #115 and is not implemented yet. The existing --theme option remains available.";
                 return false;
+            case "completion":
+                options.Workflow = Workflow.Completion;
+                if (args.Length == 2 && args[1] is "--help" or "-h") { showHelp = true; args = []; return true; }
+                if (args.Length != 2) { error = "completion requires a shell: bash, zsh, fish, or powershell."; return false; }
+                options.CompletionShell = args[1];
+                args = [];
+                return true;
             default:
                 return true;
         }

--- a/src/ConsoleToSvg/Cli/OptionParser.cs
+++ b/src/ConsoleToSvg/Cli/OptionParser.cs
@@ -57,6 +57,7 @@ public static partial class OptionParser
                 console2svg convert <input.cast|input.svg> [options]
                 console2svg theme              # Reserved for theme management (#115)
                 console2svg completion <shell> # Print shell completion code
+                console2svg completion <shell> # Print shell completion code
 
             Major options:
                 -o, --out <path>          Output file path (default: output.svg).
@@ -90,6 +91,7 @@ public static partial class OptionParser
                 console2svg replay <replay.json> [options] -- my-command with args
                 console2svg convert <input.cast|input.svg> [options]
                 console2svg theme              # Reserved for theme management (#115)
+                console2svg completion <shell> # Print shell completion code
 
             Options (Common):
                 -o, --out <path>          Output file path (default: output.svg).

--- a/src/ConsoleToSvg/Cli/ShellCompletion.cs
+++ b/src/ConsoleToSvg/Cli/ShellCompletion.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Linq;
+
+namespace ConsoleToSvg.Cli;
+
+internal static class ShellCompletion
+{
+    private const string Commands = "capture interactive replay convert theme completion";
+    private const string Options = "--help --version --out --width --height --theme --window --font --fontsize --background --timeout";
+
+    public static string? GetScript(string? shell) => shell?.ToLowerInvariant() switch
+    {
+        "bash" => $"_console2svg() {{ COMPREPLY=( $(compgen -W '{Commands} {Options}' -- \"${{COMP_WORDS[COMP_CWORD]}}\") ); }}\ncomplete -F _console2svg console2svg\n",
+        "zsh" => $"#compdef console2svg\n_arguments '1:workflow:({Commands})' '*:option:({Options})'\n",
+        "fish" => string.Join("\n", Commands.Split(' ').Select(command => $"complete -c console2svg -f -a {command}")) + "\n",
+        "powershell" => $"Register-ArgumentCompleter -Native -CommandName console2svg -ScriptBlock {{ param($wordToComplete, $commandAst, $cursorPosition) '{Commands} {Options}'.Split(' ') | Where-Object {{ $_ -like \"$wordToComplete*\" }} | ForEach-Object {{ [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }} }}\n",
+        _ => null,
+    };
+}

--- a/src/ConsoleToSvg/Cli/ShellCompletion.cs
+++ b/src/ConsoleToSvg/Cli/ShellCompletion.cs
@@ -6,13 +6,15 @@ namespace ConsoleToSvg.Cli;
 internal static class ShellCompletion
 {
     private const string Commands = "capture interactive replay convert theme completion";
-    private const string Options = "--help --version --out --width --height --theme --window --font --fontsize --background --timeout";
+    // Keep this list in sync with OptionParser.Options.cs. Both long options
+    // and their documented short aliases are offered by every shell.
+    private const string Options = "--help --version -o --out -w --width -h --height -m --mode -v --video -i --interactive -c --with-command --in --mask --verbose --frame --time --crop-top --crop-right --crop-bottom --crop-left --theme --forecolor -d --window --padding --no-loop --no-colorenv --no-delete-envs --fps --timing --sleep --fadeout --coalesce-ms --opacity --adjust --background --timeout --font --fontsize --save-cast --embed-cast --embed-logs --embed-replay --embed-debug --replay-save --replay --header --prompt --pcmode --pc-padding --backcolor --stdout --save-frames --size --svg-converter";
 
     public static string? GetScript(string? shell) => shell?.ToLowerInvariant() switch
     {
         "bash" => $"_console2svg() {{ COMPREPLY=( $(compgen -W '{Commands} {Options}' -- \"${{COMP_WORDS[COMP_CWORD]}}\") ); }}\ncomplete -F _console2svg console2svg\n",
         "zsh" => $"#compdef console2svg\n_arguments '1:workflow:({Commands})' '*:option:({Options})'\n",
-        "fish" => string.Join("\n", Commands.Split(' ').Select(command => $"complete -c console2svg -f -a {command}")) + "\n",
+        "fish" => string.Join("\n", Commands.Split(' ').Select(command => $"complete -c console2svg -f -a {command}")) + $"\ncomplete -c console2svg -f -a '{Options}'\n",
         "powershell" => $"Register-ArgumentCompleter -Native -CommandName console2svg -ScriptBlock {{ param($wordToComplete, $commandAst, $cursorPosition) '{Commands} {Options}'.Split(' ') | Where-Object {{ $_ -like \"$wordToComplete*\" }} | ForEach-Object {{ [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }} }}\n",
         _ => null,
     };

--- a/src/ConsoleToSvg/Program.cs
+++ b/src/ConsoleToSvg/Program.cs
@@ -49,6 +49,18 @@ internal static partial class Program
             return 0;
         }
 
+        if (options.Workflow == Workflow.Completion)
+        {
+            var script = ShellCompletion.GetScript(options.CompletionShell);
+            if (script is null)
+            {
+                await Console.Error.WriteLineAsync("completion shell must be bash, zsh, fish, or powershell.");
+                return 1;
+            }
+            await Console.Out.WriteAsync(script);
+            return 0;
+        }
+
         if (args.Length == 0 && !Console.IsInputRedirected)
         {
             Console.WriteLine(ColorizeIfSupported(OptionParser.ShortHelpText));


### PR DESCRIPTION
Closes #123\n\nAdds console2svg completion scripts for Bash, Zsh, Fish, and PowerShell.